### PR TITLE
add `GetAsync` method to `ActorRegistry`

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -5,6 +5,8 @@ namespace Akka.Hosting
     {
         public ActorRegistry() { }
         public Akka.Actor.IActorRef Get<TKey>() { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> GetAsync(System.Type key, System.Threading.CancellationToken ct = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> GetAsync<TKey>(System.Threading.CancellationToken ct = default) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.IActorRef>> GetEnumerator() { }
         public void Register<TKey>(Akka.Actor.IActorRef actor, bool overwrite = false) { }
         public bool TryGet(System.Type key, out Akka.Actor.IActorRef actor) { }
@@ -18,7 +20,7 @@ namespace Akka.Hosting
         public ActorRegistryException(string message) { }
         public ActorRegistryException(string message, System.Exception innerException) { }
     }
-    public class ActorRegistryExtension : Akka.Actor.ExtensionIdProvider<Akka.Hosting.ActorRegistry>
+    public sealed class ActorRegistryExtension : Akka.Actor.ExtensionIdProvider<Akka.Hosting.ActorRegistry>
     {
         public ActorRegistryExtension() { }
         public override Akka.Hosting.ActorRegistry CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
@@ -114,6 +116,8 @@ namespace Akka.Hosting
     public interface IReadOnlyActorRegistry : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.IActorRef>>, System.Collections.IEnumerable
     {
         Akka.Actor.IActorRef Get<TKey>();
+        System.Threading.Tasks.Task<Akka.Actor.IActorRef> GetAsync(System.Type key, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Akka.Actor.IActorRef> GetAsync<TKey>(System.Threading.CancellationToken ct = default);
         bool TryGet(System.Type key, out Akka.Actor.IActorRef actor);
         bool TryGet<TKey>(out Akka.Actor.IActorRef actor);
     }

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -275,22 +275,9 @@ namespace Akka.Hosting
             {
                 // first step during timeout is to remove our registration
                 var d = (ConcurrentDictionary<Type, ImmutableHashSet<WaitForActorRegistration>>)dict;
-                var removed = false;
-                while (!removed)
-                {
-                    if(d.TryGetValue(key, out var registrations))
-                    {
-                        var original = registrations;
-                        registrations = registrations.Remove(waitingRegistration);
-                        if (d.TryUpdate(key, registrations, original))
-                            removed = true;
-                    }
-                    else // no key exists
-                    {
-                        removed = true;
-                    }
-                }
-                
+                d.AddOrUpdate(key, type => ImmutableHashSet<WaitForActorRegistration>.Empty,
+                    (type, set) => set.Remove(waitingRegistration));
+
                 // next, cancel the task
                 waitingRegistration.Waiter.TrySetCanceled(ct);
             };

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Util;
 
@@ -94,6 +97,41 @@ namespace Akka.Hosting
         {
         }
     }
+    
+    /// <summary>
+    /// Used to implement "wait for actor" mechanics
+    /// </summary>
+    internal sealed class WaitForActorRegistration : IEquatable<WaitForActorRegistration>
+    {
+        public WaitForActorRegistration(Type key, TaskCompletionSource<IActorRef> waiter)
+        {
+            Key = key;
+            Waiter = waiter;
+        }
+
+        public Type Key { get; }
+        
+        public TaskCompletionSource<IActorRef> Waiter { get; }
+
+        public CancellationTokenRegistration CancellationRegistration { get; set; }
+
+        public bool Equals(WaitForActorRegistration other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Key == other.Key;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return ReferenceEquals(this, obj) || obj is WaitForActorRegistration other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Key.GetHashCode();
+        }
+    }
 
     /// <summary>
     /// Mutable, but thread-safe <see cref="ActorRegistry"/>.
@@ -123,6 +161,16 @@ namespace Akka.Hosting
         }
 
         /// <summary>
+        /// In the event that an actor is not available yet, typically during the very beginning of ActorSystem startup,
+        /// we can wait on that actor becoming available.
+        /// </summary>
+        /// <remarks>
+        /// Have to store a collection of <see cref="WaitForActorRegistration"/>s here so each waiter gets its own cancellation token.
+        /// </remarks>
+        private readonly ConcurrentDictionary<Type, ImmutableHashSet<WaitForActorRegistration>> _actorWaiters =
+            new ConcurrentDictionary<Type, ImmutableHashSet<WaitForActorRegistration>>();
+
+        /// <summary>
         /// Attempts to register an actor with the registry.
         /// </summary>
         /// <param name="actor">The <see cref="IActorRef"/> to register.</param>
@@ -149,6 +197,8 @@ namespace Akka.Hosting
                 return _actorRegistrations.TryAdd(key, actor);
             else
                 _actorRegistrations[key] = actor;
+            
+            NotifyWaiters(key, _actorRegistrations[key]);
             return true;
         }
 
@@ -163,7 +213,7 @@ namespace Akka.Hosting
         }
 
         /// <summary>
-        /// Try to retrieve an <see cref="IActorRef"/> with the given <see cref="TKey"/>.
+        /// Try to retrieve an <see cref="IActorRef"/> with the given type.
         /// </summary>
         /// <param name="key">The key for a particular actor.</param>
         /// <param name="actor">The bound <see cref="IActorRef"/>, if any. Is set to <see cref="ActorRefs.Nobody"/> if key is not found.</param>
@@ -178,6 +228,72 @@ namespace Akka.Hosting
 
             actor = ActorRefs.Nobody;
             return false;
+        }
+
+        public async Task<IActorRef> GetAsync<TKey>(CancellationToken ct)
+        {
+            return await GetAsync(typeof(TKey), ct);
+        }
+
+        public async Task<IActorRef> GetAsync(Type key, CancellationToken ct)
+        {
+            // try to get the populated actor first, if available
+            if (TryGet(key, out var storedActor))
+            {
+                return storedActor;
+            }
+
+            var tcs = new TaskCompletionSource<IActorRef>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var waitingRegistration = new WaitForActorRegistration(key, tcs);
+            var registration = ct.Register(CancelWaiter(key, ct, waitingRegistration), _actorWaiters);
+            waitingRegistration.CancellationRegistration = registration;
+
+            _actorWaiters.AddOrUpdate(key,
+                type => ImmutableHashSet<WaitForActorRegistration>.Empty.Add(waitingRegistration),
+                (type, set) => set.Add(waitingRegistration));
+            
+
+            return await tcs.Task.ConfigureAwait(false);
+        }
+
+        private void NotifyWaiters(Type key, IActorRef value)
+        {
+            // remove the registrations and then iterate over them
+            if (_actorWaiters.TryRemove(key, out var registrations))
+            {
+                foreach (var r in registrations)
+                {
+                    r.Waiter.TrySetResult(value);
+                    r.CancellationRegistration.Dispose();
+                }
+            }
+        }
+
+        private static Action<object> CancelWaiter(Type key, CancellationToken ct, WaitForActorRegistration waitingRegistration)
+        {
+            return dict =>
+            {
+                // first step during timeout is to remove our registration
+                var d = (ConcurrentDictionary<Type, ImmutableHashSet<WaitForActorRegistration>>)dict;
+                var removed = false;
+                while (!removed)
+                {
+                    if(d.TryGetValue(key, out var registrations))
+                    {
+                        var original = registrations;
+                        registrations = registrations.Remove(waitingRegistration);
+                        if (d.TryUpdate(key, registrations, original))
+                            removed = true;
+                    }
+                    else // no key exists
+                    {
+                        removed = true;
+                    }
+                }
+                
+                // next, cancel the task
+                waitingRegistration.Waiter.TrySetCanceled(ct);
+            };
         }
 
         /// <summary>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,12 @@
     <PropertyGroup>
         <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
         <Authors>Akka.NET Team</Authors>
-        <VersionPrefix>0.4.0</VersionPrefix>
-        <PackageReleaseNotes>• [Add Microsoft.Extensions.Logging.ILoggerFactory logging support](https://github.com/akkadotnet/Akka.Hosting/pull/72)</PackageReleaseNotes>
+        <VersionPrefix>1.0.1</VersionPrefix>
+        <PackageReleaseNotes>Version 1.0.1 fixes options bug used in the cluster sharding Akka.Hosting extension method.
+* [Update Akka.NET from 1.4.45 to 1.4.48](https://github.com/akkadotnet/akka.net/releases/tag/1.4.48)
+* [Fix SimpleDemo project failing on `Development` environment](https://github.com/akkadotnet/Akka.Hosting/pull/184)
+* [Add F# CustomJournalIdDemo project](https://github.com/akkadotnet/Akka.Hosting/pull/183)
+* [Fix cluster sharding hosting extension method options bug](https://github.com/akkadotnet/Akka.Hosting/pull/186)</PackageReleaseNotes>
         <PackageIcon>akkalogo.png</PackageIcon>
         <PackageProjectUrl>
             https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
Somewhat of an experiment - considering adding this to allow non-Akka.NET consumers to `await` for an `IActorRef` to be added to the `ActorRegistry` in the future. I'll be adding tests for the `ActorRegistry` overall in a separate PR but I have tested this functionality and it does work. However, I don't want to get users into the habit of explicitly awaiting everything from the registry just because we have it - all actors started via a `WithActors` delegate are guaranteed to be created _and available in the `ActorRegistry`_ before your `IHost.StartAsync` method exits, so you shouldn't need to await the `ActorRegsitry` when fetching any top-level actors created by the builder itself.

_However_, if you needed a child actor of some kind - one that is started _after_ the `IHost.StartAsync` method completes then this might be useful.

## Changes

Enables entries to be added to the `ActorRegistry` later in the future (i.e. actors not started explicitly via Akka.Hosting's delegates - child actors typically) without forcing consumers of the registry to poll for changes.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).