### PR TITLE
added throw-able `ActorRegistry.Register` method

### DIFF
--- a/src/Akka.Hosting.Tests/ActorRegistrySpecs.cs
+++ b/src/Akka.Hosting.Tests/ActorRegistrySpecs.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Akka.Actor;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.Tests;
+
+public class ActorRegistrySpecs
+{
+    [Fact]
+    public void Should_throw_upon_duplicate_registration()
+    {
+        // arrange
+        var registry = new ActorRegistry();
+        registry.Register<Nobody>(Nobody.Instance);
+        
+        // act
+
+        var register = () => registry.Register<Nobody>(Nobody.Instance);
+
+        // assert
+        register.Should().Throw<DuplicateActorRegistryException>();
+    }
+    
+    [Fact]
+    public void Should_not_throw_upon_duplicate_registration_when_overwrite_allowed()
+    {
+        // arrange
+        var registry = new ActorRegistry();
+        registry.Register<Nobody>(Nobody.Instance);
+        
+        // act
+
+        var register = () => registry.Register<Nobody>(Nobody.Instance, true);
+
+        // assert
+        register.Should().NotThrow<DuplicateActorRegistryException>();
+    }
+}

--- a/src/Akka.Hosting.Tests/ActorRegistrySpecs.cs
+++ b/src/Akka.Hosting.Tests/ActorRegistrySpecs.cs
@@ -36,4 +36,18 @@ public class ActorRegistrySpecs
         // assert
         register.Should().NotThrow<DuplicateActorRegistryException>();
     }
+    
+    [Fact]
+    public void Should_throw_NullReferenceException_for_Null_IActorRef()
+    {
+        // arrange
+        var registry = new ActorRegistry();
+
+        // act
+
+        var register = () => registry.Register<Nobody>(null);
+
+        // assert
+        register.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -44,8 +44,12 @@ namespace Akka.Hosting
 
         /// <inheritdoc cref="IActorRegistry.Register{TKey}"/>
         /// <exception cref="DuplicateActorRegistryException">Thrown when the same value is inserted twice and overwriting is not allowed.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a <c>null</c> <see cref="IActorRef"/> is registered.</exception>
         public void Register<TKey>(IActorRef actor, bool overwrite = false)
         {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor), "Cannot register null actors");
+            
             if (!TryRegister<TKey>(actor, overwrite))
             {
                 throw new DuplicateActorRegistryException(
@@ -73,6 +77,9 @@ namespace Akka.Hosting
         /// <returns><c>true</c> if the actor was set to this key in the registry, <c>false</c> otherwise.</returns>
         public bool TryRegister(Type key, IActorRef actor, bool overwrite = false)
         {
+            if (actor == null)
+                return false;
+            
             if (!overwrite)
                 return _actorRegistrations.TryAdd(key, actor);
             else

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -49,14 +49,14 @@ namespace Akka.Hosting
             if (!TryRegister<TKey>(actor, overwrite))
             {
                 throw new DuplicateActorRegistryException(
-                    $"An actor for type {typeof(TKey)} has already been . Call `Register(IActorRef, bool overwrite=true)` to avoid this error or use a different key.");
+                    $"An actor for type {typeof(TKey)} has already been registered. Call `Register(IActorRef, bool overwrite=true)` to avoid this error or use a different key.");
             }
         }
 
         /// <summary>
         /// Attempts to register an actor with the registry.
         /// </summary>
-        /// <param name="actor">The bound <see cref="IActorRef"/>, if any. Is set to <see cref="ActorRefs.Nobody"/> if key is not found.</param>
+        /// <param name="actor">The <see cref="IActorRef"/> to register.</param>
         /// <param name="overwrite">If <c>true</c>, allows overwriting of a previous actor with the same key. Defaults to <c>false</c>.</param>
         /// <returns><c>true</c> if the actor was set to this key in the registry, <c>false</c> otherwise.</returns>
         public bool TryRegister<TKey>(IActorRef actor, bool overwrite = false)
@@ -68,7 +68,7 @@ namespace Akka.Hosting
         /// Attempts to register an actor with the registry.
         /// </summary>
         /// <param name="key">The key for a particular actor.</param>
-        /// <param name="actor">The bound <see cref="IActorRef"/>, if any. Is set to <see cref="ActorRefs.Nobody"/> if key is not found.</param>
+        /// <param name="actor">The <see cref="IActorRef"/> to register.</param>
         /// <param name="overwrite">If <c>true</c>, allows overwriting of a previous actor with the same key. Defaults to <c>false</c>.</param>
         /// <returns><c>true</c> if the actor was set to this key in the registry, <c>false</c> otherwise.</returns>
         public bool TryRegister(Type key, IActorRef actor, bool overwrite = false)


### PR DESCRIPTION
Wanted to do this to make assertions easier to implement within the `AkkaConfigurationBuilder`.
