### PR TITLE
Add interfaces for the ActorRegistry to allow mocking in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Consists of the following packages:
 4. `Akka.Persistence.SqlServer.Hosting` - used for Akka.Persistence.SqlServer support.
 5. `Akka.Persistence.PostgreSql.Hosting` - used for Akka.Persistence.PostgreSql support.
 
-See the ["Introduction to Akka.Hosting - HOCONless, "Pit of Success" Akka.NET Runtime and Configuration" video with details here](https://www.youtube.com/watch?v=Mnb9W9ClnB0) for a walkthrough of the library and how it can save you a tremendous amount of time and trouble.
+See the ["Introduction to Akka.Hosting - HOCONless, "Pit of Success" Akka.NET Runtime and Configuration" video](https://www.youtube.com/watch?v=Mnb9W9ClnB0) for a walkthrough of the library and how it can save you a tremendous amount of time and trouble.
 
 ## Summary
 

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -115,7 +115,7 @@ namespace Akka.Hosting
             return GetEnumerator();
         }
 
-        public static IActorRegistry For(ActorSystem actorSystem)
+        public static ActorRegistry For(ActorSystem actorSystem)
         {
             return actorSystem.WithExtension<ActorRegistry, ActorRegistryExtension>();
         }

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -48,7 +48,7 @@ namespace Akka.Hosting
     /// <summary>
     /// Delegate used to instantiate <see cref="IActorRef"/>s once the <see cref="ActorSystem"/> has booted.
     /// </summary>
-    public delegate Task ActorStarter(ActorSystem system, ActorRegistry registry);
+    public delegate Task ActorStarter(ActorSystem system, IActorRegistry registry);
 
     /// <summary>
     /// Used to help populate a <see cref="SerializationSetup"/> upon starting the <see cref="ActorSystem"/>,
@@ -166,9 +166,9 @@ namespace Akka.Hosting
             }
         }
 
-        private static ActorStarter ToAsyncStarter(Action<ActorSystem, ActorRegistry> nonAsyncStarter)
+        private static ActorStarter ToAsyncStarter(Action<ActorSystem, IActorRegistry> nonAsyncStarter)
         {
-            Task Starter(ActorSystem f, ActorRegistry registry)
+            Task Starter(ActorSystem f, IActorRegistry registry)
             {
                 nonAsyncStarter(f, registry);
                 return Task.CompletedTask;
@@ -177,7 +177,7 @@ namespace Akka.Hosting
             return Starter;
         }
 
-        public AkkaConfigurationBuilder StartActors(Action<ActorSystem, ActorRegistry> starter)
+        public AkkaConfigurationBuilder StartActors(Action<ActorSystem, IActorRegistry> starter)
         {
             if (_complete) return this;
             _actorStarters.Add(ToAsyncStarter(starter));
@@ -252,7 +252,6 @@ namespace Akka.Hosting
                 var sys = ActorSystem.Create(config.ActorSystemName, actorSystemSetup);
 
                 return sys;
-            };
         }
 
         internal Task<ActorSystem> StartAsync(IServiceProvider sp)

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -210,7 +210,16 @@ namespace Akka.Hosting
             {
                 return ActorRegistry.For(sp.GetRequiredService<ActorSystem>());
             });
-
+            
+            ServiceCollection.AddSingleton<IActorRegistry>(sp =>
+            {
+                return sp.GetRequiredService<ActorRegistry>();
+            });
+            
+            ServiceCollection.AddSingleton<IReadOnlyActorRegistry>(sp =>
+            {
+                return sp.GetRequiredService<ActorRegistry>();
+            });
         }
 
         private static Func<IServiceProvider, ActorSystem> ActorSystemFactory()

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -210,6 +210,7 @@ namespace Akka.Hosting
             {
                 return ActorRegistry.For(sp.GetRequiredService<ActorSystem>());
             });
+
         }
 
         private static Func<IServiceProvider, ActorSystem> ActorSystemFactory()
@@ -252,6 +253,7 @@ namespace Akka.Hosting
                 var sys = ActorSystem.Create(config.ActorSystemName, actorSystemSetup);
 
                 return sys;
+            };
         }
 
         internal Task<ActorSystem> StartAsync(IServiceProvider sp)

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -111,7 +111,7 @@ namespace Akka.Hosting
         /// <param name="actorStarter">A <see cref="ActorStarter"/> delegate
         /// for configuring and starting actors.</param>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
-        public static AkkaConfigurationBuilder WithActors(this AkkaConfigurationBuilder builder, Action<ActorSystem, ActorRegistry> actorStarter)
+        public static AkkaConfigurationBuilder WithActors(this AkkaConfigurationBuilder builder, Action<ActorSystem, IActorRegistry> actorStarter)
         {
             return builder.StartActors(actorStarter);
         }


### PR DESCRIPTION
This PR adds both writeable and read-only interfaces for the ActorRegistry class to allow mocking in tests.