### PR TITLE
Spec Proposal to standardize HOCON path based configuration pattern

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/Lease/TestLease.cs
+++ b/src/Akka.Cluster.Hosting.Tests/Lease/TestLease.cs
@@ -9,11 +9,12 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Cluster.Hosting.SBR;
 using Akka.Configuration;
 using Akka.Coordination;
 using Akka.Event;
-using Akka.TestKit;
-using Akka.TestKit.Xunit2;
+using Akka.Hosting;
 using Akka.Util;
 
 namespace Akka.Cluster.Hosting.Tests.Lease
@@ -58,6 +59,16 @@ namespace Akka.Cluster.Hosting.Tests.Lease
         }
     }
 
+    public sealed class TestLeaseOption : LeaseOptionBase
+    {
+        public override string ConfigPath => "test-lease";
+        public override Type Class => typeof(TestLease);
+        public override void Apply(AkkaConfigurationBuilder builder, Setup setup = null)
+        {
+            // no-op
+        }
+    }
+    
     public class TestLease : Coordination.Lease
     {
         public sealed class AcquireReq : IEquatable<AcquireReq>

--- a/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
@@ -159,7 +159,7 @@ public class SplitBrainResolverSpecs
             builder.AddHocon(TestLease.Configuration, HoconAddMode.Prepend);
             builder.WithClustering(sbrOptions: new LeaseMajorityOption
             {
-                LeaseImplementation = "test-lease",
+                LeaseImplementation = new TestLeaseOption(),
                 LeaseName = "myService-akka-sbr",
                 Role = "myRole"
             });

--- a/src/Akka.Cluster.Hosting/SBR/SplitBrainResolverOption.cs
+++ b/src/Akka.Cluster.Hosting/SBR/SplitBrainResolverOption.cs
@@ -12,7 +12,7 @@ using Akka.Hosting;
 
 namespace Akka.Cluster.Hosting.SBR
 {
-    public abstract class SplitBrainResolverOption: IOption
+    public abstract class SplitBrainResolverOption: IHoconOption
     {
         public static readonly SplitBrainResolverOption Default = new KeepMajorityOption();
         
@@ -154,7 +154,7 @@ namespace Akka.Cluster.Hosting.SBR
         }
     }
 
-    public abstract class LeaseOptionBase : IOption
+    public abstract class LeaseOptionBase : IHoconOption
     {
         public abstract string ConfigPath { get; }
         public abstract Type Class { get; }

--- a/src/Akka.Hosting/IHoconOption.cs
+++ b/src/Akka.Hosting/IHoconOption.cs
@@ -60,7 +60,7 @@ namespace Akka.Hosting
     ///     }
     /// </code>
     /// </example>
-    public interface IOption
+    public interface IHoconOption
     {
         /// <summary>
         ///     The HOCON value of the HOCON path property

--- a/src/Akka.Hosting/IOption.cs
+++ b/src/Akka.Hosting/IOption.cs
@@ -62,31 +62,28 @@ namespace Akka.Hosting
     /// </example>
     public interface IOption
     {
-        public interface IOption
-        {
-            /// <summary>
-            ///     The HOCON value of the HOCON path property
-            /// </summary>
-            string ConfigPath { get; }
+        /// <summary>
+        ///     The HOCON value of the HOCON path property
+        /// </summary>
+        string ConfigPath { get; }
             
-            /// <summary>
-            ///     The class <see cref="Type"/> that will be used for the HOCON class FQCN value 
-            /// </summary>
-            Type Class { get; }
+        /// <summary>
+        ///     The class <see cref="Type"/> that will be used for the HOCON class FQCN value 
+        /// </summary>
+        Type Class { get; }
             
-            /// <summary>
-            ///     Apply this option to the <paramref name="builder"/>
-            /// </summary>
-            /// <param name="builder">
-            ///     The <see cref="AkkaConfigurationBuilder"/> to be applied to
-            /// </param>
-            /// <param name="setup">
-            ///     The <see cref="Setup"/> to be applied to, if needed.
-            /// </param>
-            /// <exception cref="ArgumentNullException">
-            ///     Thrown when <see cref="Apply"/> requires a setup but it was <c>null</c>
-            /// </exception>
-            void Apply(AkkaConfigurationBuilder builder, Setup setup = null);
-        }
+        /// <summary>
+        ///     Apply this option to the <paramref name="builder"/>
+        /// </summary>
+        /// <param name="builder">
+        ///     The <see cref="AkkaConfigurationBuilder"/> to be applied to
+        /// </param>
+        /// <param name="setup">
+        ///     The <see cref="Setup"/> to be applied to, if needed.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when <see cref="Apply"/> requires a setup but it was <c>null</c>
+        /// </exception>
+        void Apply(AkkaConfigurationBuilder builder, Setup setup = null);
     }
 }

--- a/src/Akka.Hosting/IOption.cs
+++ b/src/Akka.Hosting/IOption.cs
@@ -1,0 +1,92 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="IOption.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor.Setup;
+
+namespace Akka.Hosting
+{
+    /// <summary>
+    /// <para>
+    ///     Standardized interface template for a common HOCON configuration pattern where a configuration takes
+    ///     a HOCON config path and the config path contains a class FQCN property and other settings that
+    ///     are needed by said class.
+    /// </para>
+    /// <para>
+    ///     The pattern looks like this:
+    /// <code>
+    ///     # This HOCON property references to a config block below
+    ///     akka.discovery.method = akka.discovery.config
+    /// 
+    ///     akka.discovery.config {
+    ///         class = "Akka.Discovery.Config.ConfigServiceDiscovery, Akka.Discovery"
+    ///         # other options goes here
+    ///     }
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// Example implementation for the pattern described in the summary
+    /// <code>
+    ///     // The base class for the option
+    ///     public abstract class DiscoveryOptionBase : IOption
+    ///     { }
+    ///
+    ///     // The actual option implementation
+    ///     public class ConfigOption : DiscoveryOptionBase
+    ///     {
+    ///         // Actual option implementation here
+    ///         public void Apply(AkkaConfigurationBuilder builder)
+    ///         {
+    ///             // Modifies Akka.NET configuration either via HOCON or setup class
+    ///             builder.AddHocon($"akka.discovery.method = {ConfigPath}", HoconAddMode.Prepend);
+    ///
+    ///             // Rest of configuration goes here
+    ///         }
+    ///     }
+    ///
+    ///     // Akka.Hosting extension implementation
+    ///     public static AkkaConfigurationBuilder WithDiscovery(
+    ///         this AkkaConfigurationBuilder builder,
+    ///         DiscoveryOptionBase discOption)
+    ///     {
+    ///         var setup = new DiscoverySetup();
+    /// 
+    ///         // gets called here
+    ///         discOption.Apply(builder, setup);
+    ///     }
+    /// </code>
+    /// </example>
+    public interface IOption
+    {
+        public interface IOption
+        {
+            /// <summary>
+            ///     The HOCON value of the HOCON path property
+            /// </summary>
+            string ConfigPath { get; }
+            
+            /// <summary>
+            ///     The class <see cref="Type"/> that will be used for the HOCON class FQCN value 
+            /// </summary>
+            Type Class { get; }
+            
+            /// <summary>
+            ///     Apply this option to the <paramref name="builder"/>
+            /// </summary>
+            /// <param name="builder">
+            ///     The <see cref="AkkaConfigurationBuilder"/> to be applied to
+            /// </param>
+            /// <param name="setup">
+            ///     The <see cref="Setup"/> to be applied to, if needed.
+            /// </param>
+            /// <exception cref="ArgumentNullException">
+            ///     Thrown when <see cref="Apply"/> requires a setup but it was <c>null</c>
+            /// </exception>
+            void Apply(AkkaConfigurationBuilder builder, Setup setup = null);
+        }
+    }
+}


### PR DESCRIPTION
This will be used to standardize how Akka.Hosting addresses a very common HOCON configuration pattern.
This allows for a HOCON-less programmatical setup replacement for the HOCON path used to configure the HOCON property. 

The pattern:
```text
# This HOCON property references to a config block below
akka.discovery.method = akka.discovery.config

akka.discovery.config {
    class = "Akka.Discovery.Config.ConfigServiceDiscovery, Akka.Discovery"
    # other options goes here
}
```

Example implementation:
```csharp
// The base class for the option
public abstract class DiscoveryOptionBase : IOption
{ }

// The actual option implementation
public class ConfigOption : DiscoveryOptionBase
{
    // Actual option implementation here
    public Type Class => typeof(ConfigServiceDiscovery);

    public string ConfigPath => "akka.discovery.config";

    public void Apply(AkkaConfigurationBuilder builder, Setup setup = null)
    {
        // Modifies Akka.NET configuration either via HOCON or setup class
        builder.AddHocon($"akka.discovery.method = {ConfigPath}", HoconAddMode.Prepend);

        // Rest of configuration goes here
    }
}

 // Akka.Hosting extension implementation
 public static AkkaConfigurationBuilder WithDiscovery(
     this AkkaConfigurationBuilder builder,
     DiscoveryOptionBase discOption)
 {
     var setup = new DiscoverySetup();

     // gets called here
     discOption.Apply(builder, setup);
 }        
```