### PR TITLE
fixed hanging ILogger test

### DIFF
--- a/src/Akka.Hosting.Tests/Logging/LoggerFactoryLoggerSpec.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerFactoryLoggerSpec.cs
@@ -41,9 +41,10 @@ public class LoggerFactoryLoggerSpec: IAsyncLifetime
         _echo = registry.Get<EchoActor>();
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
-        await _host.StopAsync();
+        _host.Dispose();
+        return Task.CompletedTask;
     }
 
     [Fact(DisplayName = "LoggerFactoryLogger should log events")]


### PR DESCRIPTION
Needed to call `Dispose` rather than `StopAsync`