### PR TITLE
added `InMemory` snapshot store and journal configuration settings

### DIFF
--- a/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
+++ b/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.39" />
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
+++ b/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="1.4.39" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using Akka.TestKit.Xunit2.Internals;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Hosting.Tests
+{
+    public class InMemoryPersistenceSpecs
+    {
+        
+        private readonly ITestOutputHelper _output;
+
+        public InMemoryPersistenceSpecs(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public sealed class MyPersistenceActor : ReceivePersistentActor
+        {
+            private List<int> _values = new List<int>();
+
+            public MyPersistenceActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+                
+                Recover<SnapshotOffer>(offer =>
+                {
+                    if (offer.Snapshot is IEnumerable<int> ints)
+                    {
+                        _values = new List<int>(ints);
+                    }
+                });
+                
+                Recover<int>(i =>
+                {
+                    _values.Add(i);
+                });
+                
+                Command<int>(i =>
+                {
+                    Persist(i, i1 =>
+                    {
+                        _values.Add(i);
+                        if (LastSequenceNr % 2 == 0)
+                        {
+                            SaveSnapshot(_values);
+                        }
+                        Sender.Tell("ACK");
+                    });
+                });
+
+                Command<string>(str => str.Equals("getall"), s =>
+                {
+                    Sender.Tell(_values.ToArray());
+                });
+                
+                Command<SaveSnapshotSuccess>(s => {});
+            }
+
+            public override string PersistenceId { get; }
+        }
+        
+        public static async Task<IHost> StartHost(Action<IServiceCollection> testSetup)
+        {
+            var host = new HostBuilder()
+                .ConfigureServices(testSetup).Build();
+        
+            await host.StartAsync();
+            return host;
+        }
+
+        [Fact]
+        public async Task Should_Start_ActorSystem_wth_InMemory_Persistence()
+        {
+            // arrange
+            using var host = await StartHost(collection => collection.AddAkka("MySys", builder =>
+            {
+                builder.WithInMemoryJournal().WithInMemorySnapshotStore()
+                    .StartActors((system, registry) =>
+                    {
+                        var myActor = system.ActorOf(Props.Create(() => new MyPersistenceActor("ac1")), "actor1");
+                        registry.Register<MyPersistenceActor>(myActor);
+                    })
+                    .WithActors((system, registry) =>
+                    {
+                        var extSystem = (ExtendedActorSystem)system;
+                        var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(_output)), "log-test");
+                        logger.Tell(new InitializeLogger(system.EventStream));
+                    });;
+            }));
+
+            var actorSystem = host.Services.GetRequiredService<ActorSystem>();
+            var actorRegistry = host.Services.GetRequiredService<ActorRegistry>();
+            var myPersistentActor = actorRegistry.Get<MyPersistenceActor>();
+            
+            // act
+            var resp1 = await myPersistentActor.Ask<string>(1, TimeSpan.FromSeconds(3));
+            var resp2 = await myPersistentActor.Ask<string>(2, TimeSpan.FromSeconds(3));
+            var snapshot = await myPersistentActor.Ask<int[]>("getall", TimeSpan.FromSeconds(3));
+
+            // assert
+            snapshot.Should().BeEquivalentTo(new[] {1, 2});
+
+            // kill + recreate actor with same PersistentId
+            await myPersistentActor.GracefulStop(TimeSpan.FromSeconds(3));
+            var myPersistentActor2 = actorSystem.ActorOf(Props.Create(() => new MyPersistenceActor("ac1")), "actor1a");
+            
+            var snapshot2 = await myPersistentActor2.Ask<int[]>("getall", TimeSpan.FromSeconds(3));
+            snapshot2.Should().BeEquivalentTo(new[] {1, 2});
+            
+            // validate configs
+            var config = actorSystem.Settings.Config;
+            config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.inmem");
+            config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.inmem");
+        }
+    }
+}

--- a/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
+++ b/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
@@ -132,5 +132,44 @@ namespace Akka.Persistence.Hosting
             jBuilder.Build();
             return builder;
         }
+        
+        public static AkkaConfigurationBuilder WithInMemoryJournal(this AkkaConfigurationBuilder builder)
+        {
+            return WithInMemoryJournal(builder, journalBuilder => { });
+        }
+
+        public static AkkaConfigurationBuilder WithInMemoryJournal(this AkkaConfigurationBuilder builder,
+            Action<AkkaPersistenceJournalBuilder> journalBuilder)
+        {
+            builder.WithJournal("inmem", journalBuilder);
+
+            const string liveConfig = @"akka.persistence.journal.plugin = akka.persistence.journal.inmem
+                akka.persistence.journal.inmem {
+                # Class name of the plugin.
+                class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+                # Dispatcher for the plugin actor.
+                plugin-dispatcher = ""akka.actor.default-dispatcher""
+            }";
+
+            builder.AddHocon(liveConfig, HoconAddMode.Prepend);
+            
+            return builder;
+        }
+
+        public static AkkaConfigurationBuilder WithInMemorySnapshotStore(this AkkaConfigurationBuilder builder)
+        {
+            const string liveConfig = @"akka.persistence.snapshot-store.plugin = akka.persistence.snapshot-store.inmem
+            # In-memory snapshot store plugin.
+            akka.persistence.snapshot-store.inmem {
+            # Class name of the plugin.
+            class = ""Akka.Persistence.Snapshot.MemorySnapshotStore, Akka.Persistence""
+            # Dispatcher for the plugin actor.
+            plugin-dispatcher = ""akka.actor.default-dispatcher""
+        }";
+
+            builder.AddHocon(liveConfig, HoconAddMode.Prepend);
+            
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
## Changes

Adds support for in-memory journal and snapshot configuration. Designed so developers can easily turn these on for testing purposes.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).#
* [x] Changes in public API reviewed, if any.
