### PR TITLE
adding `ClusterSingleton` hosting methods

### DIFF
--- a/Akka.Hosting.sln
+++ b/Akka.Hosting.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.SqlSharding", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Remote.Hosting.Tests", "src\Akka.Remote.Hosting.Tests\Akka.Remote.Hosting.Tests.csproj", "{4D748F16-AC22-4E8B-94D7-3DAF6B7CBD00}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Cluster.Hosting.Tests", "src\Akka.Cluster.Hosting.Tests\Akka.Cluster.Hosting.Tests.csproj", "{EEFCC5A9-94BB-41DA-A9D3-12ACB889FE42}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,10 @@ Global
 		{4D748F16-AC22-4E8B-94D7-3DAF6B7CBD00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D748F16-AC22-4E8B-94D7-3DAF6B7CBD00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4D748F16-AC22-4E8B-94D7-3DAF6B7CBD00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEFCC5A9-94BB-41DA-A9D3-12ACB889FE42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFCC5A9-94BB-41DA-A9D3-12ACB889FE42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEFCC5A9-94BB-41DA-A9D3-12ACB889FE42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEFCC5A9-94BB-41DA-A9D3-12ACB889FE42}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+        <PackageReference Include="xunit" Version="$(XunitVersion)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Akka.Cluster.Hosting\Akka.Cluster.Hosting.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -4,7 +4,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVerison)" />
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -4,6 +4,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVerison)" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Remote.Hosting;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Akka.Cluster.Hosting.Tests;
+
+public class ClusterSingletonSpecs
+{
+    private class MySingletonActor : ReceiveActor
+    {
+        public static Props MyProps => Props.Create(() => new MySingletonActor());
+        
+        public MySingletonActor()
+        {
+            ReceiveAny(_ => Sender.Tell(_));
+        }
+    }
+    
+    private static async Task<IHost> CreateHost(Action<AkkaConfigurationBuilder> specBuilder, string clusterRole)
+    {
+        var tcs = new TaskCompletionSource();
+        
+        var host = new HostBuilder()
+            .ConfigureServices(collection =>
+            {
+                collection.AddAkka("TestSys", (configurationBuilder, provider) =>
+                {
+                    configurationBuilder.WithRemoting("localhost", 0)
+                        .WithClustering(new ClusterOptions(){ Roles = new []{ clusterRole }})
+                        .WithActors(async (system, registry) =>
+                        {
+                            var cluster = Cluster.Get(system);
+                            var myAddress = cluster.SelfAddress;
+                            await cluster.JoinAsync(myAddress); // force system to wait until we're up
+                            tcs.SetResult();
+                        });
+                    specBuilder(configurationBuilder);
+                });
+            }).Build();
+        
+        
+    }
+
+    [Fact]
+    public async Task Should_launch_ClusterSingletonAndProxy()
+    {
+        // arrange
+        var host = CreateHost(builder =>
+        {
+            builder.WithSingleton<MySingletonActor>("my-singleton", MySingletonActor.MyProps);
+        }, "my-host");
+
+        // act
+
+        // assert
+    }
+
+    public Task InitializeAsync()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task DisposeAsync()
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
@@ -13,24 +15,25 @@ public class ClusterSingletonSpecs
     private class MySingletonActor : ReceiveActor
     {
         public static Props MyProps => Props.Create(() => new MySingletonActor());
-        
+
         public MySingletonActor()
         {
             ReceiveAny(_ => Sender.Tell(_));
         }
     }
-    
+
     private static async Task<IHost> CreateHost(Action<AkkaConfigurationBuilder> specBuilder, string clusterRole)
     {
         var tcs = new TaskCompletionSource();
-        
+
         var host = new HostBuilder()
             .ConfigureServices(collection =>
             {
                 collection.AddAkka("TestSys", (configurationBuilder, provider) =>
                 {
-                    configurationBuilder.WithRemoting("localhost", 0)
-                        .WithClustering(new ClusterOptions(){ Roles = new []{ clusterRole }})
+                    configurationBuilder
+                        .WithRemoting("localhost", 0)
+                        .WithClustering(new ClusterOptions() { Roles = new[] { clusterRole } })
                         .WithActors(async (system, registry) =>
                         {
                             var cluster = Cluster.Get(system);
@@ -41,31 +44,32 @@ public class ClusterSingletonSpecs
                     specBuilder(configurationBuilder);
                 });
             }).Build();
-        
-        
+
+        await host.StartAsync();
+        await tcs.Task;
+
+        return host;
     }
 
     [Fact]
     public async Task Should_launch_ClusterSingletonAndProxy()
     {
         // arrange
-        var host = CreateHost(builder =>
-        {
-            builder.WithSingleton<MySingletonActor>("my-singleton", MySingletonActor.MyProps);
-        }, "my-host");
+        using var host = await CreateHost(
+            builder => { builder.WithSingleton<MySingletonActor>("my-singleton", MySingletonActor.MyProps); },
+            "my-host");
+
+        var registry = host.Services.GetRequiredService<ActorRegistry>();
+        var singletonProxy = registry.Get<MySingletonActor>();
 
         // act
+        
+        // verify round-trip to the singleton proxy and back
+        var respond = await singletonProxy.Ask<string>("hit", TimeSpan.FromSeconds(3));
 
         // assert
-    }
+        respond.Should().Be("hit");
 
-    public Task InitializeAsync()
-    {
-        throw new System.NotImplementedException();
-    }
-
-    public Task DisposeAsync()
-    {
-        throw new System.NotImplementedException();
+        await host.StopAsync();
     }
 }

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -315,20 +315,19 @@ namespace Akka.Cluster.Hosting
                         singletonProxySettings = singletonProxySettings.WithBufferSize(options.BufferSize.Value);
                     }
 
-                    CreateAndRegisterSingletonProxy<TKey>(singletonManagerRef.Path.Name, singletonProxySettings, system, registry);
+                    CreateAndRegisterSingletonProxy<TKey>($"/user/{singletonManagerRef.Path.Name}", singletonManagerRef.Path.Name, singletonProxySettings, system, registry);
                 }
             });
         }
 
-        private static void CreateAndRegisterSingletonProxy<TKey>(string singletonActorName,
+        private static void CreateAndRegisterSingletonProxy<TKey>(string singletonActorName, string singletonActorPath,
             ClusterSingletonProxySettings singletonProxySettings, ActorSystem system, IActorRegistry registry)
         {
-            var singletonProxyProps = ClusterSingletonProxy.Props($"/user/{singletonActorName}",
+            var singletonProxyProps = ClusterSingletonProxy.Props(singletonActorPath,
                 singletonProxySettings);
             var singletonProxy = system.ActorOf(singletonProxyProps, $"{singletonActorName}-proxy");
-
-            // TODO: should throw here if duplicate key used
-            registry.TryRegister<TKey>(singletonProxy);
+            
+            registry.Register<TKey>(singletonProxy);
         }
 
         /// <summary>
@@ -365,7 +364,7 @@ namespace Akka.Cluster.Hosting
 
                 singletonManagerPath ??= $"/user/{singletonName}";
                 
-                CreateAndRegisterSingletonProxy<TKey>(singletonManagerPath, singletonProxySettings, system, registry);
+                CreateAndRegisterSingletonProxy<TKey>(singletonName, singletonManagerPath, singletonProxySettings, system, registry);
             });
         }
     }

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -323,6 +323,8 @@ namespace Akka.Cluster.Hosting
                     registry.TryRegister<TKey>(singletonProxy);
                 }
             });
+
+            return builder;
         }
     }
 }

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -299,7 +299,7 @@ namespace Akka.Cluster.Hosting
                     singletonProxySettings = singletonProxySettings.WithRole(options.Role);
                 }
 
-                var singletonProps = options is { TerminationMessage: { } }
+                var singletonProps = options.TerminationMessage == null
                     ? ClusterSingletonManager.Props(actorProps, clusterSingletonManagerSettings)
                     : ClusterSingletonManager.Props(actorProps, options.TerminationMessage,
                         clusterSingletonManagerSettings);
@@ -317,7 +317,7 @@ namespace Akka.Cluster.Hosting
 
                     var singletonProxyProps = ClusterSingletonProxy.Props($"/user/{singletonManagerRef.Path.Name}",
                         singletonProxySettings);
-                    var singletonProxy = system.ActorOf(singletonProps, $"{singletonManagerRef.Path.Name}-proxy");
+                    var singletonProxy = system.ActorOf(singletonProxyProps, $"{singletonManagerRef.Path.Name}-proxy");
 
                     // TODO: should throw here if duplicate key used
                     registry.TryRegister<TKey>(singletonProxy);

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -315,7 +315,7 @@ namespace Akka.Cluster.Hosting
                         singletonProxySettings = singletonProxySettings.WithBufferSize(options.BufferSize.Value);
                     }
 
-                    CreateAndRegisterSingletonProxy<TKey>($"/user/{singletonManagerRef.Path.Name}", singletonManagerRef.Path.Name, singletonProxySettings, system, registry);
+                    CreateAndRegisterSingletonProxy<TKey>(singletonManagerRef.Path.Name, $"/user/{singletonManagerRef.Path.Name}", singletonProxySettings, system, registry);
                 }
             });
         }

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -268,7 +268,7 @@ namespace Akka.Cluster.Hosting
         /// <summary>
         /// Creates a new <see cref="ClusterSingletonManager"/> to host an actor created via <see cref="actorProps"/>.
         ///
-        /// If <see cref="createProxyToo"/> is set to <c>true</c> then this method will also create a <see cref="ClusterSingletonProxy"/> that
+        /// If <paramref name="createProxyToo"/> is set to <c>true</c> then this method will also create a <see cref="ClusterSingletonProxy"/> that
         /// will be added to the <see cref="ActorRegistry"/> using the key <see cref="TKey"/>. Otherwise this method will register nothing with
         /// the <see cref="ActorRegistry"/>.
         /// </summary>
@@ -279,7 +279,7 @@ namespace Akka.Cluster.Hosting
         /// <param name="options">Optional. The set of options for configuring both the <see cref="ClusterSingletonManager"/> and
         /// optionally, the <see cref="ClusterSingletonProxy"/>.</param>
         /// <param name="createProxyToo">When set to <c>true></c>, creates a <see cref="ClusterSingletonProxy"/> that automatically points to the <see cref="ClusterSingletonManager"/> created by this method.</param>
-        /// <typeparam name="TKey">The key type to use for the <see cref="ActorRegistry"/> when <see cref="createProxyToo"/> is set to <c>true</c>.</typeparam>
+        /// <typeparam name="TKey">The key type to use for the <see cref="ActorRegistry"/> when <paramref name="createProxyToo"/> is set to <c>true</c>.</typeparam>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
         public static AkkaConfigurationBuilder WithSingleton<TKey>(this AkkaConfigurationBuilder builder,
             string singletonName, Props actorProps, ClusterSingletonOptions options = null, bool createProxyToo = true)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,7 +18,7 @@
     <TestsNetCoreFramework>net6.0</TestsNetCoreFramework>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>17.1.0</TestSdkVersion>
+    <TestSdkVersion>17.2.0</TestSdkVersion>
     <AkkaVersion>1.4.38</AkkaVersion>
     <MicrosoftExtensionsVersion>[3.0.0,)</MicrosoftExtensionsVersion>
   </PropertyGroup>


### PR DESCRIPTION
Adding `ClusterSingletonManager` and `ClusterSingletonProxy` methods to Akka.Hosting.

## Changes

Using some of the methods I originally developed here and turning them into something re-usable across end-user projects:

https://github.com/petabridge/akkadotnet-code-samples/blob/108a694421a017aadcbcc5388a98a38fe43a8f74/src/clustering/sharding-sqlserver/SqlSharding.Shared/Sharding/ProductActorProps.cs#L24-L43

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).