### PR TITLE
Added v0.3.3 Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,4 @@
-## [0.3.2] / 13 June 2022
-- [Fixed: WithDistributedPubSub role HOCON settings not inserted in proper order](https://github.com/akkadotnet/Akka.Hosting/issues/60)
-
-## [0.3.1] / 09 June 2022
-- [Fixed: WithDistributedPubSub throws NullReferenceException](https://github.com/akkadotnet/Akka.Hosting/issues/55)
-- [Introduced `AddHoconFile` method](https://github.com/akkadotnet/Akka.Hosting/pull/58)
-- [Upgraded to Akka.NET 1.4.39](https://github.com/akkadotnet/akka.net/releases/tag/1.4.39)
+## [0.3.3] / 16 June 2022
+- [Added common `Akka.Persistence.Hosting` package to make it easier to add `IEventAdapter`s to journals](https://github.com/akkadotnet/Akka.Hosting/issues/64).
+- [Made Akka.Persistence.SqlServer.Hosting and Akka.Persistence.PostgreSql.Hosting both take a shared overload / dependency on Akka.Persistence.Hosting](https://github.com/akkadotnet/Akka.Hosting/pull/67) - did this to make it easier to add `IEventAdapter`s to each of those.
+- [Add Akka.Cluster.Tools.Client support](https://github.com/akkadotnet/Akka.Hosting/pull/66) - now possible to start `ClusterClient` and `ClusterClientReceptionist`s easily from Akka.Hosting.


### PR DESCRIPTION
## [0.3.3] / 16 June 2022
- [Added common `Akka.Persistence.Hosting` package to make it easier to add `IEventAdapter`s to journals](https://github.com/akkadotnet/Akka.Hosting/issues/64).
- [Made Akka.Persistence.SqlServer.Hosting and Akka.Persistence.PostgreSql.Hosting both take a shared overload / dependency on Akka.Persistence.Hosting](https://github.com/akkadotnet/Akka.Hosting/pull/67) - did this to make it easier to add `IEventAdapter`s to each of those.
- [Add Akka.Cluster.Tools.Client support](https://github.com/akkadotnet/Akka.Hosting/pull/66) - now possible to start `ClusterClient` and `ClusterClientReceptionist`s easily from Akka.Hosting.

Fixes #

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
