### PR TITLE
added v0.3.4 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,2 @@
-## [0.3.3] / 16 June 2022
-- [Added common `Akka.Persistence.Hosting` package to make it easier to add `IEventAdapter`s to journals](https://github.com/akkadotnet/Akka.Hosting/issues/64).
-- [Made Akka.Persistence.SqlServer.Hosting and Akka.Persistence.PostgreSql.Hosting both take a shared overload / dependency on Akka.Persistence.Hosting](https://github.com/akkadotnet/Akka.Hosting/pull/67) - did this to make it easier to add `IEventAdapter`s to each of those.
-- [Add Akka.Cluster.Tools.Client support](https://github.com/akkadotnet/Akka.Hosting/pull/66) - now possible to start `ClusterClient` and `ClusterClientReceptionist`s easily from Akka.Hosting.
+## [0.3.4] / 23 June 2022
+- [Adds `ActorRegistry`-capable overloads to the `WithShardRegion<TKey>` methods](https://github.com/akkadotnet/Akka.Hosting/pull/70)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,10 +2,8 @@
   <PropertyGroup>
    <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.3.1</VersionPrefix>
-    <PackageReleaseNotes>• [Fixed: WithDistributedPubSub throws NullReferenceException](https://github.com/akkadotnet/Akka.Hosting/issues/55)
-• [Introduced AddHoconFile method](https://github.com/akkadotnet/Akka.Hosting/pull/58)
-• [Upgraded to Akka.NET 1.4.39](https://github.com/akkadotnet/akka.net/releases/tag/1.4.39)</PackageReleaseNotes>
+    <VersionPrefix>0.3.4</VersionPrefix>
+    <PackageReleaseNotes>• [Adds ActorRegistry-capable overloads to the WithShardRegion&lt;TKey&gt; methods](https://github.com/akkadotnet/Akka.Hosting/pull/70)</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
## [0.3.4] / 23 June 2022
- [Adds `ActorRegistry`-capable overloads to the `WithShardRegion<TKey>` methods](https://github.com/akkadotnet/Akka.Hosting/pull/70)