### PR TITLE
added `AddHoconFile` method

### DIFF
--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -13,4 +13,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Akka.Hosting\Akka.Hosting.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="test.hocon" />
+    <Content Include="test.hocon">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
+++ b/src/Akka.Hosting.Tests/DISanityCheckSpecs.cs
@@ -5,12 +5,12 @@ using Akka.Actor;
 using Akka.DependencyInjection;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit;
+using static Akka.Hosting.Tests.TestHelpers;
 
 namespace Akka.Hosting.Tests;
 
-public class DiSanityCheckSpecs
+public class DiSanityCheckSpecs 
 {
     public interface IMySingletonInterface{}
     
@@ -35,19 +35,6 @@ public class DiSanityCheckSpecs
                 Sender.Tell(_singleton);
             });
         }
-    }
-    
-    private static async Task<IHost> StartHost(Action<IServiceCollection> testSetup)
-    {
-        var host = new HostBuilder()
-        .ConfigureServices(services =>
-        {
-            services.AddSingleton<IMySingletonInterface, MySingletonImpl>();
-            testSetup(services);
-        }).Build();
-        
-        await host.StartAsync();
-        return host;
     }
 
     /// <summary>

--- a/src/Akka.Hosting.Tests/HoconSpecs.cs
+++ b/src/Akka.Hosting.Tests/HoconSpecs.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static Akka.Hosting.Tests.TestHelpers;
+
+namespace Akka.Hosting.Tests;
+
+public class HoconSpecs
+{
+    [Fact]
+    public async Task Should_load_HOCON_from_file()
+    {
+        // arrange
+        using var host = await StartHost(collection => collection.AddAkka("Test", builder =>
+        {
+            builder.AddHoconFile("test.hocon");
+        }));
+        
+        // act
+        var sys = host.Services.GetRequiredService<ActorSystem>();
+        var hocon = sys.Settings.Config;
+        
+        // assert
+        hocon.HasPath("petabridge.cmd").Should().BeTrue();
+    }
+}

--- a/src/Akka.Hosting.Tests/TestHelpers.cs
+++ b/src/Akka.Hosting.Tests/TestHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Akka.Hosting.Tests;
+
+public static class TestHelpers
+{
+    public static async Task<IHost> StartHost(Action<IServiceCollection> testSetup)
+    {
+        var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<DiSanityCheckSpecs.IMySingletonInterface, DiSanityCheckSpecs.MySingletonImpl>();
+                testSetup(services);
+            }).Build();
+        
+        await host.StartAsync();
+        return host;
+    }
+}

--- a/src/Akka.Hosting.Tests/test.hocon
+++ b/src/Akka.Hosting.Tests/test.hocon
@@ -1,0 +1,9 @@
+﻿# See petabridge.cmd configuration options here: https://cmd.petabridge.com/articles/install/host-configuration.html
+petabridge.cmd{
+    # default IP address used to listen for incoming petabridge.cmd client connections
+    # should be a safe default as it listens on "all network interfaces".
+    host = "0.0.0.0"
+    
+    # default port number used to listen for incoming petabridge.cmd client connections
+    port = 9110
+}

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
@@ -88,6 +89,21 @@ namespace Akka.Hosting
             HoconAddMode addMode = HoconAddMode.Append)
         {
             return builder.AddHoconConfiguration(hocon, addMode);
+        }
+
+        /// <summary>
+        /// Automatically loads the given HOCON file from <see cref="hoconFilePath"/>
+        /// and inserts it into the <see cref="ActorSystem"/>s' configuration.
+        /// </summary>
+        /// <param name="builder">The builder instance being configured.</param>
+        /// <param name="hoconFilePath">The path to the HOCON file. Can be relative or absolute.</param>
+        /// <param name="addMode">The <see cref="HoconAddMode"/> - defaults to appending this HOCON as a fallback.</param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public static AkkaConfigurationBuilder AddHoconFile(this AkkaConfigurationBuilder builder, string hoconFilePath,
+            HoconAddMode addMode = HoconAddMode.Append)
+        {
+            var hoconText = ConfigurationFactory.ParseString(File.ReadAllText(hoconFilePath));
+            return AddHocon(builder, hoconText, addMode);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

Allows Akka.Hosting to automatically load HOCON from a file. Solves a longtime painpoint for users where they typically had to call `ConfigurationFactory.ParseString(File.ReadAllText(filePath))`. Now it's a one-liner.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
