### PR TITLE
close #48 - fixed source of NRE upon shutdown

### DIFF
--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -58,6 +58,13 @@ namespace Akka.Hosting
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            // ActorSystem may have failed to start - skip shutdown sequence if that's the case
+            // so error message doesn't get conflated.
+            if (_coordinatedShutdown == null)
+            {
+                return;
+            }
+            
             // run full CoordinatedShutdown on the Sys
             await _coordinatedShutdown.Run(CoordinatedShutdown.ClrExitReason.Instance)
                 .ConfigureAwait(false);

--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -14,6 +14,7 @@ namespace Akka.Hosting
     internal sealed class AkkaHostedService : IHostedService
     {
         private ActorSystem _actorSystem;
+        private CoordinatedShutdown _coordinatedShutdown; // grab a reference to CoordinatedShutdown early
         private readonly IServiceProvider _serviceProvider;
         private readonly AkkaConfigurationBuilder _configurationBuilder;
         private readonly IHostApplicationLifetime _hostApplicationLifetime;
@@ -33,6 +34,7 @@ namespace Akka.Hosting
             try
             {
                 _actorSystem = _serviceProvider.GetRequiredService<ActorSystem>();
+                _coordinatedShutdown = CoordinatedShutdown.Get(_actorSystem);
                 await _configurationBuilder.StartAsync(_actorSystem);
 
                 async Task TerminationHook()
@@ -57,7 +59,7 @@ namespace Akka.Hosting
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             // run full CoordinatedShutdown on the Sys
-            await CoordinatedShutdown.Get(_actorSystem).Run(CoordinatedShutdown.ClrExitReason.Instance)
+            await _coordinatedShutdown.Run(CoordinatedShutdown.ClrExitReason.Instance)
                 .ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
Fixes #48

## Changes

Acquire `CoordinatedShutdown` early so it can't NRE upon acquisition from `ActorSystem` in the event of early termination. 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).