### PR TITLE
[Breaking Change] remove default `HoconAddMode` from HOCON builders

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
@@ -86,7 +86,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
                     .AddAkka("TestSys", (configurationBuilder, _) =>
                     {
                         configurationBuilder
-                            .AddHocon(TestKit.Xunit2.TestKit.DefaultConfig)
+                            .AddHocon(TestKit.Xunit2.TestKit.DefaultConfig, HoconAddMode.Append)
                             .WithRemoting("localhost", 0)
                             .WithClustering(_clusterOptions)
                             .WithActors((system, _) =>

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -90,7 +90,7 @@ namespace Akka.Cluster.Hosting
             return builder.AddHocon(ClusterSharding.DefaultConfig()
                 .WithFallback(ClusterSingletonManager.DefaultConfig())
                 .WithFallback(DistributedPubSub.DefaultConfig())
-                .WithFallback(ClusterClientReceptionist.DefaultConfig()));
+                .WithFallback(ClusterClientReceptionist.DefaultConfig()), HoconAddMode.Append);
         }
 
         /// <summary>
@@ -305,7 +305,7 @@ namespace Akka.Cluster.Hosting
         public static AkkaConfigurationBuilder WithDistributedPubSub(this AkkaConfigurationBuilder builder,
             string role)
         {
-            var middle = builder.AddHocon(DistributedPubSub.DefaultConfig());
+            var middle = builder.AddHocon(DistributedPubSub.DefaultConfig(), HoconAddMode.Append);
             if (!string.IsNullOrEmpty(role)) // add role config
             {
                 middle = middle.AddHocon($"akka.cluster.pub-sub.role = \"{role}\"", HoconAddMode.Prepend);

--- a/src/Akka.Hosting.Tests/ExtensionsSpecs.cs
+++ b/src/Akka.Hosting.Tests/ExtensionsSpecs.cs
@@ -51,7 +51,7 @@ public class ExtensionsSpecs
     {
         using var host = await StartHost((builder, _) =>
         {
-            builder.AddHocon("akka.extensions = [\"Akka.Hosting.Tests.ExtensionsSpecs+FakeExtensionOneProvider, Akka.Hosting.Tests\"]");
+            builder.AddHocon("akka.extensions = [\"Akka.Hosting.Tests.ExtensionsSpecs+FakeExtensionOneProvider, Akka.Hosting.Tests\"]", HoconAddMode.Append);
             builder.WithExtensions(typeof(FakeExtensionTwoProvider));
         });
 
@@ -89,7 +89,7 @@ public class ExtensionsSpecs
     {
         using var host = await StartHost((builder, _) =>
         {
-            builder.AddHocon("akka.extensions = [\"Akka.Hosting.Tests.ExtensionsSpecs+FakeExtensionOneProvider, Akka.Hosting.Tests\"]");
+            builder.AddHocon("akka.extensions = [\"Akka.Hosting.Tests.ExtensionsSpecs+FakeExtensionOneProvider, Akka.Hosting.Tests\"]", HoconAddMode.Append);
             builder.WithExtension<FakeExtensionTwoProvider>();
         });
 

--- a/src/Akka.Hosting.Tests/HoconSpecs.cs
+++ b/src/Akka.Hosting.Tests/HoconSpecs.cs
@@ -15,7 +15,7 @@ public class HoconSpecs
         // arrange
         using var host = await StartHost(collection => collection.AddAkka("Test", builder =>
         {
-            builder.AddHoconFile("test.hocon");
+            builder.AddHoconFile("test.hocon", HoconAddMode.Append);
         }));
         
         // act

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -168,20 +168,15 @@ namespace Akka.Hosting
             return this;
         }
 
-        internal AkkaConfigurationBuilder AddHoconConfiguration(Config newHocon,
-            HoconAddMode addMode = HoconAddMode.Append)
+        internal AkkaConfigurationBuilder AddHoconConfiguration(Config newHocon, HoconAddMode addMode)
         {
-            switch (addMode)
+            return addMode switch
             {
-                case HoconAddMode.Append:
-                    return AddHoconConfiguration((config, add) => config.WithFallback(add), newHocon);
-                case HoconAddMode.Prepend:
-                    return AddHoconConfiguration((config, add) => add.WithFallback(config), newHocon);
-                case HoconAddMode.Replace:
-                    return AddHoconConfiguration((config, add) => add.WithFallback(config), newHocon);
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(addMode), addMode, null);
-            }
+                HoconAddMode.Append => AddHoconConfiguration((config, add) => config.WithFallback(add), newHocon),
+                HoconAddMode.Prepend => AddHoconConfiguration((config, add) => add.WithFallback(config), newHocon),
+                HoconAddMode.Replace => AddHoconConfiguration((config, add) => add.WithFallback(config), newHocon),
+                _ => throw new ArgumentOutOfRangeException(nameof(addMode), addMode, null)
+            };
         }
 
         private static ActorStarter ToAsyncStarter(Action<ActorSystem, IActorRegistry> nonAsyncStarter)

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -86,8 +86,7 @@ namespace Akka.Hosting
         /// <param name="hocon">The HOCON to add.</param>
         /// <param name="addMode">The <see cref="HoconAddMode"/> - defaults to appending this HOCON as a fallback.</param>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
-        public static AkkaConfigurationBuilder AddHocon(this AkkaConfigurationBuilder builder, Config hocon,
-            HoconAddMode addMode = HoconAddMode.Prepend)
+        public static AkkaConfigurationBuilder AddHocon(this AkkaConfigurationBuilder builder, Config hocon, HoconAddMode addMode)
         {
             return builder.AddHoconConfiguration(hocon, addMode);
         }
@@ -100,8 +99,7 @@ namespace Akka.Hosting
         /// <param name="hoconFilePath">The path to the HOCON file. Can be relative or absolute.</param>
         /// <param name="addMode">The <see cref="HoconAddMode"/> - defaults to appending this HOCON as a fallback.</param>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
-        public static AkkaConfigurationBuilder AddHoconFile(this AkkaConfigurationBuilder builder, string hoconFilePath,
-            HoconAddMode addMode = HoconAddMode.Prepend)
+        public static AkkaConfigurationBuilder AddHoconFile(this AkkaConfigurationBuilder builder, string hoconFilePath, HoconAddMode addMode)
         {
             var hoconText = ConfigurationFactory.ParseString(File.ReadAllText(hoconFilePath));
             return AddHocon(builder, hoconText, addMode);

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -87,7 +87,7 @@ namespace Akka.Hosting
         /// <param name="addMode">The <see cref="HoconAddMode"/> - defaults to appending this HOCON as a fallback.</param>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
         public static AkkaConfigurationBuilder AddHocon(this AkkaConfigurationBuilder builder, Config hocon,
-            HoconAddMode addMode = HoconAddMode.Append)
+            HoconAddMode addMode = HoconAddMode.Prepend)
         {
             return builder.AddHoconConfiguration(hocon, addMode);
         }
@@ -101,7 +101,7 @@ namespace Akka.Hosting
         /// <param name="addMode">The <see cref="HoconAddMode"/> - defaults to appending this HOCON as a fallback.</param>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
         public static AkkaConfigurationBuilder AddHoconFile(this AkkaConfigurationBuilder builder, string hoconFilePath,
-            HoconAddMode addMode = HoconAddMode.Append)
+            HoconAddMode addMode = HoconAddMode.Prepend)
         {
             var hoconText = ConfigurationFactory.ParseString(File.ReadAllText(hoconFilePath));
             return AddHocon(builder, hoconText, addMode);

--- a/src/Akka.Persistence.PostgreSql.Hosting/AkkaPersistencePostgreSqlHostingExtensions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/AkkaPersistencePostgreSqlHostingExtensions.cs
@@ -123,7 +123,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
                 builder.WithJournal("postgresql", configurator);
             }
 
-            return builder.AddHocon(finalConfig.WithFallback(PostgreSqlPersistence.DefaultConfiguration()));
+            return builder.AddHocon(finalConfig.WithFallback(PostgreSqlPersistence.DefaultConfiguration()), HoconAddMode.Append);
         }
     }
 }

--- a/src/Akka.Persistence.SqlServer.Hosting/AkkaPersistenceSqlServerHostingExtensions.cs
+++ b/src/Akka.Persistence.SqlServer.Hosting/AkkaPersistenceSqlServerHostingExtensions.cs
@@ -162,12 +162,12 @@ namespace Akka.Persistence.SqlServer.Hosting
                 case PersistenceMode.Both:
                     builder.AddHocon(journalConfiguration, HoconAddMode.Prepend);
                     builder.AddHocon(snapshotStoreConfig, HoconAddMode.Prepend);
-                    builder.AddHocon(SqlReadJournal.DefaultConfiguration());
+                    builder.AddHocon(SqlReadJournal.DefaultConfiguration(), HoconAddMode.Append);
                     break;
                 
                 case PersistenceMode.Journal:
                     builder.AddHocon(journalConfiguration, HoconAddMode.Prepend);
-                    builder.AddHocon(SqlReadJournal.DefaultConfiguration());
+                    builder.AddHocon(SqlReadJournal.DefaultConfiguration(), HoconAddMode.Append);
                     break;
                 
                 case PersistenceMode.SnapshotStore:
@@ -183,7 +183,7 @@ namespace Akka.Persistence.SqlServer.Hosting
                 builder.WithJournal("sql-server", configurator);
             }
 
-            return builder.AddHocon(SqlServerPersistence.DefaultConfiguration());
+            return builder.AddHocon(SqlServerPersistence.DefaultConfiguration(), HoconAddMode.Append);
         }
     }
 }


### PR DESCRIPTION
Fixes #134

## Changes

* Change AddHocon and AddHoconFile default mode from Append to Prepend

# WARNING
This is a breaking change for all Akka.Hosting extension plugins

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
