### PR TITLE
Add StartupTask feature

### DIFF
--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -207,17 +207,31 @@ namespace Akka.Hosting
             return this;
         }
 
-        public AkkaConfigurationBuilder AddStartup(Action<ActorSystem, IActorRegistry> starter)
+        /// <summary>
+        /// Adds a <see cref="StartupTask"/> delegate that will be executed exactly once for application initialization
+        /// once the <see cref="ActorSystem"/> and all actors is started in this process.
+        /// </summary>
+        /// <param name="startupTask">A <see cref="StartupTask"/> delegate that will be run after all actors
+        /// have been instantiated.</param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public AkkaConfigurationBuilder AddStartup(Action<ActorSystem, IActorRegistry> startupTask)
         {
             if (_complete) return this;
-            _startupTasks.Add(ToAsyncStartup(starter));
+            _startupTasks.Add(ToAsyncStartup(startupTask));
             return this;
         }
 
-        public AkkaConfigurationBuilder AddStartup(StartupTask startup)
+        /// <summary>
+        /// Adds a <see cref="StartupTask"/> delegate that will be executed exactly once for application initialization
+        /// once the <see cref="ActorSystem"/> and all actors is started in this process.
+        /// </summary>
+        /// <param name="startupTask">A <see cref="StartupTask"/> delegate that will be run after all actors
+        /// have been instantiated.</param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public AkkaConfigurationBuilder AddStartup(StartupTask startupTask)
         {
             if (_complete) return this;
-            _startupTasks.Add(startup);
+            _startupTasks.Add(startupTask);
             return this;
         }
         

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -145,5 +145,27 @@ namespace Akka.Hosting
             return builder.StartActors(actorStarter);
         }
         
+        /// <summary>
+        /// Adds a <see cref="StartupTask"/> delegate that will be executed exactly once for application initialization
+        /// once the <see cref="ActorSystem"/> and all actors is started in this process.
+        /// </summary>
+        /// <param name="builder">The builder instance being configured.</param>
+        /// <param name="startupTask">A <see cref="StartupTask"/> delegate that will be run after all actors
+        /// have been instantiated.</param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public static AkkaConfigurationBuilder WithStartup(this AkkaConfigurationBuilder builder, Action<ActorSystem, IActorRegistry> startupTask)
+            => builder.AddStartup(startupTask);
+
+        /// <summary>
+        /// Adds a <see cref="StartupTask"/> delegate that will be executed exactly once for application initialization
+        /// once the <see cref="ActorSystem"/> and all actors is started in this process.
+        /// </summary>
+        /// <param name="builder">The builder instance being configured.</param>
+        /// <param name="startupTask">A <see cref="StartupTask"/> delegate that will be run after all actors
+        /// have been instantiated.</param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public static AkkaConfigurationBuilder WithStartup(this AkkaConfigurationBuilder builder, StartupTask startupTask)
+            => builder.AddStartup(startupTask);
+        
     }
 }

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -147,28 +147,6 @@ namespace Akka.Hosting
         }
         
         /// <summary>
-        /// Adds a <see cref="StartupTask"/> delegate that will be executed exactly once for application initialization
-        /// once the <see cref="ActorSystem"/> and all actors is started in this process.
-        /// </summary>
-        /// <param name="builder">The builder instance being configured.</param>
-        /// <param name="startupTask">A <see cref="StartupTask"/> delegate that will be run after all actors
-        /// have been instantiated.</param>
-        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
-        public static AkkaConfigurationBuilder WithStartup(this AkkaConfigurationBuilder builder, Action<ActorSystem, IActorRegistry> startupTask)
-            => builder.AddStartup(startupTask);
-
-        /// <summary>
-        /// Adds a <see cref="StartupTask"/> delegate that will be executed exactly once for application initialization
-        /// once the <see cref="ActorSystem"/> and all actors is started in this process.
-        /// </summary>
-        /// <param name="builder">The builder instance being configured.</param>
-        /// <param name="startupTask">A <see cref="StartupTask"/> delegate that will be run after all actors
-        /// have been instantiated.</param>
-        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
-        public static AkkaConfigurationBuilder WithStartup(this AkkaConfigurationBuilder builder, StartupTask startupTask)
-            => builder.AddStartup(startupTask);
-        
-        /// <summary>
         /// Adds a list of Akka.NET extensions that will be started automatically when the <see cref="ActorSystem"/>
         /// starts up.
         /// </summary>


### PR DESCRIPTION
## Changes

Adds `AddStartup` using `StartupTask` delegate to the configuration builder. 
This feature is useful when a user need to run a specific initialization code if anf only if the `ActorSystem` and all of the actors have been started. Although it is semantically the same as `AddActors` and `WithActors`, it disambiguate the use-case with a guarantee that it will only be executed after everything is ready.

For example, this feature is useful for: 
- kicking off actor initializations by using `Tell()`s once all of the actor infrastructure are in place, or
- pre-populating certain persistence data after everything is set up and running, useful for unit testing.