### PR TITLE
Fixed issues with duplicate `IServiceProvider` registration

### DIFF
--- a/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
+++ b/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.DependencyInjection;

--- a/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
+++ b/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
@@ -44,7 +44,7 @@ public class DiSanityCheckSpecs
             services.AddSingleton<IMySingletonInterface, MySingletonImpl>();
             testSetup(services);
         }).Build();
-
+        
         await host.StartAsync();
         return host;
     }

--- a/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
+++ b/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
@@ -41,7 +41,7 @@ public class DiSanityCheckSpecs
         var host = new HostBuilder()
         .ConfigureServices(services =>
         {
-            services.AddSingleton<IMySingletonInterface>(new MySingletonImpl());
+            services.AddSingleton<IMySingletonInterface, MySingletonImpl>();
             testSetup(services);
         }).Build();
 

--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -31,6 +31,7 @@ namespace Akka.Hosting
         {
             try
             {
+                _configurationBuilder.Build(_serviceProvider);
                 _actorSystem = _serviceProvider.GetRequiredService<ActorSystem>();
                 await _configurationBuilder.StartAsync(_actorSystem);
                 var actorRegistry = _serviceProvider.GetRequiredService<ActorRegistry>();

--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -1,7 +1,10 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Akka.Hosting
 {
@@ -11,31 +14,45 @@ namespace Akka.Hosting
     internal sealed class AkkaHostedService : IHostedService
     {
         private ActorSystem _actorSystem;
+        private readonly IServiceProvider _serviceProvider;
         private readonly AkkaConfigurationBuilder _configurationBuilder;
         private readonly IHostApplicationLifetime _hostApplicationLifetime;
+        private readonly ILogger<AkkaHostedService> _logger;
 
-        public AkkaHostedService(AkkaConfigurationBuilder configurationBuilder, ActorSystem system, IHostApplicationLifetime hostApplicationLifetime)
+        public AkkaHostedService(AkkaConfigurationBuilder configurationBuilder, IServiceProvider serviceProvider, ILogger<AkkaHostedService> logger)
         {
-            _actorSystem = system;
             _configurationBuilder = configurationBuilder;
-            _hostApplicationLifetime = hostApplicationLifetime;
+            _hostApplicationLifetime = serviceProvider.GetRequiredService<IHostApplicationLifetime>();
+            _serviceProvider = serviceProvider;
+            _logger = logger;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            await _configurationBuilder.StartAsync( _actorSystem);
-
-            async Task TerminationHook()
+            try
             {
-                await _actorSystem.WhenTerminated.ConfigureAwait(false);
+                _actorSystem = _serviceProvider.GetRequiredService<ActorSystem>();
+                await _configurationBuilder.StartAsync(_actorSystem);
+                var actorRegistry = _serviceProvider.GetRequiredService<ActorRegistry>();
+
+                async Task TerminationHook()
+                {
+                    await _actorSystem.WhenTerminated.ConfigureAwait(false);
+                    _hostApplicationLifetime.StopApplication();
+                }
+
+                // terminate the application if the Sys is terminated first
+                // this can happen in instances such as Akka.Cluster membership changes
+#pragma warning disable CS4014
+                TerminationHook();
+#pragma warning restore CS4014
+            }
+            catch(Exception ex)
+            {
+                _logger.Log(LogLevel.Critical, ex, "Unable to start AkkaHostedService - shutting down application");
                 _hostApplicationLifetime.StopApplication();
             }
-
-            // terminate the application if the Sys is terminated first
-            // this can happen in instances such as Akka.Cluster membership changes
-#pragma warning disable CS4014
-            TerminationHook();
-#pragma warning restore CS4014
+            
         }
 
         public async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -14,15 +14,16 @@ namespace Akka.Hosting
         private readonly AkkaConfigurationBuilder _configurationBuilder;
         private readonly IHostApplicationLifetime _hostApplicationLifetime;
 
-        public AkkaHostedService(AkkaConfigurationBuilder configurationBuilder, IHostApplicationLifetime hostApplicationLifetime)
+        public AkkaHostedService(AkkaConfigurationBuilder configurationBuilder, ActorSystem system, IHostApplicationLifetime hostApplicationLifetime)
         {
+            _actorSystem = system;
             _configurationBuilder = configurationBuilder;
             _hostApplicationLifetime = hostApplicationLifetime;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            _actorSystem = await _configurationBuilder.StartAsync();
+            await _configurationBuilder.StartAsync( _actorSystem);
 
             async Task TerminationHook()
             {

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -54,7 +54,6 @@ namespace Akka.Hosting
             {
                 
                 builder(b, sp);
-                
                 return b;
             });
             

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -28,13 +28,10 @@ namespace Akka.Hosting
         /// </remarks>
         public static IServiceCollection AddAkka(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder> builder)
         {
-            var b = new AkkaConfigurationBuilder(services, actorSystemName);
-            builder(b);
-            
-            // registers the hosted services and begins execution
-            b.Build();
-
-            return services;
+            return AddAkka(services, actorSystemName, (configurationBuilder, provider) =>
+            {
+                builder(configurationBuilder);
+            });
         }
         
         /// <summary>
@@ -50,14 +47,22 @@ namespace Akka.Hosting
         /// Starts a background <see cref="IHostedService"/> that runs the <see cref="ActorSystem"/>
         /// and manages its lifecycle in accordance with Akka.NET best practices.
         /// </remarks>
-        public static IServiceCollection AddAkka(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, ServiceProvider> builder)
+        public static IServiceCollection AddAkka(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, IServiceProvider> builder)
         {
             var b = new AkkaConfigurationBuilder(services, actorSystemName);
-            var sp = services.BuildServiceProvider();
-            builder(b, sp);
+            services.AddSingleton<AkkaConfigurationBuilder>(sp =>
+            {
+                
+                builder(b, sp);
+                
+                return b;
+            });
             
             // registers the hosted services and begins execution
-            b.Build();
+            b.Bind();
+            
+            // start the IHostedService which will run Akka.NET
+            services.AddHostedService<AkkaHostedService>();
 
             return services;
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
    <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.1.4</VersionPrefix>
-    <PackageReleaseNotes>• Added WithCustomSerializer  method to make it easy to add additional Serializer instances to an ActorSystem</PackageReleaseNotes>
+    <VersionPrefix>0.1.5</VersionPrefix>
+    <PackageReleaseNotes>• Added Akka.Persistence.PostgreSql.Hosting NuGet package to support Postgres users.</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
This fixes a bug I noticed while adding Akka.Hosting support to [Phobos](https://phobos.petabridge.com/)

https://twitter.com/Aaronontheweb/status/1512497162948595717 - this turned out to be caused by Akka.Hosting calling `ServiceCollection.BuildProvider()` in multiple instances - which causes the service registration delegates to be called multiple times, thus the version of a dependency your `ActorSystem` is running with can be different than the one ASP.NET might resolve.

## Changes

We've re-arranged the internals around Microsoft.Extensions.DependencyInjection inside Akka.Hosting to never actually instantiate the `IServiceProvider` ourselves - we let the runtime handle that so we end up with a consistent, single instance across the entire `IHost`.

We've also changed it such that the `AkkaHostedService` will terminate the entire application in the event of a failure at startup - whereas before it would simply error out in the background without saying anything.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.