### PR TITLE
Fix #55, wrong HOCON insertion ordering

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
@@ -47,6 +47,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
         var response = testProbe.ExpectMsg<SubscribeAck>();
 
         // assert
+        _system.Settings.Config.GetString("akka.cluster.pub-sub.role").Should().Be("my-host");
         response.Subscribe.Topic.Should().Be("testSub");
         response.Subscribe.Ref.Should().Be(testProbe);
 
@@ -97,7 +98,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
                                 
                                 _log.Info("Distributed pub-sub test system initialized.");
                             })
-                            .WithDistributedPubSub("pub-sub-host");
+                            .WithDistributedPubSub("my-host");
                         _specBuilder(configurationBuilder);
                     });
             }).Build();

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -254,7 +254,7 @@ namespace Akka.Cluster.Hosting
             var middle = builder.AddHocon(DistributedPubSub.DefaultConfig());
             if (!string.IsNullOrEmpty(role)) // add role config
             {
-                middle = middle.AddHocon($"akka.cluster.pub-sub.role = \"{role}\"");
+                middle = middle.AddHocon($"akka.cluster.pub-sub.role = \"{role}\"", HoconAddMode.Prepend);
             }
 
             return middle.WithActors((system, registry) =>


### PR DESCRIPTION
Fixes #55

## Changes
HOCON setting was inserted in the wrong order. Needed to add `HoconAddMode.Prepend`.
