### PR TITLE
Fix ILoggerFactory logger

### DIFF
--- a/src/Akka.Hosting/Logging/AkkaLoggerFactoryExtensions.cs
+++ b/src/Akka.Hosting/Logging/AkkaLoggerFactoryExtensions.cs
@@ -16,12 +16,14 @@ namespace Akka.Hosting.Logging
 {
     public static class AkkaLoggerFactoryExtensions
     {
-        public static AkkaConfigurationBuilder WithLoggerFactory(this AkkaConfigurationBuilder builder)
+        public static AkkaConfigurationBuilder WithLoggerFactory(this AkkaConfigurationBuilder builder, ILoggerFactory loggerFactory)
         {
-            return builder.AddHocon("akka.loggers = [\"Akka.Hosting.Logging.LoggerFactoryLogger, Akka.Hosting\"]");
+            return builder
+                .AddHocon("akka.loggers = [\"Akka.Hosting.Logging.LoggerFactoryLogger, Akka.Hosting\"]")
+                .AddSetup(new LoggerFactorySetup(loggerFactory));
         }
         
-        public static AkkaConfigurationBuilder AddLoggerFactory(this AkkaConfigurationBuilder builder)
+        public static AkkaConfigurationBuilder AddLoggerFactory(this AkkaConfigurationBuilder builder, ILoggerFactory loggerFactory)
         {
             var loggers = builder.Configuration.HasValue
                 ? builder.Configuration.Value.GetStringList("akka.loggers")
@@ -31,7 +33,8 @@ namespace Akka.Hosting.Logging
                 loggers.Add("Akka.Event.DefaultLogger");
             
             loggers.Add("Akka.Hosting.Logging.LoggerFactoryLogger, Akka.Hosting");
-            return builder.AddHocon($"akka.loggers = [{string.Join(", ", loggers.Select(s => $"\"{s}\""))}]");
+            return builder.AddHocon($"akka.loggers = [{string.Join(", ", loggers.Select(s => $"\"{s}\""))}]")
+                .AddSetup(new LoggerFactorySetup(loggerFactory));
         }
         
     }

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Text;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Event;
 using Microsoft.Extensions.Logging;
@@ -30,7 +31,12 @@ namespace Akka.Hosting.Logging
         public LoggerFactoryLogger()
         {
             _messageFormat = string.Format(DefaultMessageFormat, DefaultTimeStampFormat);
-            _loggerFactory = Context.System.Settings.Setup.Get<LoggerFactorySetup>().Value.LoggerFactory;
+            var setup = Context.System.Settings.Setup.Get<LoggerFactorySetup>();
+            if (!setup.HasValue) 
+                throw new ConfigurationException(
+                    $"Could not start {nameof(LoggerFactoryLogger)}, the required setup class " +
+                    $"{nameof(LoggerFactorySetup)} could not be found. Have you added this to the ActorSystem setup?");
+            _loggerFactory = setup.Value.LoggerFactory;
         }
 
         protected override void PostStop()

--- a/src/Akka.Hosting/Logging/LoggerFactorySetup.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactorySetup.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Akka.Hosting.Logging
 {
-    internal class LoggerFactorySetup : Setup
+    public class LoggerFactorySetup : Setup
     {
         public LoggerFactorySetup(ILoggerFactory loggerFactory)
         {

--- a/src/Akka.Hosting/Logging/LoggerFactorySetup.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactorySetup.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="LoggerFactorySetup.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor.Setup;
+using Microsoft.Extensions.Logging;
+
+namespace Akka.Hosting.Logging
+{
+    internal class LoggerFactorySetup : Setup
+    {
+        public LoggerFactorySetup(ILoggerFactory loggerFactory)
+        {
+            LoggerFactory = loggerFactory;
+        }
+
+        public ILoggerFactory LoggerFactory { get; }
+    }
+}

--- a/src/Examples/Akka.Hosting.LoggingDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.LoggingDemo/Program.cs
@@ -13,7 +13,7 @@ builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider
 {
     configurationBuilder
         .AddHocon("akka.loglevel = DEBUG")
-        .WithLoggerFactory()
+        .WithLoggerFactory(serviceProvider.GetRequiredService<ILoggerFactory>())
         .WithRemoting("localhost", 8110)
         .WithClustering(new ClusterOptions(){ Roles = new[]{ "myRole" }, 
             SeedNodes = new[]{ Address.Parse("akka.tcp://MyActorSystem@localhost:8110")}})


### PR DESCRIPTION
Fixes #78

dependency injection might not be initialized when logger actors are being created because how early it is being created during the ActorSystem lifetime. The fix is to pass the ILoggerFactor instance using a Setup class so that it is available as soon as the actor started.

Hosting extension API is changed from `WithLoggerFactory(this AkkaConfigurationBuilder builder)` to `WithLoggerFactory(this AkkaConfigurationBuilder builder, ILoggerFactory loggerFactory)`, ILoggerFactory need to passed in explicitly during setup.

```
builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider) =>
{
    configurationBuilder
        .AddHocon("akka.loglevel = DEBUG")
        .WithLoggerFactory(serviceProvider.GetRequiredService<ILoggerFactory>())
        .WithActors((system, registry) =>
        {
            var echo = system.ActorOf(act =>
            {
                act.ReceiveAny((o, context) =>
                {
                    Logging.GetLogger(context.System, "echo").Info($"Actor received {o}");
                    context.Sender.Tell($"{context.Self} rcv {o}");
                });
            }, "echo");
            registry.TryRegister<Echo>(echo); // register for DI
        });
});
```

__NOTE__
This is the first logger that actually needs both a hocon configuration AND a setup to work correctly when set up manually, this is inevitable to prevent racy conditions. Another solution would be to use a static variable to pass the ILoggerFactory instance to the logger actor, but this is a very bad anti-pattern.