### PR TITLE
added Akka.Hosting v0.2.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,2 @@
-## [0.1.5] / 06 April 2022
-- Added `Akka.Persistence.PostgreSql.Hosting` NuGet package to support Postgres users.
+## [0.2.0] / 09 April 2022
+- [Bugfix: Fixed issues with duplicate `IServiceProvider` registration](https://github.com/akkadotnet/Akka.Hosting/pull/32), this could cause multiple instances of dependencies to be instantiated since Akka.Hosting creating multiple `IServiceProvider` instances during the construction process. This has been resolved.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
    <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.1.5</VersionPrefix>
-    <PackageReleaseNotes>• Added Akka.Persistence.PostgreSql.Hosting NuGet package to support Postgres users.</PackageReleaseNotes>
+    <VersionPrefix>0.2.0</VersionPrefix>
+    <PackageReleaseNotes>• [Bugfix: Fixed issues with duplicate IServiceProvider registration](https://github.com/akkadotnet/Akka.Hosting/pull/32)%2C this could cause multiple instances of dependencies to be instantiated since Akka.Hosting creating multiple IServiceProvider instances during the construction process. This has been resolved.</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
## [0.2.0] / 09 April 2022
- [Bugfix: Fixed issues with duplicate `IServiceProvider` registration](https://github.com/akkadotnet/Akka.Hosting/pull/32), this could cause multiple instances of dependencies to be instantiated since Akka.Hosting creating multiple `IServiceProvider` instances during the construction process. This has been resolved.