### PR TITLE
Sharding add actor registry overloads

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
@@ -1,0 +1,13 @@
+﻿using Xunit.Abstractions;
+
+namespace Akka.Cluster.Hosting.Tests;
+
+public class ClusterShardingSpecs
+{
+    public ClusterShardingSpecs(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    public ITestOutputHelper Output { get; }
+}

--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
@@ -1,13 +1,113 @@
-﻿using Xunit.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Sharding;
+using Akka.Hosting;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Cluster.Hosting.Tests;
 
 public class ClusterShardingSpecs
 {
+    public sealed class MyTopLevelActor : ReceiveActor
+    {
+    }
+
+    public sealed class MyEntityActor : ReceiveActor
+    {
+        public MyEntityActor(string entityId, IActorRef sourceRef)
+        {
+            EntityId = entityId;
+            SourceRef = sourceRef;
+
+            Receive<GetId>(g => { Sender.Tell(EntityId); });
+            Receive<GetSourceRef>(g => Sender.Tell(SourceRef));
+        }
+
+        public string EntityId { get; }
+
+        public IActorRef SourceRef { get; }
+
+        public sealed class GetId : IWithId
+        {
+            public GetId(string id)
+            {
+                Id = id;
+            }
+
+            public string Id { get; }
+        }
+
+        public sealed class GetSourceRef : IWithId
+        {
+            public GetSourceRef(string id)
+            {
+                Id = id;
+            }
+
+            public string Id { get; }
+        }
+    }
+
+    public interface IWithId
+    {
+        string Id { get; }
+    }
+
+    public sealed class Extractor : HashCodeMessageExtractor
+    {
+        public Extractor() : base(30)
+        {
+        }
+
+        public override string EntityId(object message)
+        {
+            if (message is IWithId withId)
+                return withId.Id;
+            return string.Empty;
+        }
+    }
+
     public ClusterShardingSpecs(ITestOutputHelper output)
     {
         Output = output;
     }
 
     public ITestOutputHelper Output { get; }
+
+    [Fact]
+    public async Task Should_use_ActorRegistry_with_ShardRegion()
+    {
+        // arrange
+        using var host = await TestHelper.CreateHost(builder =>
+        {
+            builder.WithActors((system, registry) =>
+                {
+                    var tLevel = system.ActorOf(Props.Create(() => new MyTopLevelActor()), "toplevel");
+                    registry.Register<MyTopLevelActor>(tLevel);
+                })
+                .WithShardRegion<MyEntityActor>("entities", (system, registry) =>
+                {
+                    var tLevel = registry.Get<MyTopLevelActor>();
+                    return s => Props.Create(() => new MyEntityActor(s, tLevel));
+                }, new Extractor(), new ShardOptions() { Role = "my-host", StateStoreMode = StateStoreMode.DData });
+        }, new ClusterOptions() { Roles = new[] { "my-host" } }, Output);
+
+        var actorSystem = host.Services.GetRequiredService<ActorSystem>();
+        var actorRegistry = ActorRegistry.For(actorSystem);
+        var shardRegion = actorRegistry.Get<MyEntityActor>();
+        
+        // act
+        var id = await shardRegion.Ask<string>(new MyEntityActor.GetId("foo"), TimeSpan.FromSeconds(3));
+        var sourceRef =
+            await shardRegion.Ask<IActorRef>(new MyEntityActor.GetSourceRef("foo"), TimeSpan.FromSeconds(3));
+
+        // assert
+        id.Should().Be("foo");
+        sourceRef.Should().Be(actorRegistry.Get<MyTopLevelActor>());
+    }
 }

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
@@ -1,64 +1,13 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Event;
 using Akka.Hosting;
-using Akka.Remote.Hosting;
-using Akka.TestKit.Xunit2.Internals;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.Cluster.Hosting.Tests;
-
-public static class TestHelper
-{
-
-    public static async Task<IHost> CreateHost(Action<AkkaConfigurationBuilder> specBuilder, ClusterOptions options, ITestOutputHelper output)
-    {
-        var tcs = new TaskCompletionSource();
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-
-        var host = new HostBuilder()
-            .ConfigureServices(collection =>
-            {
-                collection.AddAkka("TestSys", (configurationBuilder, provider) =>
-                {
-                    configurationBuilder
-                        .WithRemoting("localhost", 0)
-                        .WithClustering(options)
-                        .WithActors((system, registry) =>
-                        {
-                            var extSystem = (ExtendedActorSystem)system;
-                            var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(output)), "log-test");
-                            logger.Tell(new InitializeLogger(system.EventStream));
-                        })
-                        .WithActors(async (system, registry) =>
-                        {
-                            var cluster = Cluster.Get(system);
-                            cluster.RegisterOnMemberUp(() =>
-                            {
-                                tcs.SetResult();
-                            });  
-                            if (options.SeedNodes == null || options.SeedNodes.Length == 0)
-                            {
-                                var myAddress = cluster.SelfAddress;
-                                await cluster.JoinAsync(myAddress); // force system to wait until we're up
-                            }
-                        });
-                    specBuilder(configurationBuilder);
-                });
-            }).Build();
-
-        await host.StartAsync(cancellationTokenSource.Token);
-        await (tcs.Task.WaitAsync(cancellationTokenSource.Token));
-
-        return host;
-    }
-}
 
 public class ClusterSingletonSpecs
 {

--- a/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
+++ b/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using Akka.Remote.Hosting;
+using Akka.TestKit.Xunit2.Internals;
+using Microsoft.Extensions.Hosting;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Hosting.Tests;
+
+public static class TestHelper
+{
+
+    public static async Task<IHost> CreateHost(Action<AkkaConfigurationBuilder> specBuilder, ClusterOptions options, ITestOutputHelper output)
+    {
+        var tcs = new TaskCompletionSource();
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var host = new HostBuilder()
+            .ConfigureServices(collection =>
+            {
+                collection.AddAkka("TestSys", (configurationBuilder, provider) =>
+                {
+                    configurationBuilder
+                        .WithRemoting("localhost", 0)
+                        .WithClustering(options)
+                        .WithActors((system, registry) =>
+                        {
+                            var extSystem = (ExtendedActorSystem)system;
+                            var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(output)), "log-test");
+                            logger.Tell(new InitializeLogger(system.EventStream));
+                        })
+                        .WithActors(async (system, registry) =>
+                        {
+                            var cluster = Cluster.Get(system);
+                            cluster.RegisterOnMemberUp(() =>
+                            {
+                                tcs.SetResult();
+                            });  
+                            if (options.SeedNodes == null || options.SeedNodes.Length == 0)
+                            {
+                                var myAddress = cluster.SelfAddress;
+                                await cluster.JoinAsync(myAddress); // force system to wait until we're up
+                            }
+                        });
+                    specBuilder(configurationBuilder);
+                });
+            }).Build();
+
+        await host.StartAsync(cancellationTokenSource.Token);
+        await (tcs.Task.WaitAsync(cancellationTokenSource.Token));
+
+        return host;
+    }
+}

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -138,10 +138,8 @@ namespace Akka.Cluster.Hosting
                         .WithRole(shardOptions.Role)
                         .WithRememberEntities(shardOptions.RememberEntities)
                         .WithStateStoreMode(shardOptions.StateStoreMode), messageExtractor);
-
-                // TODO: should throw here if duplicate key used
-
-                registry.TryRegister<TKey>(shardRegion);
+                
+                registry.Register<TKey>(shardRegion);
             });
         }
 
@@ -179,9 +177,44 @@ namespace Akka.Cluster.Hosting
                         .WithRememberEntities(shardOptions.RememberEntities)
                         .WithStateStoreMode(shardOptions.StateStoreMode), extractEntityId, extractShardId);
 
-                // TODO: should throw here if duplicate key used
+                registry.Register<TKey>(shardRegion);
+            });
+        }
+        
+        public static AkkaConfigurationBuilder WithShardRegion<TKey>(this AkkaConfigurationBuilder builder,
+            string typeName,
+            Func<ActorSystem, IActorRegistry, Func<string, Props>> compositePropsFactory, IMessageExtractor messageExtractor, ShardOptions shardOptions)
+        {
+            return builder.WithActors(async (system, registry) =>
+            {
+                var entityPropsFactory = compositePropsFactory(system, registry);
+                
+                var shardRegion = await ClusterSharding.Get(system).StartAsync(typeName, entityPropsFactory,
+                    ClusterShardingSettings.Create(system)
+                        .WithRole(shardOptions.Role)
+                        .WithRememberEntities(shardOptions.RememberEntities)
+                        .WithStateStoreMode(shardOptions.StateStoreMode), messageExtractor);
 
-                registry.TryRegister<TKey>(shardRegion);
+                registry.Register<TKey>(shardRegion);
+            });
+        }
+
+        public static AkkaConfigurationBuilder WithShardRegion<TKey>(this AkkaConfigurationBuilder builder,
+            string typeName,
+            Func<ActorSystem, IActorRegistry, Func<string, Props>> compositePropsFactory, ExtractEntityId extractEntityId,
+            ExtractShardId extractShardId, ShardOptions shardOptions)
+        {
+            return builder.WithActors(async (system, registry) =>
+            {
+                var entityPropsFactory = compositePropsFactory(system, registry);
+                
+                var shardRegion = await ClusterSharding.Get(system).StartAsync(typeName, entityPropsFactory,
+                    ClusterShardingSettings.Create(system)
+                        .WithRole(shardOptions.Role)
+                        .WithRememberEntities(shardOptions.RememberEntities)
+                        .WithStateStoreMode(shardOptions.StateStoreMode), extractEntityId, extractShardId);
+
+                registry.Register<TKey>(shardRegion);
             });
         }
 
@@ -210,10 +243,8 @@ namespace Akka.Cluster.Hosting
             {
                 var shardRegionProxy = await ClusterSharding.Get(system)
                     .StartProxyAsync(typeName, roleName, extractEntityId, extractShardId);
-
-                // TODO: should throw here if duplicate key used
-
-                registry.TryRegister<TKey>(shardRegionProxy);
+                
+                registry.Register<TKey>(shardRegionProxy);
             });
         }
 
@@ -237,10 +268,8 @@ namespace Akka.Cluster.Hosting
             {
                 var shardRegionProxy = await ClusterSharding.Get(system)
                     .StartProxyAsync(typeName, roleName, messageExtractor);
-
-                // TODO: should throw here if duplicate key used
-
-                registry.TryRegister<TKey>(shardRegionProxy);
+                
+                registry.Register<TKey>(shardRegionProxy);
             });
         }
 
@@ -267,7 +296,7 @@ namespace Akka.Cluster.Hosting
             {
                 // force the initialization
                 var mediator = DistributedPubSub.Get(system).Mediator;
-                registry.TryRegister<DistributedPubSub>(mediator);
+                registry.Register<DistributedPubSub>(mediator);
             });
         }
 


### PR DESCRIPTION
## Changes

Adds `ActorRegistry`-capable overloads to the `WithShardRegion<TKey>` methods, which are useful in cases where my entity actors need to take a dependency on another actor reference through their constructors.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
