### PR TITLE
Don't override custom `ProviderSelection` instances

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,2 @@
-## [0.2.0] / 09 April 2022
-- [Bugfix: Fixed issues with duplicate `IServiceProvider` registration](https://github.com/akkadotnet/Akka.Hosting/pull/32), this could cause multiple instances of dependencies to be instantiated since Akka.Hosting creating multiple `IServiceProvider` instances during the construction process. This has been resolved.
+## [0.2.1] / 09 April 2022
+- Bugfix: when using Akka.Remote or Akka.Cluster, don't override any custom `ProviderSelection`s provided by the user.

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -90,6 +90,7 @@ namespace Akka.Cluster.Hosting
                 switch (builder.ActorRefProvider.Value)
                 {
                     case ProviderSelection.Cluster _:
+                    case ProviderSelection.Custom _:
                         return hoconBuilder; // no-op
                 }
             }

--- a/src/Akka.Remote.Hosting/AkkaRemoteHostingExtensions.cs
+++ b/src/Akka.Remote.Hosting/AkkaRemoteHostingExtensions.cs
@@ -38,6 +38,7 @@ namespace Akka.Remote.Hosting
                 {
                     case ProviderSelection.Cluster _:
                     case ProviderSelection.Remote _:
+                    case ProviderSelection.Custom _:
                         return hoconBuilder; // no-op
                 }
             }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
    <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.2.0</VersionPrefix>
-    <PackageReleaseNotes>• [Bugfix: Fixed issues with duplicate IServiceProvider registration](https://github.com/akkadotnet/Akka.Hosting/pull/32)%2C this could cause multiple instances of dependencies to be instantiated since Akka.Hosting creating multiple IServiceProvider instances during the construction process. This has been resolved.</PackageReleaseNotes>
+    <VersionPrefix>0.2.1</VersionPrefix>
+    <PackageReleaseNotes>• Bugfix: when using Akka.Remote or Akka.Cluster%2C don't override any custom ProviderSelections provided by the user.</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
## [0.2.1] / 09 April 2022
- Bugfix: when using Akka.Remote or Akka.Cluster, don't override any custom `ProviderSelection`s provided by the user.
