### PR TITLE
added 0.3.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,5 @@
-## [0.2.2] / 10 April 2022
-- [Bugfix: Akka.Remote.Hosting doesn't support `public-hostname` correctly](https://github.com/akkadotnet/Akka.Hosting/issues/36)
+## [0.3.0] / 24 May 2022
+- [Add interfaces for the `ActorRegistry` to allow mocking in tests](https://github.com/akkadotnet/Akka.Hosting/pull/42)
+- [Fixed: Akka.Hosting NRE upon shutdown](https://github.com/akkadotnet/Akka.Hosting/pull/49)
+- [added throw-able `ActorRegistry.Register` method](https://github.com/akkadotnet/Akka.Hosting/pull/50)
+- [Akka.Cluster.Hosting: adding `ClusterSingleton` hosting methods](https://github.com/akkadotnet/Akka.Hosting/pull/51)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,11 @@
   <PropertyGroup>
    <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.2.2</VersionPrefix>
-    <PackageReleaseNotes>• [Bugfix: Akka.Remote.Hosting doesn't support public-hostname correctly](https://github.com/akkadotnet/Akka.Hosting/issues/36)</PackageReleaseNotes>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <PackageReleaseNotes>• [Add interfaces for the ActorRegistry to allow mocking in tests](https://github.com/akkadotnet/Akka.Hosting/pull/42)
+• [Fixed: Akka.Hosting NRE upon shutdown](https://github.com/akkadotnet/Akka.Hosting/pull/49)
+• [added throw-able ActorRegistry.Register method](https://github.com/akkadotnet/Akka.Hosting/pull/50)
+• [Akka.Cluster.Hosting: adding ClusterSingleton hosting methods](https://github.com/akkadotnet/Akka.Hosting/pull/51)</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
## [0.3.0] / 24 May 2022
- [Add interfaces for the `ActorRegistry` to allow mocking in tests](https://github.com/akkadotnet/Akka.Hosting/pull/42)
- [Fixed: Akka.Hosting NRE upon shutdown](https://github.com/akkadotnet/Akka.Hosting/pull/49)
- [added throw-able `ActorRegistry.Register` method](https://github.com/akkadotnet/Akka.Hosting/pull/50)
- [Akka.Cluster.Hosting: adding `ClusterSingleton` hosting methods](https://github.com/akkadotnet/Akka.Hosting/pull/51)
