### PR TITLE
Add split brain resolver configuration support to Akka.Cluster.Hosting

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/Lease/TestLease.cs
+++ b/src/Akka.Cluster.Hosting.Tests/Lease/TestLease.cs
@@ -1,0 +1,157 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestLease.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Coordination;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Akka.Util;
+
+namespace Akka.Cluster.Hosting.Tests.Lease
+{
+    public class TestLeaseExtExtensionProvider : ExtensionIdProvider<TestLeaseExt>
+    {
+        public override TestLeaseExt CreateExtension(ExtendedActorSystem system)
+        {
+            var extension = new TestLeaseExt(system);
+            return extension;
+        }
+    }
+
+    public class TestLeaseExt : IExtension
+    {
+        public static TestLeaseExt Get(ActorSystem system)
+        {
+            return system.WithExtension<TestLeaseExt, TestLeaseExtExtensionProvider>();
+        }
+
+        private readonly ExtendedActorSystem _system;
+        private readonly ConcurrentDictionary<string, TestLease> _testLeases = new ConcurrentDictionary<string, TestLease>();
+
+        public TestLeaseExt(ExtendedActorSystem system)
+        {
+            _system = system;
+            _system.Settings.InjectTopLevelFallback(LeaseProvider.DefaultConfig());
+        }
+
+        public TestLease GetTestLease(string name)
+        {
+            if (!_testLeases.TryGetValue(name, out var lease))
+            {
+                throw new InvalidOperationException($"Test lease {name} has not been set yet. Current leases {string.Join(",", _testLeases.Keys)}");
+            }
+            return lease;
+        }
+
+        public void SetTestLease(string name, TestLease lease)
+        {
+            _testLeases[name] = lease;
+        }
+    }
+
+    public class TestLease : Coordination.Lease
+    {
+        public sealed class AcquireReq : IEquatable<AcquireReq>
+        {
+            public string Owner { get; }
+
+            public AcquireReq(string owner)
+            {
+                Owner = owner;
+            }
+
+            public bool Equals(AcquireReq other)
+            {
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(this, other)) return true;
+
+                return Equals(Owner, other.Owner);
+            }
+
+            public override bool Equals(object obj) => obj is AcquireReq a && Equals(a);
+
+            public override int GetHashCode() => Owner.GetHashCode();
+
+            public override string ToString() => $"AcquireReq({Owner})";
+        }
+
+        public sealed class ReleaseReq : IEquatable<ReleaseReq>
+        {
+            public string Owner { get; }
+
+            public ReleaseReq(string owner)
+            {
+                Owner = owner;
+            }
+
+            public bool Equals(ReleaseReq other)
+            {
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(this, other)) return true;
+
+                return Equals(Owner, other.Owner);
+            }
+
+            public override bool Equals(object obj) => obj is ReleaseReq r && Equals(r);
+
+            public override int GetHashCode() => Owner.GetHashCode();
+
+            public override string ToString() => $"ReleaseReq({Owner})";
+        }
+
+        public static Config Configuration => ConfigurationFactory.ParseString(
+            $"test-lease.lease-class = \"{typeof(TestLease).AssemblyQualifiedName}\"");
+
+        private readonly AtomicReference<Task<bool>> _nextAcquireResult;
+        private readonly AtomicBoolean _nextCheckLeaseResult = new();
+        private readonly AtomicReference<Action<Exception>> _currentCallBack = new(_ => { });
+        private readonly ILoggingAdapter _log;
+        private TaskCompletionSource<bool> InitialPromise { get; } = new();
+
+        public TestLease(LeaseSettings settings, ExtendedActorSystem system)
+            : base(settings)
+        {
+            _log = Logging.GetLogger(system, "TestLease");
+            _log.Info("Creating lease {0}", settings);
+
+            _nextAcquireResult = new AtomicReference<Task<bool>>(InitialPromise.Task);
+
+            TestLeaseExt.Get(system).SetTestLease(settings.LeaseName, this);
+        }
+
+        public void SetNextAcquireResult(Task<bool> next) => _nextAcquireResult.GetAndSet(next);
+
+        public void SetNextCheckLeaseResult(bool value) => _nextCheckLeaseResult.GetAndSet(value);
+
+        public Action<Exception> GetCurrentCallback() => _currentCallBack.Value;
+
+
+        public override Task<bool> Acquire()
+        {
+            _log.Info("acquire, current response " + _nextAcquireResult);
+            return _nextAcquireResult.Value;
+        }
+
+        public override Task<bool> Release()
+        {
+            return Task.FromResult(true);
+        }
+
+        public override bool CheckLease() => _nextCheckLeaseResult.Value;
+
+        public override Task<bool> Acquire(Action<Exception> leaseLostCallback)
+        {
+            _currentCallBack.GetAndSet(leaseLostCallback);
+            return Acquire();
+        }
+    }
+}

--- a/src/Akka.Cluster.Hosting.Tests/Lease/TestLeaseActor.cs
+++ b/src/Akka.Cluster.Hosting.Tests/Lease/TestLeaseActor.cs
@@ -1,0 +1,253 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestLease.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Coordination;
+using Akka.Event;
+using Akka.Util;
+
+namespace Akka.Cluster.Hosting.Tests.Lease
+{
+    public class TestLeaseActor : ActorBase
+    {
+        public interface ILeaseRequest
+        {
+        }
+
+        public sealed class Acquire : ILeaseRequest, IEquatable<Acquire>
+        {
+            public string Owner { get; }
+
+            public Acquire(string owner)
+            {
+                Owner = owner;
+            }
+
+            public bool Equals(Acquire other)
+            {
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(this, other)) return true;
+
+                return Equals(Owner, other.Owner);
+            }
+
+            public override bool Equals(object obj) => obj is Acquire a && Equals(a);
+
+            public override int GetHashCode() => Owner.GetHashCode();
+
+            public override string ToString() => $"Acquire({Owner})";
+        }
+
+        public sealed class Release : ILeaseRequest, IEquatable<Release>
+        {
+            public string Owner { get; }
+
+            public Release(string owner)
+            {
+                Owner = owner;
+            }
+
+            public bool Equals(Release other)
+            {
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(this, other)) return true;
+
+                return Equals(Owner, other.Owner);
+            }
+
+            public override bool Equals(object obj) => obj is Release r && Equals(r);
+
+            public override int GetHashCode() => Owner.GetHashCode();
+
+            public override string ToString() => $"Release({Owner})";
+        }
+
+        public sealed class Create : ILeaseRequest, IEquatable<Create>
+        {
+            public string LeaseName { get; }
+            public string OwnerName { get; }
+
+            public Create(string leaseName, string ownerName)
+            {
+                LeaseName = leaseName;
+                OwnerName = ownerName;
+            }
+
+            public bool Equals(Create other)
+            {
+                if (ReferenceEquals(other, null)) return false;
+                if (ReferenceEquals(this, other)) return true;
+
+                return Equals(LeaseName, other.LeaseName) && Equals(OwnerName, other.OwnerName);
+            }
+
+            public override bool Equals(object obj) => obj is Create c && Equals(c);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = LeaseName.GetHashCode();
+                    hashCode = (hashCode * 397) ^ OwnerName.GetHashCode();
+                    return hashCode;
+                }
+            }
+
+            public override string ToString() => $"Create({LeaseName}, {OwnerName})";
+        }
+
+        public sealed class GetRequests
+        {
+            public static readonly GetRequests Instance = new GetRequests();
+            private GetRequests()
+            {
+            }
+        }
+
+        public sealed class LeaseRequests
+        {
+            public List<ILeaseRequest> Requests { get; }
+
+            public LeaseRequests(List<ILeaseRequest> requests)
+            {
+                Requests = requests;
+            }
+
+            public override string ToString() => $"LeaseRequests({string.Join(", ", Requests.Select(i => i.ToString()))})";
+        }
+
+
+        public sealed class ActionRequest // boolean of Failure
+        {
+            public ILeaseRequest Request { get; }
+            public bool Result { get; }
+
+            public ActionRequest(ILeaseRequest request, bool result)
+            {
+                Request = request;
+                Result = result;
+            }
+
+            public override string ToString() => $"ActionRequest({Request}, {Result})";
+        }
+
+        public static Props Props => Props.Create(() => new TestLeaseActor());
+
+        private ILoggingAdapter _log = Context.GetLogger();
+        private readonly List<(IActorRef, ILeaseRequest)> _requests = new List<(IActorRef, ILeaseRequest)>();
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case Create c:
+                    _log.Info("Lease created with name {0} ownerName {1}", c.LeaseName, c.OwnerName);
+                    return true;
+
+                case ILeaseRequest request:
+                    _log.Info("Lease request {0} from {1}", request, Sender);
+                    _requests.Insert(0, (Sender, request));
+                    return true;
+
+                case GetRequests _:
+                    Sender.Tell(new LeaseRequests(_requests.Select(i => i.Item2).ToList()));
+                    return true;
+
+                case ActionRequest ar:
+                    var r = _requests.FirstOrDefault(i => i.Item2.Equals(ar.Request));
+                    if (r.Item1 != null)
+                    {
+                        _log.Info("Actioning request {0} to {1}", r.Item2, ar.Result);
+                        r.Item1.Tell(ar.Result);
+                        _requests.RemoveAll(i => i.Item2.Equals(ar.Request));
+                    }
+                    else
+                        throw new InvalidOperationException($"unknown request to action: {ar.Request}. Requests: { string.Join(", ", _requests.Select(i => $"([{i.Item1}],[{i.Item2}])"))}");
+                    return true;
+            }
+            return false;
+        }
+    }
+
+
+
+    public class TestLeaseActorClientExtExtensionProvider : ExtensionIdProvider<TestLeaseActorClientExt>
+    {
+        public override TestLeaseActorClientExt CreateExtension(ExtendedActorSystem system)
+        {
+            var extension = new TestLeaseActorClientExt(system);
+            return extension;
+        }
+    }
+
+    public class TestLeaseActorClientExt : IExtension
+    {
+        public static TestLeaseActorClientExt Get(ActorSystem system)
+        {
+            return system.WithExtension<TestLeaseActorClientExt, TestLeaseActorClientExtExtensionProvider>();
+        }
+
+        private readonly ExtendedActorSystem _system;
+        private AtomicReference<IActorRef> leaseActor = new AtomicReference<IActorRef>();
+
+        public TestLeaseActorClientExt(ExtendedActorSystem system)
+        {
+            _system = system;
+        }
+
+        public IActorRef GetLeaseActor()
+        {
+            var lease = leaseActor.Value;
+            if (lease == null)
+                throw new InvalidOperationException("LeaseActorRef must be set first");
+            return lease;
+        }
+
+        public void SetActorLease(IActorRef client)
+        {
+            leaseActor.GetAndSet(client);
+        }
+    }
+
+    public class TestLeaseActorClient : Coordination.Lease
+    {
+        private ILoggingAdapter _log;
+
+        private IActorRef leaseActor;
+
+        public TestLeaseActorClient(LeaseSettings settings, ExtendedActorSystem system)
+            : base(settings)
+        {
+            _log = Logging.GetLogger(system, "TestLeaseActorClient");
+
+            leaseActor = TestLeaseActorClientExt.Get(system).GetLeaseActor();
+            _log.Info("lease created {0}", settings);
+            leaseActor.Tell(new TestLeaseActor.Create(settings.LeaseName, settings.OwnerName));
+        }
+
+        public override Task<bool> Acquire()
+        {
+            return leaseActor.Ask(new TestLeaseActor.Acquire(Settings.OwnerName)).ContinueWith(r => (bool)r.Result);
+        }
+
+        public override Task<bool> Release()
+        {
+            return leaseActor.Ask(new TestLeaseActor.Release(Settings.OwnerName)).ContinueWith(r => (bool)r.Result);
+        }
+
+        public override bool CheckLease() => false;
+
+        public override Task<bool> Acquire(Action<Exception> leaseLostCallback)
+        {
+            return leaseActor.Ask(new TestLeaseActor.Acquire(Settings.OwnerName)).ContinueWith(r => (bool)r.Result);
+        }
+    }
+}

--- a/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
@@ -1,0 +1,178 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SplitBrainResolverSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Hosting.SBR;
+using Akka.Cluster.Hosting.Tests.Lease;
+using Akka.Cluster.SBR;
+using Akka.Hosting;
+using Akka.Remote.Hosting;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Akka.Cluster.Hosting.Tests;
+
+public class SplitBrainResolverSpecs
+{
+    private readonly ITestOutputHelper _output;
+    
+    public SplitBrainResolverSpecs(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private async Task<IHost> StartHost(Action<AkkaConfigurationBuilder> specBuilder)
+    {
+        var tcs = new TaskCompletionSource();
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        
+        var host = new HostBuilder()
+            .ConfigureLogging(logger =>
+            {
+                logger.ClearProviders();
+                logger.AddProvider(new XUnitLoggerProvider(_output, LogLevel.Information));
+            })
+            .ConfigureServices(collection =>
+            {
+                collection.AddAkka("TestSys", (configurationBuilder, provider) =>
+                {
+                    configurationBuilder
+                        .ConfigureLoggers(logger =>
+                        {
+                            logger.ClearLoggers();
+                            logger.AddLoggerFactory();
+                        })
+                        .WithRemoting("localhost", 0)
+                        .AddStartup((system, registry) =>
+                        {
+                            var cluster = Cluster.Get(system);
+                            cluster.RegisterOnMemberUp(() =>
+                            {
+                                tcs.SetResult();
+                            });
+                            cluster.Join(cluster.SelfAddress);
+                        });
+                    specBuilder(configurationBuilder);
+                });
+            }).Build();
+
+        await host.StartAsync(cancellationTokenSource.Token);
+        await tcs.Task.WaitAsync(cancellationTokenSource.Token);
+
+        return host;
+    }
+    
+    [Fact(DisplayName = "Default SBR set from Akka.Hosting should load")]
+    public async Task HostingSbrTest()
+    {
+        var host = await StartHost(builder =>
+        {
+            builder.WithClustering(sbrOptions: SplitBrainResolverOption.Default);
+        });
+
+        var system = host.Services.GetRequiredService<ActorSystem>();
+        
+        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        var settings = new SplitBrainResolverSettings(system.Settings.Config);
+        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.KeepMajorityName);
+        settings.KeepMajorityRole.Should().BeNull();
+    }
+    
+    [Fact(DisplayName = "Static quorum SBR set from Akka.Hosting should load")]
+    public async Task StaticQuorumTest()
+    {
+        var host = await StartHost(builder =>
+        {
+            builder.WithClustering(sbrOptions: new StaticQuorumOption
+            {
+                QuorumSize = 1,
+                Role = "myRole"
+            });
+        });
+
+        var system = host.Services.GetRequiredService<ActorSystem>();
+        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        
+        var settings = new SplitBrainResolverSettings(system.Settings.Config);
+        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.StaticQuorumName);
+        settings.StaticQuorumSettings.Size.Should().Be(1);
+        settings.StaticQuorumSettings.Role.Should().Be("myRole");
+    }
+    
+    [Fact(DisplayName = "Keep majority SBR set from Akka.Hosting should load")]
+    public async Task KeepMajorityTest()
+    {
+        var host = await StartHost(builder =>
+        {
+            builder.WithClustering(sbrOptions: new KeepMajorityOption
+            {
+                Role = "myRole"
+            });
+        });
+
+        var system = host.Services.GetRequiredService<ActorSystem>();
+        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        
+        var settings = new SplitBrainResolverSettings(system.Settings.Config);
+        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.KeepMajorityName);
+        settings.KeepMajorityRole.Should().Be("myRole");
+    }
+    
+    [Fact(DisplayName = "Keep oldest SBR set from Akka.Hosting should load")]
+    public async Task KeepOldestTest()
+    {
+        var host = await StartHost(builder =>
+        {
+            builder.WithClustering(sbrOptions: new KeepOldestOption
+            {
+                DownIfAlone = false,
+                Role = "myRole"
+            });
+        });
+
+        var system = host.Services.GetRequiredService<ActorSystem>();
+        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        
+        var settings = new SplitBrainResolverSettings(system.Settings.Config);
+        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.KeepOldestName);
+        settings.KeepOldestSettings.DownIfAlone.Should().BeFalse();
+        settings.KeepOldestSettings.Role.Should().Be("myRole");
+    }
+    
+    [Fact(DisplayName = "Lease Majority SBR set from Akka.Hosting should load")]
+    public async Task LeaseMajorityTest()
+    {
+        var host = await StartHost(builder =>
+        {
+            builder.AddHocon(TestLease.Configuration, HoconAddMode.Prepend);
+            builder.WithClustering(sbrOptions: new LeaseMajorityOption
+            {
+                LeaseImplementation = "test-lease",
+                LeaseName = "myService-akka-sbr",
+                Role = "myRole"
+            });
+        });
+
+        var system = host.Services.GetRequiredService<ActorSystem>();
+        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        
+        var settings = new SplitBrainResolverSettings(system.Settings.Config);
+        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.LeaseMajorityName);
+        settings.LeaseMajoritySettings.LeaseImplementation.Should().Be("test-lease");
+        settings.LeaseMajoritySettings.LeaseName.Should().Be("myService-akka-sbr");
+        settings.LeaseMajoritySettings.Role.Should().Be("myRole");
+    }
+    
+}

--- a/src/Akka.Cluster.Hosting/SBR/SplitBrainResolverOption.cs
+++ b/src/Akka.Cluster.Hosting/SBR/SplitBrainResolverOption.cs
@@ -5,6 +5,7 @@
 // -----------------------------------------------------------------------
 
 using System;
+using Akka.Annotations;
 using Akka.Coordination;
 
 namespace Akka.Cluster.Hosting.SBR
@@ -86,7 +87,7 @@ namespace Akka.Cluster.Hosting.SBR
         /// <summary>
         /// A class type that extends the abstract class <see cref="Lease"/>
         /// </summary>
-        public Type LeaseImplementation { get; set; }
+        public string LeaseImplementation { get; set; }
         
         /// <summary>
         /// <para>The name of the lease.</para>

--- a/src/Akka.Cluster.Hosting/SBR/SplitBrainResolverOption.cs
+++ b/src/Akka.Cluster.Hosting/SBR/SplitBrainResolverOption.cs
@@ -1,0 +1,99 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SplitBrainResolverOption.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Coordination;
+
+namespace Akka.Cluster.Hosting.SBR
+{
+    public abstract class SplitBrainResolverOption
+    {
+        public static readonly SplitBrainResolverOption Default = new KeepMajorityOption();
+        
+        /// <summary>
+        /// if the <see cref="Role"/> is defined the decision is based only on members with that <see cref="Role"/>
+        /// </summary>
+        public string Role { get; set; }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Down the unreachable nodes if the number of remaining nodes are greater than or equal to the given
+    /// <see cref="QuorumSize"/>. Otherwise down the reachable nodes, i.e. it will shut down that side of the partition.
+    /// In other words, the <see cref="QuorumSize"/> defines the minimum number of nodes that the cluster must have
+    /// to be operational. If there are unreachable nodes when starting up the cluster, before reaching this limit,
+    /// the cluster may shutdown itself immediately. This is not an issue if you start all nodes at approximately
+    /// the same time.
+    /// </para>
+    /// <para>
+    /// Note that you must not add more members to the cluster than '<see cref="QuorumSize"/> * 2 - 1', because then
+    /// both sides may down each other and thereby form two separate clusters. For example, <see cref="QuorumSize"/>
+    /// configured to 3 in a 6 node cluster may result in a split where each side consists of 3 nodes each,
+    /// i.e. each side thinks it has enough nodes to continue by itself. A warning is logged if this recommendation is violated.
+    /// </para>
+    /// </summary>
+    public sealed class StaticQuorumOption : SplitBrainResolverOption
+    {
+        /// <summary>
+        /// Minimum number of nodes that the cluster must have
+        /// </summary>
+        public int QuorumSize { get; set; } = 0;
+    }
+
+    /// <summary>
+    /// Down the unreachable nodes if the current node is in the majority part based the last known membership
+    /// information. Otherwise down the reachable nodes, i.e. the own part. If the the parts are of equal size the part
+    /// containing the node with the lowest address is kept.
+    /// Note that if there are more than two partitions and none is in majority each part will shutdown itself,
+    /// terminating the whole cluster.
+    /// </summary>
+    public sealed class KeepMajorityOption : SplitBrainResolverOption
+    {
+    }
+
+    /// <summary>
+    /// <para>
+    /// Down the part that does not contain the oldest member (current singleton).
+    /// </para>
+    /// When <see cref="DownIfAlone"/> is <c>true</c>:
+    /// <list type="bullet">
+    ///   <item>If the oldest node crashes the others will remove it from the cluster.</item>
+    ///   <item>If oldest node is partitioned from all other nodes, the oldest will down itself and keep all other nodes running.</item>
+    ///   <item>The strategy will not down the single oldest node when it is the only remaining node in the cluster.</item>
+    /// </list>
+    /// When <see cref="DownIfAlone"/> is <c>false</c> and the oldest node crashes, all other nodes will down themselves,
+    /// i.e. shutdown the whole cluster together with the oldest node.
+    /// </summary>
+    public sealed class KeepOldestOption : SplitBrainResolverOption
+    {
+        /// <summary>
+        /// Enable downing of the oldest node when it is partitioned from all other nodes
+        /// </summary>
+        public bool DownIfAlone { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Keep the part that can acquire the lease, and down the other part.
+    /// Best effort is to keep the side that has most nodes, i.e. the majority side.
+    /// This is achieved by adding a delay before trying to acquire the lease on the
+    /// minority side.
+    /// </summary>
+    public sealed class LeaseMajorityOption : SplitBrainResolverOption
+    {
+        /// <summary>
+        /// A class type that extends the abstract class <see cref="Lease"/>
+        /// </summary>
+        public Type LeaseImplementation { get; set; }
+        
+        /// <summary>
+        /// <para>The name of the lease.</para>
+        /// 
+        /// The recommended format for the lease name is "{service-name}-akka-sbr".
+        /// When lease-name is not defined, the name will be set to "{actor-system-name}-akka-sbr"
+        /// </summary>
+        public string LeaseName { get; set; }
+    }
+}


### PR DESCRIPTION
Adds additional optional parameter to `WithClustering()` to also set up a split brain resolver for the cluster.