### PR TITLE
Modularize and optionize persistence hosting methods

### DIFF
--- a/Akka.Hosting.sln
+++ b/Akka.Hosting.sln
@@ -45,6 +45,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.TestKit", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.TestKit.Tests", "src\Akka.Hosting.TestKit.Tests\Akka.Hosting.TestKit.Tests.csproj", "{3883AD08-B981-4943-8153-1E7FFD2C3127}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.CustomJournalIdDemo", "src\Examples\Akka.Hosting.CustomJournalIdDemo\Akka.Hosting.CustomJournalIdDemo.csproj", "{89865EC9-B8BF-414C-B69D-B84CAA00025D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,10 @@ Global
 		{3883AD08-B981-4943-8153-1E7FFD2C3127}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3883AD08-B981-4943-8153-1E7FFD2C3127}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3883AD08-B981-4943-8153-1E7FFD2C3127}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89865EC9-B8BF-414C-B69D-B84CAA00025D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89865EC9-B8BF-414C-B69D-B84CAA00025D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89865EC9-B8BF-414C-B69D-B84CAA00025D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89865EC9-B8BF-414C-B69D-B84CAA00025D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,5 +134,6 @@ Global
 		{5F6A7BE8-6906-46CE-BA1C-72EA11EFA33B} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
 		{2C2C2DE2-5A79-4689-9D1A-D70CCF17545B} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
 		{4F79325B-9EE7-4501-800F-7A1F8DFBCC80} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
+		{89865EC9-B8BF-414C-B69D-B84CAA00025D} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
 	EndGlobalSection
 EndGlobal

--- a/Akka.Hosting.sln.DotSettings
+++ b/Akka.Hosting.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -45,6 +45,24 @@ namespace Akka.Cluster.Hosting
         public bool RememberEntities { get; set; } = false;
 
         public string Role { get; set; }
+
+        /// <summary>
+        ///     <para>
+        ///         The journal plugin configuration identifier used by persistence mode, eg. "sql-server" or "postgresql"
+        ///     </para>
+        ///     <b>NOTE</b> This setting is only used when <see cref="StateStoreMode"/> is set to
+        ///     <see cref="Akka.Cluster.Sharding.StateStoreMode.Persistence"/>
+        /// </summary>
+        public string JournalPluginId { get; set; } = null;
+
+        /// <summary>
+        ///     <para>
+        ///         The snapshot store plugin configuration identifier used by persistence mode, eg. "sql-server" or "postgresql"
+        ///     </para>
+        ///     <b>NOTE</b> This setting is only used when <see cref="StateStoreMode"/> is set to
+        ///     <see cref="Akka.Cluster.Sharding.StateStoreMode.Persistence"/>
+        /// </summary>
+        public string SnapshotPluginId { get; set; } = null;
     }
 
     public static class AkkaClusterHostingExtensions
@@ -152,11 +170,18 @@ namespace Akka.Cluster.Hosting
         {
             return builder.WithActors(async (system, registry) =>
             {
-                var shardRegion = await ClusterSharding.Get(system).StartAsync(typeName, entityPropsFactory,
-                    ClusterShardingSettings.Create(system)
-                        .WithRole(shardOptions.Role)
-                        .WithRememberEntities(shardOptions.RememberEntities)
-                        .WithStateStoreMode(shardOptions.StateStoreMode), messageExtractor);
+                var settings = ClusterShardingSettings.Create(system)
+                    .WithRole(shardOptions.Role)
+                    .WithRememberEntities(shardOptions.RememberEntities)
+                    .WithStateStoreMode(shardOptions.StateStoreMode);
+
+                if (shardOptions.StateStoreMode == StateStoreMode.Persistence)
+                    settings = settings
+                        .WithJournalPluginId(shardOptions.JournalPluginId)
+                        .WithSnapshotPluginId(shardOptions.SnapshotPluginId);
+                
+                var shardRegion = await ClusterSharding.Get(system)
+                    .StartAsync(typeName, entityPropsFactory, settings, messageExtractor);
                 
                 registry.Register<TKey>(shardRegion);
             });
@@ -190,11 +215,18 @@ namespace Akka.Cluster.Hosting
         {
             return builder.WithActors(async (system, registry) =>
             {
-                var shardRegion = await ClusterSharding.Get(system).StartAsync(typeName, entityPropsFactory,
-                    ClusterShardingSettings.Create(system)
-                        .WithRole(shardOptions.Role)
-                        .WithRememberEntities(shardOptions.RememberEntities)
-                        .WithStateStoreMode(shardOptions.StateStoreMode), extractEntityId, extractShardId);
+                var settings = ClusterShardingSettings.Create(system)
+                    .WithRole(shardOptions.Role)
+                    .WithRememberEntities(shardOptions.RememberEntities)
+                    .WithStateStoreMode(shardOptions.StateStoreMode);
+
+                if (shardOptions.StateStoreMode == StateStoreMode.Persistence)
+                    settings = settings
+                        .WithJournalPluginId(shardOptions.JournalPluginId)
+                        .WithSnapshotPluginId(shardOptions.SnapshotPluginId);
+                
+                var shardRegion = await ClusterSharding.Get(system)
+                    .StartAsync(typeName, entityPropsFactory, settings, extractEntityId, extractShardId);
 
                 registry.Register<TKey>(shardRegion);
             });
@@ -206,13 +238,20 @@ namespace Akka.Cluster.Hosting
         {
             return builder.WithActors(async (system, registry) =>
             {
+                var settings = ClusterShardingSettings.Create(system)
+                    .WithRole(shardOptions.Role)
+                    .WithRememberEntities(shardOptions.RememberEntities)
+                    .WithStateStoreMode(shardOptions.StateStoreMode);
+
+                if (shardOptions.StateStoreMode == StateStoreMode.Persistence)
+                    settings = settings
+                        .WithJournalPluginId(shardOptions.JournalPluginId)
+                        .WithSnapshotPluginId(shardOptions.SnapshotPluginId);
+                
                 var entityPropsFactory = compositePropsFactory(system, registry);
                 
-                var shardRegion = await ClusterSharding.Get(system).StartAsync(typeName, entityPropsFactory,
-                    ClusterShardingSettings.Create(system)
-                        .WithRole(shardOptions.Role)
-                        .WithRememberEntities(shardOptions.RememberEntities)
-                        .WithStateStoreMode(shardOptions.StateStoreMode), messageExtractor);
+                var shardRegion = await ClusterSharding.Get(system)
+                    .StartAsync(typeName, entityPropsFactory, settings, messageExtractor);
 
                 registry.Register<TKey>(shardRegion);
             });
@@ -225,13 +264,20 @@ namespace Akka.Cluster.Hosting
         {
             return builder.WithActors(async (system, registry) =>
             {
+                var settings = ClusterShardingSettings.Create(system)
+                    .WithRole(shardOptions.Role)
+                    .WithRememberEntities(shardOptions.RememberEntities)
+                    .WithStateStoreMode(shardOptions.StateStoreMode);
+
+                if (shardOptions.StateStoreMode == StateStoreMode.Persistence)
+                    settings = settings
+                        .WithJournalPluginId(shardOptions.JournalPluginId)
+                        .WithSnapshotPluginId(shardOptions.SnapshotPluginId);
+                
                 var entityPropsFactory = compositePropsFactory(system, registry);
                 
-                var shardRegion = await ClusterSharding.Get(system).StartAsync(typeName, entityPropsFactory,
-                    ClusterShardingSettings.Create(system)
-                        .WithRole(shardOptions.Role)
-                        .WithRememberEntities(shardOptions.RememberEntities)
-                        .WithStateStoreMode(shardOptions.StateStoreMode), extractEntityId, extractShardId);
+                var shardRegion = await ClusterSharding.Get(system)
+                    .StartAsync(typeName, entityPropsFactory, settings, extractEntityId, extractShardId);
 
                 registry.Register<TKey>(shardRegion);
             });

--- a/src/Akka.Hosting.Tests/UtilSpec.cs
+++ b/src/Akka.Hosting.Tests/UtilSpec.cs
@@ -1,0 +1,24 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="UtilSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.Tests;
+
+public class UtilSpec
+{
+    [Fact(DisplayName = "Config.MoveTo() should move config to a new path properly")]
+    public void MoveToSpec()
+    {
+        var hocon = (Config)"a: 1, b: { c: 2 }";
+        var moved = hocon.MoveTo("x.y.z");
+        moved.GetInt("x.y.z.a").Should().Be(1);
+        moved.GetInt("x.y.z.b.c").Should().Be(2);
+    }
+}

--- a/src/Akka.Hosting/HoconExtensions.cs
+++ b/src/Akka.Hosting/HoconExtensions.cs
@@ -21,7 +21,7 @@ namespace Akka.Hosting
             if (text is null)
                 throw new ConfigurationException("Value can not be null");
             
-            return EscapeRegex.IsMatch(text) ? $"\"{text}\"" : text;
+            return EscapeRegex.IsMatch(text) || text == string.Empty ? $"\"{text}\"" : text;
         }
 
         public static string ToHocon(this bool? value)

--- a/src/Akka.Hosting/Util.cs
+++ b/src/Akka.Hosting/Util.cs
@@ -1,0 +1,42 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Util.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using Akka.Configuration;
+using Akka.Configuration.Hocon;
+using Akka.Util.Internal;
+
+namespace Akka.Hosting
+{
+    public static class Util
+    {
+        public static Config MoveTo(this Config config, string path)
+        {
+            var rootObj = new HoconObject();
+            var rootValue = new HoconValue();
+            rootValue.Values.Add(rootObj);
+            
+            var lastObject = rootObj;
+
+            var keys = path.SplitDottedPathHonouringQuotes().ToArray();
+            for (var i = 0; i < keys.Length - 1; i++)
+            {
+                var key = keys[i];
+                var innerObject = new HoconObject();
+                var innerValue = new HoconValue();
+                innerValue.Values.Add(innerObject);
+                
+                lastObject.GetOrCreateKey(key);
+                lastObject.Items[key] = innerValue;
+                lastObject = innerObject;
+            }
+            lastObject.Items[keys[keys.Length - 1]] = config.Root;
+            
+            return new Config(new HoconRoot(rootValue));
+        }
+    }
+}

--- a/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
+++ b/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Akka.Hosting.TestKit\Akka.Hosting.TestKit.csproj" />
       <ProjectReference Include="..\Akka.Persistence.Hosting\Akka.Persistence.Hosting.csproj" />
+      <ProjectReference Include="..\Akka.Persistence.PostgreSql.Hosting\Akka.Persistence.PostgreSql.Hosting.csproj" />
       <ProjectReference Include="..\Akka.Persistence.SqlServer.Hosting\Akka.Persistence.SqlServer.Hosting.csproj" />
     </ItemGroup>
 

--- a/src/Akka.Persistence.Hosting.Tests/HoconKeyValidatorSpec.cs
+++ b/src/Akka.Persistence.Hosting.Tests/HoconKeyValidatorSpec.cs
@@ -17,14 +17,9 @@ public class HoconKeyValidatorSpec
     [Theory(DisplayName = "HOCON key validator should detect illegal characters")]
     public void ValidatorTest(string input, string[] illegals)
     {
-        var (illegal, illegalChars) = input.IsIllegalHoconKey();
-        if (illegals.Length == 0)
-            illegal.Should().BeFalse();
-        else
-        {
-            illegal.Should().BeTrue();
-            illegalChars.Should().BeEquivalentTo(illegals);
-        }
+        var illegalChars = input.IsIllegalHoconKey();
+        illegalChars.Length.Should().Be(illegals.Length);
+        illegalChars.Should().BeEquivalentTo(illegals);
     }
 
     public static IEnumerable<object[]> StringFactory()

--- a/src/Akka.Persistence.Hosting.Tests/HoconKeyValidatorSpec.cs
+++ b/src/Akka.Persistence.Hosting.Tests/HoconKeyValidatorSpec.cs
@@ -1,0 +1,40 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HoconKeyValidatorSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Hosting.Tests;
+
+public class HoconKeyValidatorSpec
+{
+    [MemberData(nameof(StringFactory))]
+    [Theory(DisplayName = "HOCON key validator should detect illegal characters")]
+    public void ValidatorTest(string input, string[] illegals)
+    {
+        var (illegal, illegalChars) = input.IsIllegalHoconKey();
+        if (illegals.Length == 0)
+            illegal.Should().BeFalse();
+        else
+        {
+            illegal.Should().BeTrue();
+            illegalChars.Should().BeEquivalentTo(illegals);
+        }
+    }
+
+    public static IEnumerable<object[]> StringFactory()
+    {
+        yield return new object[] { "a.:\u0020", new []{".", ":", "\\u0020"} };
+        yield return new object[] { "a.b.c:d:", new []{".", ":"} };
+        yield return new object[] { "a..c::", new []{".", ":"} };
+        yield return new object[] { "\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006", new []{"\\u00A0", "\\u1680", "\\u2000", "\\u2001", "\\u2002", "\\u2003", "\\u2004", "\\u2005", "\\u2006"} };
+        yield return new object[] { "=,#`^", new []{"=", ",", "#", "`", "^"} };
+        yield return new object[] { "[x]y{z}", new []{"[", "]", "{", "}"} };
+        yield return new object[] { "-_%()'~|+01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ<>", Array.Empty<string>() };
+    }
+}

--- a/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
@@ -68,15 +68,6 @@ namespace Akka.Persistence.Hosting.Tests
             public override string PersistenceId { get; }
         }
         
-        public static async Task<IHost> StartHost(Action<IServiceCollection> testSetup)
-        {
-            var host = new HostBuilder()
-                .ConfigureServices(testSetup).Build();
-        
-            await host.StartAsync();
-            return host;
-        }
-        
         protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
             builder

--- a/src/Akka.Persistence.Hosting.Tests/PostgreSql/PostgreSqlOptionsSpec.cs
+++ b/src/Akka.Persistence.Hosting.Tests/PostgreSql/PostgreSqlOptionsSpec.cs
@@ -33,7 +33,7 @@ public class PostgreSqlOptionsSpec
     public void DefaultJournalOptionsTest()
     {
         var options = new PostgreSqlJournalOptions(false);
-        var emptyRootConfig = options.ToConfig();
+        var emptyRootConfig = options.ToConfig().WithFallback(options.DefaultConfig);
         var baseRootConfig = Config.Empty
             .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
@@ -51,7 +51,7 @@ public class PostgreSqlOptionsSpec
     public void CustomIdJournalOptionsTest()
     {
         var options = new PostgreSqlJournalOptions(false, "custom");
-        var emptyRootConfig = options.ToConfig();
+        var emptyRootConfig = options.ToConfig().WithFallback(options.DefaultConfig);
         var baseRootConfig = Config.Empty
             .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
@@ -132,7 +132,7 @@ public class PostgreSqlOptionsSpec
     public void DefaultSnapshotOptionsTest()
     {
         var options = new PostgreSqlSnapshotOptions(false);
-        var emptyRootConfig = options.ToConfig();
+        var emptyRootConfig = options.ToConfig().WithFallback(options.DefaultConfig);
         var baseRootConfig = Config.Empty
             .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
@@ -150,7 +150,7 @@ public class PostgreSqlOptionsSpec
     public void CustomIdSnapshotOptionsTest()
     {
         var options = new PostgreSqlSnapshotOptions(false, "custom");
-        var emptyRootConfig = options.ToConfig();
+        var emptyRootConfig = options.ToConfig().WithFallback(options.DefaultConfig);
         var baseRootConfig = Config.Empty
             .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         

--- a/src/Akka.Persistence.Hosting.Tests/PostgreSql/PostgreSqlOptionsSpec.cs
+++ b/src/Akka.Persistence.Hosting.Tests/PostgreSql/PostgreSqlOptionsSpec.cs
@@ -1,90 +1,85 @@
 ﻿// -----------------------------------------------------------------------
-//  <copyright file="SqlServerOptionsSpec.cs" company="Akka.NET Project">
+//  <copyright file="PostgreSqlOptionsSpec.cs" company="Akka.NET Project">
 //      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using Akka.Configuration;
+using Akka.Persistence.PostgreSql;
+using Akka.Persistence.PostgreSql.Hosting;
 using Akka.Persistence.Query.Sql;
-using Akka.Persistence.SqlServer;
-using Akka.Persistence.SqlServer.Hosting;
 using Akka.Util;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 
-namespace Akka.Persistence.Hosting.Tests.SqlServer;
+namespace Akka.Persistence.Hosting.Tests.PostgreSql;
 
-public class SqlServerOptionsSpec
+public class PostgreSqlOptionsSpec
 {
     #region Journal unit tests
 
-    [Fact(DisplayName = "SqlServerJournalOptions as default plugin should generate plugin setting")]
+    [Fact(DisplayName = "PostgreSqlJournalOptions as default plugin should generate plugin setting")]
     public void DefaultPluginJournalOptionsTest()
     {
-        var options = new SqlServerJournalOptions(true);
+        var options = new PostgreSqlJournalOptions(true);
         var config = options.ToConfig();
 
-        config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.sql-server");
-        config.HasPath("akka.persistence.journal.sql-server").Should().BeTrue();
+        config.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.postgresql");
+        config.HasPath("akka.persistence.journal.postgresql").Should().BeTrue();
     }
 
-    [Fact(DisplayName = "Empty SqlServerJournalOptions should equal empty config with default fallback")]
+    [Fact(DisplayName = "Empty PostgreSqlJournalOptions should equal empty config with default fallback")]
     public void DefaultJournalOptionsTest()
     {
-        var options = new SqlServerJournalOptions(false);
+        var options = new PostgreSqlJournalOptions(false);
         var emptyRootConfig = options.ToConfig();
         var baseRootConfig = Config.Empty
-            .WithFallback(SqlServerPersistence.DefaultConfiguration())
-            .WithFallback(SqlReadJournal.DefaultConfiguration());
+            .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
         AssertString(emptyRootConfig, baseRootConfig, "akka.persistence.journal.plugin");
-        AssertTimespan(emptyRootConfig, baseRootConfig, "akka.persistence.query.journal.sql.refresh-interval");
         
-        var config = emptyRootConfig.GetConfig("akka.persistence.journal.sql-server");
-        var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.sql-server");
+        var config = emptyRootConfig.GetConfig("akka.persistence.journal.postgresql");
+        var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.postgresql");
         config.Should().NotBeNull();
         baseConfig.Should().NotBeNull();
 
         AssertJournalConfig(config, baseConfig);
     }
     
-    [Fact(DisplayName = "Empty SqlServerJournalOptions with custom identifier should equal empty config with default fallback")]
+    [Fact(DisplayName = "Empty PostgreSqlJournalOptions with custom identifier should equal empty config with default fallback")]
     public void CustomIdJournalOptionsTest()
     {
-        var options = new SqlServerJournalOptions(false, "custom");
+        var options = new PostgreSqlJournalOptions(false, "custom");
         var emptyRootConfig = options.ToConfig();
         var baseRootConfig = Config.Empty
-            .WithFallback(SqlServerPersistence.DefaultConfiguration())
-            .WithFallback(SqlReadJournal.DefaultConfiguration());
+            .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
         AssertString(emptyRootConfig, baseRootConfig, "akka.persistence.journal.plugin");
-        AssertTimespan(emptyRootConfig, baseRootConfig, "akka.persistence.query.journal.sql.refresh-interval");
         
         var config = emptyRootConfig.GetConfig("akka.persistence.journal.custom");
-        var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.sql-server");
+        var baseConfig = baseRootConfig.GetConfig("akka.persistence.journal.postgresql");
         config.Should().NotBeNull();
         baseConfig.Should().NotBeNull();
 
         AssertJournalConfig(config, baseConfig);
     }
     
-    [Fact(DisplayName = "SqlServerJournalOptions should generate proper config")]
+    [Fact(DisplayName = "PostgreSqlJournalOptions should generate proper config")]
     public void JournalOptionsTest()
     {
-        var options = new SqlServerJournalOptions(true)
+        var options = new PostgreSqlJournalOptions(true)
         {
             Identifier = "custom",
             AutoInitialize = true,
             ConnectionString = "testConnection",
             ConnectionTimeout = 1.Seconds(),
             MetadataTableName = "testMetadata",
-            QueryRefreshInterval = 2.Seconds(),
             SchemaName = "testSchema",
             SequentialAccess = false,
             TableName = "testTable",
-            UseConstantParameterSize = true
+            StoredAs = StoredAsType.Json,
+            UseBigIntIdentityForOrderingColumn = true
         };
         options.Adapters.AddWriteEventAdapter<EventAdapterSpecs.EventMapper1>("mapper1", new [] { typeof(EventAdapterSpecs.Event1) });
         options.Adapters.AddReadEventAdapter<EventAdapterSpecs.ReadAdapter>("reader1", new [] { typeof(EventAdapterSpecs.Event1) });
@@ -95,9 +90,6 @@ public class SqlServerOptionsSpec
         
         baseConfig.GetString("akka.persistence.journal.plugin").Should().Be("akka.persistence.journal.custom");
 
-        baseConfig.GetTimeSpan("akka.persistence.query.journal.sql.refresh-interval").Should()
-            .Be(options.QueryRefreshInterval);
-        
         var config = baseConfig.GetConfig("akka.persistence.journal.custom");
         config.Should().NotBeNull();
         config.GetString("connection-string").Should().Be(options.ConnectionString);
@@ -107,7 +99,8 @@ public class SqlServerOptionsSpec
         config.GetBoolean("auto-initialize").Should().Be(options.AutoInitialize);
         config.GetString("metadata-table-name").Should().Be(options.MetadataTableName);
         config.GetBoolean("sequential-access").Should().Be(options.SequentialAccess);
-        config.GetBoolean("use-constant-parameter-size").Should().Be(options.UseConstantParameterSize);
+        config.GetString("stored-as").Should().Be(options.StoredAs.ToHocon());
+        config.GetBoolean("use-bigint-identity-for-ordering-column").Should().Be(options.UseBigIntIdentityForOrderingColumn);
         
         config.GetStringList($"event-adapter-bindings.\"{typeof(EventAdapterSpecs.Event1).TypeQualifiedName()}\"").Should()
             .BeEquivalentTo("mapper1", "reader1", "tagger");
@@ -118,63 +111,63 @@ public class SqlServerOptionsSpec
         config.GetString("event-adapters.reader1").Should().Be(typeof(EventAdapterSpecs.ReadAdapter).TypeQualifiedName());
         config.GetString("event-adapters.combo").Should().Be(typeof(EventAdapterSpecs.ComboAdapter).TypeQualifiedName());
         config.GetString("event-adapters.tagger").Should().Be(typeof(EventAdapterSpecs.Tagger).TypeQualifiedName());
+
     }
 
     #endregion
 
     #region Snapshot unit tests
 
-    [Fact(DisplayName = "SqlServerSnapshotOptions as default plugin should generate plugin setting")]
+    [Fact(DisplayName = "PostgreSqlSnapshotOptions as default plugin should generate plugin setting")]
     public void DefaultPluginSnapshotOptionsTest()
     {
-        var options = new SqlServerSnapshotOptions(true);
+        var options = new PostgreSqlSnapshotOptions(true);
         var config = options.ToConfig();
 
-        config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.sql-server");
-        config.HasPath("akka.persistence.snapshot-store.sql-server").Should().BeTrue();
+        config.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.postgresql");
+        config.HasPath("akka.persistence.snapshot-store.postgresql").Should().BeTrue();
     }
 
-    [Fact(DisplayName = "Empty SqlServerSnapshotOptions should equal empty config with default fallback")]
+    [Fact(DisplayName = "Empty PostgreSqlSnapshotOptions with default fallback should return default config")]
     public void DefaultSnapshotOptionsTest()
     {
-        var options = new SqlServerSnapshotOptions(false);
+        var options = new PostgreSqlSnapshotOptions(false);
         var emptyRootConfig = options.ToConfig();
         var baseRootConfig = Config.Empty
-            .WithFallback(SqlServerPersistence.DefaultConfiguration());
+            .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
         AssertString(emptyRootConfig, baseRootConfig, "akka.persistence.snapshot-store.plugin");
         
-        var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.sql-server");
-        var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.sql-server");
-        config.Should().NotBeNull();
-        baseConfig.Should().NotBeNull();
-        
-        AssertSnapshotConfig(config, baseConfig);
-    }
-    
-    [Fact(DisplayName = "Empty SqlServerSnapshotOptions with custom identifier should equal empty config with default fallback")]
-    public void CustomIdSnapshotOptionsTest()
-    {
-        var options = new SqlServerSnapshotOptions(false, "custom");
-        var emptyRootConfig = options.ToConfig();
-        var baseRootConfig = Config.Empty
-            .WithFallback(SqlServerPersistence.DefaultConfiguration());
-        
-        AssertString(emptyRootConfig, baseRootConfig, "akka.persistence.snapshot-store.plugin");
-        AssertTimespan(emptyRootConfig, baseRootConfig, "akka.persistence.query.snapshot-store.sql.refresh-interval");
-        
-        var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.custom");
-        var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.sql-server");
+        var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.postgresql");
+        var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.postgresql");
         config.Should().NotBeNull();
         baseConfig.Should().NotBeNull();
 
         AssertSnapshotConfig(config, baseConfig);
     }
     
-    [Fact(DisplayName = "SqlServerSnapshotOptions should generate proper config")]
+    [Fact(DisplayName = "Empty PostgreSqlSnapshotOptions with custom identifier should equal empty config with default fallback")]
+    public void CustomIdSnapshotOptionsTest()
+    {
+        var options = new PostgreSqlSnapshotOptions(false, "custom");
+        var emptyRootConfig = options.ToConfig();
+        var baseRootConfig = Config.Empty
+            .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
+        
+        AssertString(emptyRootConfig, baseRootConfig, "akka.persistence.snapshot-store.plugin");
+        
+        var config = emptyRootConfig.GetConfig("akka.persistence.snapshot-store.custom");
+        var baseConfig = baseRootConfig.GetConfig("akka.persistence.snapshot-store.postgresql");
+        config.Should().NotBeNull();
+        baseConfig.Should().NotBeNull();
+
+        AssertSnapshotConfig(config, baseConfig);
+    }
+    
+    [Fact(DisplayName = "PostgreSqlSnapshotOptions should generate proper config")]
     public void SnapshotOptionsTest()
     {
-        var options = new SqlServerSnapshotOptions(true)
+        var options = new PostgreSqlSnapshotOptions(true)
         {
             Identifier = "custom",
             AutoInitialize = true,
@@ -183,10 +176,10 @@ public class SqlServerOptionsSpec
             SchemaName = "testSchema",
             SequentialAccess = false,
             TableName = "testTable",
-            UseConstantParameterSize = true
+            StoredAs = StoredAsType.Json,
         };
         var baseConfig = options.ToConfig()
-            .WithFallback(SqlServerPersistence.DefaultConfiguration());
+            .WithFallback(PostgreSqlPersistence.DefaultConfiguration());
         
         baseConfig.GetString("akka.persistence.snapshot-store.plugin").Should().Be("akka.persistence.snapshot-store.custom");
 
@@ -198,7 +191,7 @@ public class SqlServerOptionsSpec
         config.GetString("table-name").Should().Be(options.TableName);
         config.GetBoolean("auto-initialize").Should().Be(options.AutoInitialize);
         config.GetBoolean("sequential-access").Should().Be(options.SequentialAccess);
-        config.GetBoolean("use-constant-parameter-size").Should().Be(options.UseConstantParameterSize);
+        config.GetString("stored-as").Should().Be(options.StoredAs.ToHocon());
     }
 
     #endregion
@@ -212,10 +205,10 @@ public class SqlServerOptionsSpec
         AssertString(underTest, reference, "schema-name");
         AssertString(underTest, reference, "table-name");
         AssertBoolean(underTest, reference, "auto-initialize");
-        AssertString(underTest, reference, "timestamp-provider");
         AssertString(underTest, reference, "metadata-table-name");
         AssertBoolean(underTest, reference, "sequential-access");
-        AssertBoolean(underTest, reference, "use-constant-parameter-size");
+        AssertString(underTest, reference, "stored-as");
+        AssertBoolean(underTest, reference, "use-bigint-identity-for-ordering-column");
     }
 
     private static void AssertSnapshotConfig(Config underTest, Config reference)
@@ -230,7 +223,7 @@ public class SqlServerOptionsSpec
         AssertBoolean(underTest, reference, "sequential-access");
         AssertBoolean(underTest, reference, "use-constant-parameter-size");
     }
-    
+
     private static void AssertString(Config underTest, Config reference, string hoconPath)
     {
         underTest.GetString(hoconPath).Should().Be(reference.GetString(hoconPath));

--- a/src/Akka.Persistence.Hosting.Tests/SqlServer/SqlServerOptionsSpec.cs
+++ b/src/Akka.Persistence.Hosting.Tests/SqlServer/SqlServerOptionsSpec.cs
@@ -34,7 +34,7 @@ public class SqlServerOptionsSpec
     public void DefaultJournalOptionsTest()
     {
         var options = new SqlServerJournalOptions(false);
-        var emptyRootConfig = options.ToConfig();
+        var emptyRootConfig = options.ToConfig().WithFallback(options.DefaultConfig);
         var baseRootConfig = Config.Empty
             .WithFallback(SqlServerPersistence.DefaultConfiguration())
             .WithFallback(SqlReadJournal.DefaultConfiguration());
@@ -54,7 +54,7 @@ public class SqlServerOptionsSpec
     public void CustomIdJournalOptionsTest()
     {
         var options = new SqlServerJournalOptions(false, "custom");
-        var emptyRootConfig = options.ToConfig();
+        var emptyRootConfig = options.ToConfig().WithFallback(options.DefaultConfig);
         var baseRootConfig = Config.Empty
             .WithFallback(SqlServerPersistence.DefaultConfiguration())
             .WithFallback(SqlReadJournal.DefaultConfiguration());

--- a/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
+++ b/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
@@ -5,6 +5,7 @@ using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Persistence.Journal;
 using Akka.Util;
+using Akka.Actor;
 
 #nullable enable
 namespace Akka.Persistence.Hosting
@@ -125,6 +126,14 @@ namespace Akka.Persistence.Hosting
     /// </summary>
     public static class AkkaPersistenceHostingExtensions
     {
+        /// <summary>
+        /// A generic way to add both journal and snapshot store configuration to the <see cref="ActorSystem"/>
+        /// </summary>
+        /// <param name="builder">The builder instance being configured.</param>
+        /// <param name="journalOptions">The specific journal options instance used to configure the journal. For example, an instance of <c>SqlServerJournalOptions</c></param>
+        /// <param name="snapshotOptions">The specific snapshot store options instance used to configure the snapshot store. For example, an instance of <c>SqlServerSnapshotOptions</c></param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public static AkkaConfigurationBuilder WithJournalAndSnapshot(
             this AkkaConfigurationBuilder builder,
             JournalOptions journalOptions, 
@@ -146,6 +155,13 @@ namespace Akka.Persistence.Hosting
             return builder.AddHocon(defaultConfig, HoconAddMode.Append);
         }
         
+        /// <summary>
+        /// A generic way to add journal configuration to the <see cref="ActorSystem"/>
+        /// </summary>
+        /// <param name="builder">The builder instance being configured.</param>
+        /// <param name="journalOptions">The specific journal options instance used to configure the journal. For example, an instance of <c>SqlServerJournalOptions</c></param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public static AkkaConfigurationBuilder WithJournal(
             this AkkaConfigurationBuilder builder,
             JournalOptions journalOptions)
@@ -157,6 +173,13 @@ namespace Akka.Persistence.Hosting
             return builder.AddHocon(journalOptions.DefaultConfig, HoconAddMode.Append);
         }
         
+        /// <summary>
+        /// A generic way to add snapshot store configuration to the <see cref="ActorSystem"/>
+        /// </summary>
+        /// <param name="builder">The builder instance being configured.</param>
+        /// <param name="snapshotOptions">The specific snapshot store options instance used to configure the snapshot store. For example, an instance of <c>SqlServerSnapshotOptions</c></param>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public static AkkaConfigurationBuilder WithSnapshot(
             this AkkaConfigurationBuilder builder,
             SnapshotOptions snapshotOptions)

--- a/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
+++ b/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
@@ -6,6 +6,7 @@ using Akka.Hosting;
 using Akka.Persistence.Journal;
 using Akka.Util;
 
+#nullable enable
 namespace Akka.Persistence.Hosting
 {
     public enum PersistenceMode
@@ -87,23 +88,35 @@ namespace Akka.Persistence.Hosting
                 return;
 
             var adapters = new StringBuilder()
-                .Append($"akka.persistence.journal.{JournalId}").Append("{")
-                .AppendLine("event-adapters {");
-            foreach (var kv in Adapters)
-            {
-                adapters.AppendLine($"{kv.Key} = \"{kv.Value.TypeQualifiedName()}\"");
-            }
+                .Append($"akka.persistence.journal.{JournalId}").Append("{");
 
-            adapters.AppendLine("}").AppendLine("event-adapter-bindings {");
-            foreach (var kv in Bindings)
-            {
-                adapters.AppendLine($"\"{kv.Key.TypeQualifiedName()}\" = [{string.Join(",", kv.Value)}]");
-            }
+            AppendAdapters(adapters);
 
-            adapters.AppendLine("}").AppendLine("}");
+            adapters.AppendLine("}");
 
             var finalHocon = ConfigurationFactory.ParseString(adapters.ToString());
             Builder.AddHocon(finalHocon, HoconAddMode.Prepend);
+        }
+
+        internal void AppendAdapters(StringBuilder sb)
+        {
+            // useless configuration - don't bother.
+            if (Adapters.Count == 0 || Bindings.Count == 0)
+                return;
+            
+            sb.AppendLine("event-adapters {");
+            foreach (var kv in Adapters)
+            {
+                sb.AppendLine($"{kv.Key} = \"{kv.Value.TypeQualifiedName()}\"");
+            }
+
+            sb.AppendLine("}").AppendLine("event-adapter-bindings {");
+            foreach (var kv in Bindings)
+            {
+                sb.AppendLine($"\"{kv.Key.TypeQualifiedName()}\" = [{string.Join(",", kv.Value)}]");
+            }
+
+            sb.AppendLine("}");
         }
     }
 
@@ -112,18 +125,63 @@ namespace Akka.Persistence.Hosting
     /// </summary>
     public static class AkkaPersistenceHostingExtensions
     {
+        public static AkkaConfigurationBuilder WithJournalAndSnapshot(
+            this AkkaConfigurationBuilder builder,
+            JournalOptions journalOptions, 
+            SnapshotOptions snapshotOptions)
+        {
+            if (journalOptions is null)
+                throw new ArgumentNullException(nameof(journalOptions));
+            if (snapshotOptions is null)
+                throw new ArgumentNullException(nameof(snapshotOptions));
+            
+            builder.AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend);
+            var defaultConfig = journalOptions.DefaultConfig;
+
+            builder.AddHocon(snapshotOptions.ToConfig(), HoconAddMode.Prepend);
+            defaultConfig = defaultConfig.Equals(snapshotOptions.DefaultConfig)
+                    ? defaultConfig 
+                    : defaultConfig.WithFallback(snapshotOptions.DefaultConfig);
+
+            return builder.AddHocon(defaultConfig, HoconAddMode.Append);
+        }
+        
+        public static AkkaConfigurationBuilder WithJournal(
+            this AkkaConfigurationBuilder builder,
+            JournalOptions journalOptions)
+        {
+            if (journalOptions is null)
+                throw new ArgumentNullException(nameof(journalOptions));
+            
+            builder.AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend);
+            return builder.AddHocon(journalOptions.DefaultConfig, HoconAddMode.Append);
+        }
+        
+        public static AkkaConfigurationBuilder WithSnapshot(
+            this AkkaConfigurationBuilder builder,
+            SnapshotOptions snapshotOptions)
+        {
+            if (snapshotOptions is null)
+                throw new ArgumentNullException(nameof(snapshotOptions));
+            
+            builder.AddHocon(snapshotOptions.ToConfig(), HoconAddMode.Prepend);
+            return builder.AddHocon(snapshotOptions.DefaultConfig, HoconAddMode.Append);
+        }
+        
         /// <summary>
         /// Used to configure a specific Akka.Persistence.Journal instance, primarily to support <see cref="IEventAdapter"/>s.
         /// </summary>
         /// <param name="builder">The builder instance being configured.</param>
-        /// <param name="journalId">The id of the journal. i.e. if you want to apply this adapter to the `akka.persistence.journal.sql` journal, just type `sql`.</param>
+        /// <param name="journalId">The id of the journal. i.e. if you want to apply this adapter to the `akka.persistence.journal.sql-server` journal, just type `sql-server`.</param>
         /// <param name="journalBuilder">Configuration method for configuring the journal.</param>
         /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
         /// <remarks>
         /// This method can be called multiple times for different <see cref="IEventAdapter"/>s.
         /// </remarks>
-        public static AkkaConfigurationBuilder WithJournal(this AkkaConfigurationBuilder builder,
-            string journalId, Action<AkkaPersistenceJournalBuilder> journalBuilder)
+        public static AkkaConfigurationBuilder WithJournal(
+            this AkkaConfigurationBuilder builder,
+            string journalId, 
+            Action<AkkaPersistenceJournalBuilder> journalBuilder)
         {
             var jBuilder = new AkkaPersistenceJournalBuilder(journalId, builder);
             journalBuilder(jBuilder);
@@ -135,41 +193,40 @@ namespace Akka.Persistence.Hosting
         
         public static AkkaConfigurationBuilder WithInMemoryJournal(this AkkaConfigurationBuilder builder)
         {
-            return WithInMemoryJournal(builder, journalBuilder => { });
+            return WithInMemoryJournal(builder, _ => { });
         }
 
-        public static AkkaConfigurationBuilder WithInMemoryJournal(this AkkaConfigurationBuilder builder,
-            Action<AkkaPersistenceJournalBuilder> journalBuilder)
+        public static AkkaConfigurationBuilder WithInMemoryJournal(
+            this AkkaConfigurationBuilder builder,
+            Action<AkkaPersistenceJournalBuilder> journalBuilder,
+            string journalId = "inmem",
+            bool isDefaultPlugin = true)
         {
-            builder.WithJournal("inmem", journalBuilder);
+            builder.WithJournal(journalId, journalBuilder);
 
-            const string liveConfig = @"akka.persistence.journal.plugin = akka.persistence.journal.inmem
-                akka.persistence.journal.inmem {
-                # Class name of the plugin.
-                class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
-                # Dispatcher for the plugin actor.
-                plugin-dispatcher = ""akka.actor.default-dispatcher""
-            }";
+            var liveConfig = 
+@$"{(isDefaultPlugin ? $"akka.persistence.journal.plugin = akka.persistence.journal.{journalId}" : "")} 
+akka.persistence.journal.{journalId} {{
+    class = ""Akka.Persistence.Journal.MemoryJournal, Akka.Persistence""
+    plugin-dispatcher = ""akka.actor.default-dispatcher""
+}}";
 
-            builder.AddHocon(liveConfig, HoconAddMode.Prepend);
-            
-            return builder;
+            return builder.AddHocon(liveConfig, HoconAddMode.Prepend);
         }
 
-        public static AkkaConfigurationBuilder WithInMemorySnapshotStore(this AkkaConfigurationBuilder builder)
+        public static AkkaConfigurationBuilder WithInMemorySnapshotStore(
+            this AkkaConfigurationBuilder builder,
+            string snapshotStoreId = "inmem",
+            bool isDefaultPlugin = true)
         {
-            const string liveConfig = @"akka.persistence.snapshot-store.plugin = akka.persistence.snapshot-store.inmem
-            # In-memory snapshot store plugin.
-            akka.persistence.snapshot-store.inmem {
-            # Class name of the plugin.
-            class = ""Akka.Persistence.Snapshot.MemorySnapshotStore, Akka.Persistence""
-            # Dispatcher for the plugin actor.
-            plugin-dispatcher = ""akka.actor.default-dispatcher""
-        }";
+            var liveConfig = 
+$@"{(isDefaultPlugin ? $"akka.persistence.snapshot-store.plugin = akka.persistence.snapshot-store.{snapshotStoreId}" : "")}
+akka.persistence.snapshot-store.{snapshotStoreId} {{
+    class = ""Akka.Persistence.Snapshot.MemorySnapshotStore, Akka.Persistence""
+    plugin-dispatcher = ""akka.actor.default-dispatcher""
+}}";
 
-            builder.AddHocon(liveConfig, HoconAddMode.Prepend);
-            
-            return builder;
+            return builder.AddHocon(liveConfig, HoconAddMode.Prepend);
         }
     }
 }

--- a/src/Akka.Persistence.Hosting/JournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/JournalOptions.cs
@@ -58,8 +58,8 @@ namespace Akka.Persistence.Hosting
             if(string.IsNullOrWhiteSpace(Identifier))
                 throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} is null or whitespace");
 
-            var (illegal, illegalChars) = Identifier.IsIllegalHoconKey();
-            if (illegal)
+            var illegalChars = Identifier.IsIllegalHoconKey();
+            if (illegalChars.Length > 0)
             {
                 throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} contains illegal character(s) {string.Join(", ", illegalChars)}");
             }

--- a/src/Akka.Persistence.Hosting/JournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/JournalOptions.cs
@@ -1,0 +1,85 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="JournalOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Configuration;
+using Akka.Hosting;
+
+#nullable enable
+namespace Akka.Persistence.Hosting
+{
+    public abstract class JournalOptions
+    {
+        private readonly bool _isDefault;
+        
+        protected JournalOptions(bool isDefault)
+        {
+            _isDefault = isDefault;
+        }
+        
+        public abstract string Identifier { get; set; }
+        
+        /// <summary>
+        ///     <para>
+        ///         Should corresponding journal table be initialized automatically.
+        ///     </para>
+        ///     <b>Default</b>: false
+        /// </summary>
+        public bool AutoInitialize { get; set; } = false;
+        
+        /// <summary>
+        ///     <para>
+        ///         Default serializer used as manifest serializer when applicable and payload serializer when no
+        ///         specific binding overrides are specified
+        ///     </para>
+        ///     <b>Default</b>: json
+        /// </summary>
+        public string Serializer { get; set; } = "json";
+        
+        public abstract Config DefaultConfig { get; }
+        
+        public AkkaPersistenceJournalBuilder Adapters { get; set; } = new ("", null!);
+        
+        /// <summary>
+        /// The chain config builder.
+        /// The top <see cref="JournalOptions.Build"/> caps the configuration with the outer `akka.persistence.journal.{id}` HOCON block.
+        /// If you need to add more properties into this block, append them __BEFORE__ calling <c>base.Build()</c>.
+        /// If you need to add more properties outside of this block, append them __AFTER__ calling <c>base.Build()</c>.
+        /// </summary>
+        /// <param name="sb"><see cref="StringBuilder"/> instance from lower chain</param>
+        /// <returns>The fully built <see cref="StringBuilder"/> containing the `akka.persistence.journal.{id}` HOCON block.</returns>
+        /// <exception cref="Exception">Thrown when <see cref="Identifier"/> is null or whitespace</exception>
+        protected virtual StringBuilder Build(StringBuilder sb)
+        {
+            if(string.IsNullOrWhiteSpace(Identifier))
+                throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} is null or whitespace");
+
+            var (illegal, illegalChars) = Identifier.IsIllegalHoconKey();
+            if (illegal)
+            {
+                throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} contains illegal character(s) {string.Join(", ", illegalChars)}");
+            }
+            
+            sb.Insert(0, $"akka.persistence.journal.{Identifier.ToHocon()} {{{Environment.NewLine}");
+            sb.AppendLine($"auto-initialize = {AutoInitialize.ToHocon()}");
+            sb.AppendLine($"serializer = {Serializer.ToHocon()}");
+            Adapters.AppendAdapters(sb);
+            sb.AppendLine("}");
+            
+            if (_isDefault)
+                sb.AppendLine($"akka.persistence.journal.plugin = akka.persistence.journal.{Identifier.ToHocon()}");
+
+            return sb;
+        }
+        
+        public Config ToConfig()
+            => ToString();
+        
+        public sealed override string ToString()
+            => Build(new StringBuilder()).ToString();
+    }
+}

--- a/src/Akka.Persistence.Hosting/JournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/JournalOptions.cs
@@ -66,13 +66,15 @@ namespace Akka.Persistence.Hosting
         /// The default HOCON configuration for this specific snapshot store configuration identifier, normalized to the
         /// plugin identifier name
         /// </summary>
-        public Config DefaultConfig => InternalDefaultConfig.MoveTo($"akka.persistence.journal.{Identifier}");
+        public Config DefaultConfig => InternalDefaultConfig.MoveTo(PluginId);
         
         /// <summary>
         /// The journal adapter builder, use this builder to add custom journal
         /// <see cref="IEventAdapter"/>, <see cref="IWriteEventAdapter"/>, or <see cref="IReadEventAdapter"/>
         /// </summary>
         public AkkaPersistenceJournalBuilder Adapters { get; set; } = new ("", null!);
+
+        public string PluginId => $"akka.persistence.journal.{Identifier}";
         
         /// <summary>
         /// The chain config builder.
@@ -94,14 +96,14 @@ namespace Akka.Persistence.Hosting
                 throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} contains illegal character(s) {string.Join(", ", illegalChars)}");
             }
             
-            sb.Insert(0, $"akka.persistence.journal.{Identifier.ToHocon()} {{{Environment.NewLine}");
+            sb.Insert(0, $"{PluginId} {{{Environment.NewLine}");
             sb.AppendLine($"auto-initialize = {AutoInitialize.ToHocon()}");
             sb.AppendLine($"serializer = {Serializer.ToHocon()}");
             Adapters.AppendAdapters(sb);
             sb.AppendLine("}");
             
             if (_isDefault)
-                sb.AppendLine($"akka.persistence.journal.plugin = akka.persistence.journal.{Identifier}");
+                sb.AppendLine($"akka.persistence.journal.plugin = {PluginId}");
 
             return sb;
         }

--- a/src/Akka.Persistence.Hosting/JournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/JournalOptions.cs
@@ -12,6 +12,10 @@ using Akka.Hosting;
 #nullable enable
 namespace Akka.Persistence.Hosting
 {
+    /// <summary>
+    /// Base class for all journal options class. If you're writing an options class for SQL plugins, use
+    /// <see cref="SqlJournalOptions"/> instead.
+    /// </summary>
     public abstract class JournalOptions
     {
         private readonly bool _isDefault;
@@ -25,7 +29,7 @@ namespace Akka.Persistence.Hosting
         
         /// <summary>
         ///     <para>
-        ///         Should corresponding journal table be initialized automatically.
+        ///         Should corresponding journal be initialized automatically, if applicable.
         ///     </para>
         ///     <b>Default</b>: false
         /// </summary>
@@ -40,7 +44,18 @@ namespace Akka.Persistence.Hosting
         /// </summary>
         public string Serializer { get; set; } = "json";
         
-        public abstract Config DefaultConfig { get; }
+        /// <summary>
+        /// The default configuration for this journal. This must be the actual configuration block for this journal.
+        /// Example:
+        /// protected override Config InternalDefaultConfig = PostgreSqlPersistence.DefaultConfiguration()
+        ///     .GetConfig("akka.persistence.journal.postgresql");
+        /// </summary>
+        protected abstract Config InternalDefaultConfig { get; }
+
+        /// <summary>
+        /// The default configuration for this specific journal configuration identifier
+        /// </summary>
+        public Config DefaultConfig => InternalDefaultConfig.MoveTo($"akka.persistence.journal.{Identifier}");
         
         public AkkaPersistenceJournalBuilder Adapters { get; set; } = new ("", null!);
         
@@ -71,7 +86,7 @@ namespace Akka.Persistence.Hosting
             sb.AppendLine("}");
             
             if (_isDefault)
-                sb.AppendLine($"akka.persistence.journal.plugin = akka.persistence.journal.{Identifier.ToHocon()}");
+                sb.AppendLine($"akka.persistence.journal.plugin = akka.persistence.journal.{Identifier}");
 
             return sb;
         }

--- a/src/Akka.Persistence.Hosting/Properties/FriendsOf.cs
+++ b/src/Akka.Persistence.Hosting/Properties/FriendsOf.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.Persistence.Hosting.Tests")]

--- a/src/Akka.Persistence.Hosting/SnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SnapshotOptions.cs
@@ -24,11 +24,18 @@ namespace Akka.Persistence.Hosting
             _isDefault = isDefault;
         }
         
+        /// <summary>
+        /// <b>NOTE</b> If you're implementing an option class for new Akka.Hosting persistence, you need to override
+        /// this property and provide a default value. The default value have to be the default journal configuration
+        /// identifier name (i.e. "sql-server" or "postgresql"
+        /// </summary>
         public abstract string Identifier { get; set; }
         
         /// <summary>
-        ///     Should corresponding snapshot store table be initialized automatically.
-        ///     <b>Default</b>: false
+        ///     <para>
+        ///         Should corresponding snapshot store be initialized automatically, if applicable.
+        ///     </para>
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public bool AutoInitialize { get; set; } = false;
         
@@ -37,18 +44,26 @@ namespace Akka.Persistence.Hosting
         ///         Default serializer used as manifest serializer when applicable and payload serializer when no
         ///         specific binding overrides are specified
         ///     </para>
-        ///     <b>Default</b>: json
+        ///     <b>Default</b>: <c>"json"</c>
         /// </summary>
         public string Serializer { get; set; } = "json";
         
         /// <summary>
-        /// The default configuration for this journal. This must be the actual configuration block for this journal.
-        /// Example:
-        /// protected override Config InternalDefaultConfig = PostgreSqlPersistence.DefaultConfiguration()
-        ///     .GetConfig("akka.persistence.snapshot-store.postgresql");
+        ///     <para>
+        ///         The default configuration for this snapshot store. This must be the actual configuration block for this journal.
+        ///     </para>
+        ///     Example:
+        ///     <code>
+        ///         protected override Config InternalDefaultConfig = PostgreSqlPersistence.DefaultConfiguration()
+        ///             .GetConfig("akka.persistence.snapshot-store.postgresql");
+        ///     </code>
         /// </summary>
         protected abstract Config InternalDefaultConfig { get; }
         
+        /// <summary>
+        /// The default HOCON configuration for this specific journal configuration identifier, normalized to the
+        /// plugin identifier name
+        /// </summary>
         public Config DefaultConfig => InternalDefaultConfig.MoveTo($"akka.persistence.snapshot-store.{Identifier}");
         
         /// <summary>
@@ -82,9 +97,17 @@ namespace Akka.Persistence.Hosting
             return sb;
         }
         
+        /// <summary>
+        /// Transforms the snapshot store options class into a HOCON <see cref="Config"/> instance 
+        /// </summary>
+        /// <returns>The <see cref="Config"/> equivalence of this options instance</returns>
         public Config ToConfig()
             => ToString();
         
+        /// <summary>
+        /// Transforms the snapshot store options class into a HOCON string
+        /// </summary>
+        /// <returns>The HOCON string representation of this options instance</returns>
         public sealed override string ToString()
             => Build(new StringBuilder()).ToString();
     }

--- a/src/Akka.Persistence.Hosting/SnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SnapshotOptions.cs
@@ -64,7 +64,9 @@ namespace Akka.Persistence.Hosting
         /// The default HOCON configuration for this specific journal configuration identifier, normalized to the
         /// plugin identifier name
         /// </summary>
-        public Config DefaultConfig => InternalDefaultConfig.MoveTo($"akka.persistence.snapshot-store.{Identifier}");
+        public Config DefaultConfig => InternalDefaultConfig.MoveTo(PluginId);
+
+        public string PluginId => $"akka.persistence.snapshot-store.{Identifier}";
         
         /// <summary>
         /// The chain config builder.
@@ -86,13 +88,13 @@ namespace Akka.Persistence.Hosting
                 throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} contains illegal character(s) {string.Join(", ", illegalChars)}");
             }
             
-            sb.Insert(0, $"akka.persistence.snapshot-store.{Identifier} {{{Environment.NewLine}");
+            sb.Insert(0, $"{PluginId} {{{Environment.NewLine}");
             sb.AppendLine($"serializer = {Serializer.ToHocon()}");
             sb.AppendLine($"auto-initialize = {AutoInitialize.ToHocon()}");
             sb.AppendLine("}");
             
             if (_isDefault)
-                sb.AppendLine($"akka.persistence.snapshot-store.plugin = akka.persistence.snapshot-store.{Identifier}");
+                sb.AppendLine($"akka.persistence.snapshot-store.plugin = {PluginId}");
             
             return sb;
         }

--- a/src/Akka.Persistence.Hosting/SnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SnapshotOptions.cs
@@ -1,0 +1,79 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SnapshotOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Configuration;
+using Akka.Hosting;
+
+namespace Akka.Persistence.Hosting
+{
+    public abstract class SnapshotOptions
+    {
+        private readonly bool _isDefault;
+        
+        protected SnapshotOptions(bool isDefault)
+        {
+            _isDefault = isDefault;
+        }
+        
+        public abstract string Identifier { get; set; }
+        
+        /// <summary>
+        ///     Should corresponding snapshot store table be initialized automatically.
+        ///     <b>Default</b>: false
+        /// </summary>
+        public bool AutoInitialize { get; set; } = false;
+        
+        /// <summary>
+        ///     <para>
+        ///         Default serializer used as manifest serializer when applicable and payload serializer when no
+        ///         specific binding overrides are specified
+        ///     </para>
+        ///     <b>Default</b>: json
+        /// </summary>
+        public string Serializer { get; set; } = "json";
+        
+        public abstract Config DefaultConfig { get; }
+        
+        /// <summary>
+        /// The chain config builder.
+        /// The top <see cref="SnapshotOptions.Build"/> caps the configuration with the outer `akka.persistence.snapshot-store.{id}` HOCON block.
+        /// If you need to add more properties into this block, append them __BEFORE__ calling <c>base.Build()</c>.
+        /// If you need to add more properties outside of this block, append them __AFTER__ calling <c>base.Build()</c>.
+        /// </summary>
+        /// <param name="sb"><see cref="StringBuilder"/> instance from lower chain</param>
+        /// <returns>The fully built <see cref="StringBuilder"/> containing the `akka.persistence.snapshot-store.{id}` HOCON block.</returns>
+        /// <exception cref="Exception">Thrown when <see cref="Identifier"/> is null or whitespace</exception>
+        protected virtual StringBuilder Build(StringBuilder sb)
+        {
+            if(string.IsNullOrWhiteSpace(Identifier))
+                throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} is null or whitespace");
+            
+            var (illegal, illegalChars) = Identifier.IsIllegalHoconKey();
+            if (illegal)
+            {
+                throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} contains illegal character(s) {string.Join(", ", illegalChars)}");
+            }
+            
+            sb.Insert(0, $"akka.persistence.snapshot-store.{Identifier.ToHocon()} {{{Environment.NewLine}");
+            sb.AppendLine($"serializer = {Serializer.ToHocon()}");
+            sb.AppendLine($"auto-initialize = {AutoInitialize.ToHocon()}");
+            sb.AppendLine("}");
+            
+            if (_isDefault)
+                sb.AppendLine($"akka.persistence.snapshot-store.plugin = akka.persistence.snapshot-store.{Identifier.ToHocon()}");
+            
+            return sb;
+        }
+        
+        public Config ToConfig()
+            => ToString();
+        
+        public sealed override string ToString()
+            => Build(new StringBuilder()).ToString();
+    }
+}

--- a/src/Akka.Persistence.Hosting/SnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SnapshotOptions.cs
@@ -53,8 +53,8 @@ namespace Akka.Persistence.Hosting
             if(string.IsNullOrWhiteSpace(Identifier))
                 throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} is null or whitespace");
             
-            var (illegal, illegalChars) = Identifier.IsIllegalHoconKey();
-            if (illegal)
+            var illegalChars = Identifier.IsIllegalHoconKey();
+            if (illegalChars.Length > 0)
             {
                 throw new Exception($"Invalid {GetType()}, {nameof(Identifier)} contains illegal character(s) {string.Join(", ", illegalChars)}");
             }

--- a/src/Akka.Persistence.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/SqlJournalOptions.cs
@@ -34,10 +34,31 @@ namespace Akka.Persistence.Hosting
         /// </summary>
         public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
+        /// <summary>
+        ///     <para>
+        ///         The database schema name to table corresponding with persistent journal
+        ///     </para>
+        ///     <b>NOTE</b> When implementing this options, override this property with a valid default schema name for
+        ///     the SQL database
+        /// </summary>
         public abstract string SchemaName { get; set; }
 
+        /// <summary>
+        ///     <para>
+        ///         The database journal table name corresponding with persistent journal
+        ///     </para>
+        ///     <b>NOTE</b> When implementing this options, override this property with a valid default table name for
+        ///     the SQL database
+        /// </summary>
         public abstract string TableName { get; set; }
 
+        /// <summary>
+        ///     <para>
+        ///         The database metadata table name corresponding with persistent journal
+        ///     </para>
+        ///     <b>NOTE</b> When implementing this options, override this property with a valid default metadata table
+        ///     name for the SQL database
+        /// </summary>
         public abstract string MetadataTableName { get; set; }
 
         /// <summary>

--- a/src/Akka.Persistence.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/SqlJournalOptions.cs
@@ -11,6 +11,10 @@ using Akka.Hosting;
 #nullable enable
 namespace Akka.Persistence.Hosting
 {
+    /// <summary>
+    /// Base class for all SQL-based journal options class. If you're writing an options class for no-SQL or other kind
+    /// of plugins, use <see cref="JournalOptions"/> instead.
+    /// </summary>
     public abstract class SqlJournalOptions: JournalOptions
     {
         protected SqlJournalOptions(bool isDefault): base(isDefault)

--- a/src/Akka.Persistence.Hosting/SqlJournalOptions.cs
+++ b/src/Akka.Persistence.Hosting/SqlJournalOptions.cs
@@ -1,0 +1,60 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlJournalOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Hosting;
+
+#nullable enable
+namespace Akka.Persistence.Hosting
+{
+    public abstract class SqlJournalOptions: JournalOptions
+    {
+        protected SqlJournalOptions(bool isDefault): base(isDefault)
+        {
+        }
+
+        /// <summary>
+        ///     Connection string used for database access
+        /// </summary>
+        public string ConnectionString { get; set; } = "";
+
+        /// <summary>
+        ///     <para>
+        ///         SQL commands timeout.
+        ///     </para>
+        ///     <b>Default</b>: 30 seconds
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        public abstract string SchemaName { get; set; }
+
+        public abstract string TableName { get; set; }
+
+        public abstract string MetadataTableName { get; set; }
+
+        /// <summary>
+        ///     <para>
+        ///         Uses the CommandBehavior.SequentialAccess when creating DB commands, providing a performance
+        ///         improvement for reading large BLOBS.
+        ///     </para>
+        ///     <b>Default</b>: false
+        /// </summary>
+        public abstract bool SequentialAccess { get; set; }
+
+        protected override StringBuilder Build(StringBuilder sb)
+        {
+            sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
+            sb.AppendLine($"connection-timeout = {ConnectionTimeout.ToHocon()}");
+            sb.AppendLine($"schema-name = {SchemaName.ToHocon()}");
+            sb.AppendLine($"table-name = {TableName.ToHocon()}");
+            sb.AppendLine($"metadata-table-name = {MetadataTableName.ToHocon()}");
+            sb.AppendLine($"sequential-access = {SequentialAccess.ToHocon()}");
+
+            return base.Build(sb);
+        }
+    }
+}

--- a/src/Akka.Persistence.Hosting/SqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SqlSnapshotOptions.cs
@@ -32,14 +32,30 @@ namespace Akka.Persistence.Hosting
         /// </summary>
         public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
+        /// <summary>
+        ///     <para>
+        ///         The database schema name to table corresponding with persistent snapshot store
+        ///     </para>
+        ///     <b>NOTE</b> When implementing this options, override this property with a valid default schema name for
+        ///     the SQL database
+        /// </summary>
         public abstract string SchemaName { get; set; }
 
+        /// <summary>
+        ///     <para>
+        ///         The database snapshot store table name corresponding with persistent journal
+        ///     </para>
+        ///     <b>NOTE</b> When implementing this options, override this property with a valid default table name for
+        ///     the SQL database
+        /// </summary>
         public abstract string TableName { get; set; }
 
         /// <summary>
-        ///     Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance
-        ///     improvement for reading large BLOBS.
-        ///     <b>Default</b>: false
+        ///     <para>
+        ///         Uses the CommandBehavior.SequentialAccess when creating DB commands, providing a performance
+        ///         improvement for reading large BLOBS.
+        ///     </para>
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public abstract bool SequentialAccess { get; set; }
 

--- a/src/Akka.Persistence.Hosting/SqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SqlSnapshotOptions.cs
@@ -11,6 +11,10 @@ using Akka.Hosting;
 #nullable enable
 namespace Akka.Persistence.Hosting
 {
+    /// <summary>
+    /// Base class for all SQL-based snapshot-store options class. If you're writing an options class for no-SQL or
+    /// other kind of plugins, use <see cref="SnapshotOptions"/> instead.
+    /// </summary>
     public abstract class SqlSnapshotOptions: SnapshotOptions
     {
         protected SqlSnapshotOptions(bool isDefault): base(isDefault)

--- a/src/Akka.Persistence.Hosting/SqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.Hosting/SqlSnapshotOptions.cs
@@ -1,0 +1,54 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="SqlSnapshotOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Hosting;
+
+#nullable enable
+namespace Akka.Persistence.Hosting
+{
+    public abstract class SqlSnapshotOptions: SnapshotOptions
+    {
+        protected SqlSnapshotOptions(bool isDefault): base(isDefault)
+        {
+        }
+
+        /// <summary>
+        ///     Connection string used for database access.
+        /// </summary>
+        public string ConnectionString { get; set; } = "";
+
+        /// <summary>
+        ///     SQL commands timeout.
+        ///     <b>Default</b>: 30 seconds
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        public abstract string SchemaName { get; set; }
+
+        public abstract string TableName { get; set; }
+
+        /// <summary>
+        ///     Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance
+        ///     improvement for reading large BLOBS.
+        ///     <b>Default</b>: false
+        /// </summary>
+        public abstract bool SequentialAccess { get; set; }
+
+        protected override StringBuilder Build(StringBuilder sb)
+        {
+            sb.AppendLine($"connection-string = {ConnectionString.ToHocon()}");
+            sb.AppendLine($"connection-timeout = {ConnectionTimeout.ToHocon()}");
+            sb.AppendLine($"schema-name = {SchemaName.ToHocon()}");
+            sb.AppendLine($"table-name = {TableName.ToHocon()}");
+            sb.AppendLine($"sequential-access = {SequentialAccess.ToHocon()}");
+
+            return base.Build(sb);
+        }
+
+    }
+}

--- a/src/Akka.Persistence.Hosting/Utils.cs
+++ b/src/Akka.Persistence.Hosting/Utils.cs
@@ -13,25 +13,22 @@ namespace Akka.Persistence.Hosting
 {
     public static class Utils
     {
-        // This regex is conservative. Normally '.' and '/' is allowed in a HOCON literal, but we'll ban it
-        // just because it'll make our life harder in the future.
-        private static readonly Regex IllegalRegex = new (
-            "([\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF\u0009\u000A\u000B\u000C\u000D\u001C\u001D\u001E\u001F$\"{}\\[\\]:=,#`^?!@*&\\./])", 
-            RegexOptions.Compiled);
+        // This illegal character list is conservative. Normally '.' and '/' is allowed in a HOCON literal, but we'll
+        // ban it just because it'll make our life harder in the future.
+        private const string IllegalChars = "$\"{}[]:=,#`^?!@*&\\./";
 
-        public static (bool, string[]) IsIllegalHoconKey(this string s)
+        public static string[] IsIllegalHoconKey(this string s)
         {
-            var match = IllegalRegex.Match(s);
-            if (!match.Success)
-                return (false, Array.Empty<string>());
-
             var illegals = new List<string>();
-            while (match.Success)
+            foreach (var c in s)
             {
-                illegals.Add(match.Value);
-                match = match.NextMatch();
+                if(IllegalChars.Contains(c))
+                    illegals.Add($"{c}");
+                else if(char.IsWhiteSpace(c))
+                    illegals.Add($"\\u{(int)c:X4}");
             }
-            return (true, illegals.Distinct().Select(c => char.IsWhiteSpace(c[0]) ? $"\\u{(int)c[0]:X4}" : c).ToArray());
+
+            return illegals.Distinct().ToArray();
         }
     }
 }

--- a/src/Akka.Persistence.Hosting/Utils.cs
+++ b/src/Akka.Persistence.Hosting/Utils.cs
@@ -4,14 +4,12 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Akka.Persistence.Hosting
 {
-    public static class Utils
+    internal static class Utils
     {
         // This illegal character list is conservative. Normally '.' and '/' is allowed in a HOCON literal, but we'll
         // ban it just because it'll make our life harder in the future.

--- a/src/Akka.Persistence.Hosting/Utils.cs
+++ b/src/Akka.Persistence.Hosting/Utils.cs
@@ -1,0 +1,37 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Utils.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Akka.Persistence.Hosting
+{
+    public static class Utils
+    {
+        // This regex is conservative. Normally '.' and '/' is allowed in a HOCON literal, but we'll ban it
+        // just because it'll make our life harder in the future.
+        private static readonly Regex IllegalRegex = new (
+            "([\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF\u0009\u000A\u000B\u000C\u000D\u001C\u001D\u001E\u001F$\"{}\\[\\]:=,#`^?!@*&\\./])", 
+            RegexOptions.Compiled);
+
+        public static (bool, string[]) IsIllegalHoconKey(this string s)
+        {
+            var match = IllegalRegex.Match(s);
+            if (!match.Success)
+                return (false, Array.Empty<string>());
+
+            var illegals = new List<string>();
+            while (match.Success)
+            {
+                illegals.Add(match.Value);
+                match = match.NextMatch();
+            }
+            return (true, illegals.Distinct().Select(c => char.IsWhiteSpace(c[0]) ? $"\\u{(int)c[0]:X4}" : c).ToArray());
+        }
+    }
+}

--- a/src/Akka.Persistence.PostgreSql.Hosting/AkkaPersistencePostgreSqlHostingExtensions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/AkkaPersistencePostgreSqlHostingExtensions.cs
@@ -21,37 +21,60 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     Connection string used for database access.
         /// </param>
         /// <param name="mode">
-        ///     Determines which settings should be added by this method call.
+        ///     <para>
+        ///         Determines which settings should be added by this method call.
+        ///     </para>
+        ///     <i>Default</i>: <see cref="PersistenceMode.Both"/>
         /// </param>
         /// <param name="schemaName">
-        ///     The schema name for the journal and snapshot store table.
+        ///     <para>
+        ///         The schema name for the journal and snapshot store table.
+        ///     </para>
+        ///     <i>Default</i>: <c>"public"</c>
         /// </param>
         /// <param name="autoInitialize">
-        ///     Should the SQL store table be initialized automatically.
+        ///     <para>
+        ///         Should the SQL store table be initialized automatically.
+        ///     </para>
+        ///     <i>Default</i>: <c>false</c>
         /// </param>
         /// <param name="storedAsType">
-        ///     Determines how data are being de/serialized into the table.
+        ///     <para>
+        ///         Determines how data are being de/serialized into the table.
+        ///     </para>
+        ///     <i>Default</i>: <see cref="StoredAsType.ByteA"/>
         /// </param>
         /// <param name="sequentialAccess">
-        ///     Uses the `CommandBehavior.SequentialAccess` when creating SQL commands, providing a performance
-        ///     improvement for reading large BLOBS.
+        ///     <para>
+        ///         Uses the `CommandBehavior.SequentialAccess` when creating SQL commands, providing a performance
+        ///         improvement for reading large BLOBS.
+        ///     </para>
+        ///     <i>Default</i>: <c>false</c>
         /// </param>
         /// <param name="useBigintIdentityForOrderingColumn">
-        ///     When set to true, persistence will use `BIGINT` and `GENERATED ALWAYS AS IDENTITY` for journal table
-        ///     schema creation.
+        ///     <para>
+        ///         When set to true, persistence will use `BIGINT` and `GENERATED ALWAYS AS IDENTITY` for journal table
+        ///         schema creation.
+        ///     </para>
+        ///     <i>Default</i>: <c>false</c>
         /// </param>
         /// <param name="journalBuilder">
         ///     <para>
         ///         An <see cref="Action{T}"/> used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance.
         ///     </para>
-        ///     <b>Default</b>: <c>null</c>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
-        /// <param name="pluginIdentifier">The configuration identifier for the plugins</param>
+        /// <param name="pluginIdentifier">
+        ///     <para>
+        ///         The configuration identifier for the plugins
+        ///     </para>
+        ///     <i>Default</i>: <c>"postgresql"</c>
+        /// </param>
         /// <param name="isDefaultPlugin">
         ///     <para>
         ///         A <c>bool</c> flag to set the plugin as the default persistence plugin for the <see cref="ActorSystem"/>
         ///     </para>
-        ///     <b>Default</b>: <c>true</c>
+        ///     <i>Default</i>: <c>true</c>
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
@@ -111,22 +134,32 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     The builder instance being configured.
         /// </param>
         /// <param name="snapshotOptionConfigurator">
-        ///     An <see cref="Action{T}"/> that modifies an instance of <see cref="PostgreSqlSnapshotOptions"/>,
-        ///     used to configure the snapshot store plugin
+        ///     <para>
+        ///         An <see cref="Action{T}"/> that modifies an instance of <see cref="PostgreSqlSnapshotOptions"/>,
+        ///         used to configure the snapshot store plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <param name="journalOptionConfigurator">
-        ///     An <see cref="Action{T}"/> that modifies an instance of <see cref="PostgreSqlJournalOptions"/>,
-        ///     used to configure the journal plugin
+        ///     <para>
+        ///         An <see cref="Action{T}"/> that modifies an instance of <see cref="PostgreSqlJournalOptions"/>,
+        ///         used to configure the journal plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <param name="isDefaultPlugin">
         ///     <para>
         ///         A <c>bool</c> flag to set the plugin as the default persistence plugin for the <see cref="ActorSystem"/>
         ///     </para>
-        ///     <b>Default</b>: <c>true</c>
+        ///     <i>Default</i>: <c>true</c>
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when both <param name="journalOptionConfigurator"/> and
+        ///     <param name="snapshotOptionConfigurator"/> are null.
+        /// </exception>
         public static AkkaConfigurationBuilder WithPostgreSqlPersistence(
             this AkkaConfigurationBuilder builder,
             Action<PostgreSqlJournalOptions>? journalOptionConfigurator = null,
@@ -160,14 +193,23 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     The builder instance being configured.
         /// </param>
         /// <param name="snapshotOptions">
-        ///     An instance of <see cref="PostgreSqlSnapshotOptions"/>, used to configure the snapshot store plugin
+        ///     <para>
+        ///         An instance of <see cref="PostgreSqlSnapshotOptions"/>, used to configure the snapshot store plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <param name="journalOptions">
-        ///     An instance of <see cref="PostgreSqlJournalOptions"/>, used to configure the journal plugin
+        ///     <para>
+        ///         An instance of <see cref="PostgreSqlJournalOptions"/>, used to configure the journal plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when both <param name="journalOptions"/> and <param name="snapshotOptions"/> are null.
+        /// </exception>
         public static AkkaConfigurationBuilder WithPostgreSqlPersistence(
             this AkkaConfigurationBuilder builder,
             PostgreSqlJournalOptions? journalOptions = null,

--- a/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlJournalOptions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlJournalOptions.cs
@@ -12,10 +12,19 @@ using Akka.Persistence.Hosting;
 #nullable enable
 namespace Akka.Persistence.PostgreSql.Hosting
 {
+    /// <summary>
+    /// Akka.Hosting options class to set up PostgreSql persistence journal.
+    /// </summary>
     public sealed class PostgreSqlJournalOptions: SqlJournalOptions
     {
-        internal static readonly Config Default = PostgreSqlPersistence.DefaultConfiguration();
+        private static readonly Config Default = PostgreSqlPersistence.DefaultConfiguration()
+            .GetConfig(PostgreSqlJournalSettings.JournalConfigPath);
         
+        /// <summary>
+        /// Create a new instance of <see cref="PostgreSqlJournalOptions"/>
+        /// </summary>
+        /// <param name="isDefaultPlugin">Indicates if this journal configuration should be the default configuration for all persistence</param>
+        /// <param name="identifier">The journal configuration identifier, <b>default</b>: "postgresql"</param>
         public PostgreSqlJournalOptions(bool isDefaultPlugin, string identifier = "postgresql") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -73,13 +82,10 @@ namespace Akka.Persistence.PostgreSql.Hosting
         /// </summary>
         public bool UseBigIntIdentityForOrderingColumn { get; set; } = false;
 
-        public override Config DefaultConfig => Default;
+        protected override Config InternalDefaultConfig => Default;
 
         protected override StringBuilder Build(StringBuilder sb)
         {
-            sb.AppendLine("class = \"Akka.Persistence.PostgreSql.Journal.PostgreSqlJournal, Akka.Persistence.PostgreSql\"");
-            sb.AppendLine("plugin-dispatcher = \"akka.actor.default-dispatcher\"");
-            sb.AppendLine("timestamp-provider = \"Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common\"");
             sb.AppendLine($"use-bigint-identity-for-ordering-column = {(UseBigIntIdentityForOrderingColumn ? "on" : "off")}");
             sb.AppendLine($"stored-as = {StoredAs.ToHocon()}");
             

--- a/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlJournalOptions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlJournalOptions.cs
@@ -1,0 +1,89 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlJournalOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Configuration;
+using Akka.Persistence.Hosting;
+
+#nullable enable
+namespace Akka.Persistence.PostgreSql.Hosting
+{
+    public sealed class PostgreSqlJournalOptions: SqlJournalOptions
+    {
+        internal static readonly Config Default = PostgreSqlPersistence.DefaultConfiguration();
+        
+        public PostgreSqlJournalOptions(bool isDefaultPlugin, string identifier = "postgresql") : base(isDefaultPlugin)
+        {
+            Identifier = identifier;
+        }
+        
+        /// <summary>
+        ///     <para>
+        ///         The plugin identifier for this persistence plugin
+        ///     </para>
+        ///     <b>Default</b>: "postgresql"
+        /// </summary>
+        public override string Identifier { get; set; }
+        
+        /// <summary>
+        ///     <para>
+        ///         PostgreSQL schema name to table corresponding with persistent journal.
+        ///     </para>
+        ///     <b>Default</b>: "public"
+        /// </summary>
+        public override string SchemaName { get; set; } = "public";
+        
+        /// <summary>
+        ///     <para>
+        ///         PostgreSQL table corresponding with persistent journal.
+        ///     </para>
+        ///     <b>Default</b>: "event_journal"
+        /// </summary>
+        public override string TableName { get; set; } = "event_journal";
+        
+        /// <summary>
+        ///     <para>
+        ///         PostgreSQL table corresponding with persistent journal metadata.
+        ///     </para>
+        ///     <b>Default</b>: "metadata"
+        /// </summary>
+        public override string MetadataTableName { get; set; } = "metadata";
+
+        /// <summary>
+        ///     <para>
+        ///         Uses the CommandBehavior.SequentialAccess when creating DB commands, providing a performance
+        ///         improvement for reading large BLOBS.
+        ///     </para>
+        ///     <b>Default</b>: false
+        /// </summary>
+        public override bool SequentialAccess { get; set; } = false;
+        
+        /// <summary>
+        /// Postgres data type for payload column
+        /// </summary>
+        public StoredAsType StoredAs { get; set; } = StoredAsType.ByteA;
+        
+        /// <summary>
+        /// When turned on, persistence will use `BIGINT` and `GENERATED ALWAYS AS IDENTITY` for the ordering column
+        /// in the journal table during schema creation.
+        /// </summary>
+        public bool UseBigIntIdentityForOrderingColumn { get; set; } = false;
+
+        public override Config DefaultConfig => Default;
+
+        protected override StringBuilder Build(StringBuilder sb)
+        {
+            sb.AppendLine("class = \"Akka.Persistence.PostgreSql.Journal.PostgreSqlJournal, Akka.Persistence.PostgreSql\"");
+            sb.AppendLine("plugin-dispatcher = \"akka.actor.default-dispatcher\"");
+            sb.AppendLine("timestamp-provider = \"Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common\"");
+            sb.AppendLine($"use-bigint-identity-for-ordering-column = {(UseBigIntIdentityForOrderingColumn ? "on" : "off")}");
+            sb.AppendLine($"stored-as = {StoredAs.ToHocon()}");
+            
+            return base.Build(sb);
+        }
+    }
+}

--- a/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlJournalOptions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlJournalOptions.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         /// Create a new instance of <see cref="PostgreSqlJournalOptions"/>
         /// </summary>
         /// <param name="isDefaultPlugin">Indicates if this journal configuration should be the default configuration for all persistence</param>
-        /// <param name="identifier">The journal configuration identifier, <b>default</b>: "postgresql"</param>
+        /// <param name="identifier">The journal configuration identifier. <i>Default</i>: "postgresql"</param>
         public PostgreSqlJournalOptions(bool isDefaultPlugin, string identifier = "postgresql") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -34,7 +34,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         The plugin identifier for this persistence plugin
         ///     </para>
-        ///     <b>Default</b>: "postgresql"
+        ///     <b>Default</b>: <c>"postgresql"</c>
         /// </summary>
         public override string Identifier { get; set; }
         
@@ -42,7 +42,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         PostgreSQL schema name to table corresponding with persistent journal.
         ///     </para>
-        ///     <b>Default</b>: "public"
+        ///     <b>Default</b>: <c>"public"</c>
         /// </summary>
         public override string SchemaName { get; set; } = "public";
         
@@ -50,7 +50,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         PostgreSQL table corresponding with persistent journal.
         ///     </para>
-        ///     <b>Default</b>: "event_journal"
+        ///     <b>Default</b>: <c>"event_journal"</c>
         /// </summary>
         public override string TableName { get; set; } = "event_journal";
         
@@ -58,7 +58,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         PostgreSQL table corresponding with persistent journal metadata.
         ///     </para>
-        ///     <b>Default</b>: "metadata"
+        ///     <b>Default</b>: <c>"metadata"</c>
         /// </summary>
         public override string MetadataTableName { get; set; } = "metadata";
 
@@ -67,18 +67,24 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///         Uses the CommandBehavior.SequentialAccess when creating DB commands, providing a performance
         ///         improvement for reading large BLOBS.
         ///     </para>
-        ///     <b>Default</b>: false
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public override bool SequentialAccess { get; set; } = false;
         
         /// <summary>
-        /// Postgres data type for payload column
+        ///     <para>
+        ///         Postgres data type for payload column
+        ///     </para>
+        ///     <b>Default</b>: <see cref="StoredAsType.ByteA"/>
         /// </summary>
         public StoredAsType StoredAs { get; set; } = StoredAsType.ByteA;
         
         /// <summary>
-        /// When turned on, persistence will use `BIGINT` and `GENERATED ALWAYS AS IDENTITY` for the ordering column
-        /// in the journal table during schema creation.
+        ///     <para>
+        ///         When turned on, persistence will use `BIGINT` and `GENERATED ALWAYS AS IDENTITY` for the ordering
+        ///         column in the journal table during schema creation.
+        ///     </para>
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public bool UseBigIntIdentityForOrderingColumn { get; set; } = false;
 

--- a/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlSnapshotOptions.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         /// Create a new instance of <see cref="PostgreSqlSnapshotOptions"/>
         /// </summary>
         /// <param name="isDefaultPlugin">Indicates if this snapshot store configuration should be the default configuration for all persistence</param>
-        /// <param name="identifier">The snapshot store configuration identifier, <b>default</b>: "postgresql"</param>
+        /// <param name="identifier">The snapshot store configuration identifier, <i>Default</i>: "postgresql"</param>
         public PostgreSqlSnapshotOptions(bool isDefaultPlugin, string identifier = "postgresql") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -34,7 +34,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         The plugin identifier for this persistence plugin
         ///     </para>
-        ///     <b>Default</b>: "postgresql"
+        ///     <b>Default</b>: <c>"postgresql"</c>
         /// </summary>
         public override string Identifier { get; set; }
         
@@ -42,7 +42,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         PostgreSQL schema name to table corresponding with persistent snapshot store.
         ///     </para>
-        ///     <b>Default</b>: "public"
+        ///     <b>Default</b>: <c>"public"</c>
         /// </summary>
         public override string SchemaName { get; set; } = "public";
         
@@ -50,14 +50,16 @@ namespace Akka.Persistence.PostgreSql.Hosting
         ///     <para>
         ///         PostgreSQL table corresponding with persistent snapshot store.
         ///     </para>
-        ///     <b>Default</b>: "snapshot_store"
+        ///     <b>Default</b>: <c>"snapshot_store"</c>
         /// </summary>
         public override string TableName { get; set; } = "snapshot_store";
         
         /// <summary>
-        ///     Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance
-        ///     improvement for reading large BLOBS.
-        ///     <b>Default</b>: false
+        ///     <para>
+        ///         Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance
+        ///         improvement for reading large BLOBS.
+        ///     </para>
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public override bool SequentialAccess { get; set; } = false;
 

--- a/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlSnapshotOptions.cs
@@ -12,8 +12,19 @@ using Akka.Persistence.Hosting;
 #nullable enable
 namespace Akka.Persistence.PostgreSql.Hosting
 {
+    /// <summary>
+    /// Akka.Hosting options class to set up PostgreSql persistence snapshot store.
+    /// </summary>
     public sealed class PostgreSqlSnapshotOptions: SqlSnapshotOptions
     {
+        private static readonly Config Default = PostgreSqlPersistence.DefaultConfiguration()
+            .GetConfig(PostgreSqlSnapshotStoreSettings.SnapshotStoreConfigPath);
+        
+        /// <summary>
+        /// Create a new instance of <see cref="PostgreSqlSnapshotOptions"/>
+        /// </summary>
+        /// <param name="isDefaultPlugin">Indicates if this snapshot store configuration should be the default configuration for all persistence</param>
+        /// <param name="identifier">The snapshot store configuration identifier, <b>default</b>: "postgresql"</param>
         public PostgreSqlSnapshotOptions(bool isDefaultPlugin, string identifier = "postgresql") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -58,12 +69,10 @@ namespace Akka.Persistence.PostgreSql.Hosting
         /// </summary>
         public StoredAsType StoredAs { get; set; } = StoredAsType.ByteA;
 
-        public override Config DefaultConfig => PostgreSqlJournalOptions.Default;
+        protected override Config InternalDefaultConfig => Default;
 
         protected override StringBuilder Build(StringBuilder sb)
         {
-            sb.AppendLine("class = \"Akka.Persistence.PostgreSql.Snapshot.PostgreSqlSnapshotStore, Akka.Persistence.PostgreSql\"");
-            sb.AppendLine("plugin-dispatcher = \"akka.actor.default-dispatcher\"");
             sb.AppendLine($"stored-as = {StoredAs.ToHocon()}");
 
             return base.Build(sb);

--- a/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlSnapshotOptions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/PostgreSqlSnapshotOptions.cs
@@ -1,0 +1,72 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="PostgreSqlSnapshotOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Configuration;
+using Akka.Persistence.Hosting;
+
+#nullable enable
+namespace Akka.Persistence.PostgreSql.Hosting
+{
+    public sealed class PostgreSqlSnapshotOptions: SqlSnapshotOptions
+    {
+        public PostgreSqlSnapshotOptions(bool isDefaultPlugin, string identifier = "postgresql") : base(isDefaultPlugin)
+        {
+            Identifier = identifier;
+        }
+        
+        /// <summary>
+        ///     <para>
+        ///         The plugin identifier for this persistence plugin
+        ///     </para>
+        ///     <b>Default</b>: "postgresql"
+        /// </summary>
+        public override string Identifier { get; set; }
+        
+        /// <summary>
+        ///     <para>
+        ///         PostgreSQL schema name to table corresponding with persistent snapshot store.
+        ///     </para>
+        ///     <b>Default</b>: "public"
+        /// </summary>
+        public override string SchemaName { get; set; } = "public";
+        
+        /// <summary>
+        ///     <para>
+        ///         PostgreSQL table corresponding with persistent snapshot store.
+        ///     </para>
+        ///     <b>Default</b>: "snapshot_store"
+        /// </summary>
+        public override string TableName { get; set; } = "snapshot_store";
+        
+        /// <summary>
+        ///     Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance
+        ///     improvement for reading large BLOBS.
+        ///     <b>Default</b>: false
+        /// </summary>
+        public override bool SequentialAccess { get; set; } = false;
+
+        /// <summary>
+        ///     <para>
+        ///         Postgres data type for the payload column
+        ///     </para>
+        ///     <b>Default</b>: <see cref="StoredAsType.ByteA"/>
+        /// </summary>
+        public StoredAsType StoredAs { get; set; } = StoredAsType.ByteA;
+
+        public override Config DefaultConfig => PostgreSqlJournalOptions.Default;
+
+        protected override StringBuilder Build(StringBuilder sb)
+        {
+            sb.AppendLine("class = \"Akka.Persistence.PostgreSql.Snapshot.PostgreSqlSnapshotStore, Akka.Persistence.PostgreSql\"");
+            sb.AppendLine("plugin-dispatcher = \"akka.actor.default-dispatcher\"");
+            sb.AppendLine($"stored-as = {StoredAs.ToHocon()}");
+
+            return base.Build(sb);
+        }
+    }
+}

--- a/src/Akka.Persistence.PostgreSql.Hosting/Properties/FriendsOf.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/Properties/FriendsOf.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.Persistence.Hosting.Tests")]

--- a/src/Akka.Persistence.PostgreSql.Hosting/StoredAsExtensions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/StoredAsExtensions.cs
@@ -10,7 +10,7 @@ namespace Akka.Persistence.PostgreSql.Hosting
 {
     public static class StoredAsExtensions
     {
-        public static string ToHocon(this StoredAsType storedAsType)
+        internal static string ToHocon(this StoredAsType storedAsType)
             => storedAsType switch
             {
                 StoredAsType.ByteA => "bytea",

--- a/src/Akka.Persistence.PostgreSql.Hosting/StoredAsExtensions.cs
+++ b/src/Akka.Persistence.PostgreSql.Hosting/StoredAsExtensions.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="StoredAsExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Akka.Persistence.PostgreSql.Hosting
+{
+    public static class StoredAsExtensions
+    {
+        public static string ToHocon(this StoredAsType storedAsType)
+            => storedAsType switch
+            {
+                StoredAsType.ByteA => "bytea",
+                StoredAsType.Json => "json",
+                StoredAsType.JsonB => "jsonb",
+                _ => throw new ArgumentOutOfRangeException(nameof(storedAsType), storedAsType, "Invalid StoredAsType defined.")
+            };
+    }
+}

--- a/src/Akka.Persistence.SqlServer.Hosting/AkkaPersistenceSqlServerHostingExtensions.cs
+++ b/src/Akka.Persistence.SqlServer.Hosting/AkkaPersistenceSqlServerHostingExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using Akka.Actor;
-using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
-using Akka.Persistence.Query.Sql;
 
 #nullable enable
 namespace Akka.Persistence.SqlServer.Hosting
@@ -26,8 +24,14 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     Should the SQL store table be initialized automatically.
         /// </param>
         /// <param name="mode"></param>
-        /// <param name="configurator">
+        /// <param name="journalBuilder">
         ///     An Action delegate used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance.
+        /// </param>
+        /// <param name="isDefaultPlugin">
+        ///     <para>
+        ///         A <c>bool</c> flag to set the plugin as the default persistence plugin for the <see cref="ActorSystem"/>
+        ///     </para>
+        ///     <b>Default</b>: <c>true</c>
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
@@ -37,33 +41,37 @@ namespace Akka.Persistence.SqlServer.Hosting
             this AkkaConfigurationBuilder builder,
             string connectionString,
             PersistenceMode mode = PersistenceMode.Both, 
-            Action<AkkaPersistenceJournalBuilder>? configurator = null,
-            bool autoInitialize = true)
+            Action<AkkaPersistenceJournalBuilder>? journalBuilder = null,
+            bool autoInitialize = true,
+            bool isDefaultPlugin = true)
         {
-            Config journalConfiguration = @$"
-            akka.persistence {{
-                journal {{
-                    plugin = ""akka.persistence.journal.sql-server""
-                    sql-server {{
-                        connection-string = ""{connectionString}""
-                        auto-initialize = {autoInitialize.ToHocon()}
-                    }}
-                }}
-                query.journal.sql.refresh-interval = 1s
-            }}";
+            if (mode == PersistenceMode.SnapshotStore && journalBuilder is { })
+                throw new Exception($"{nameof(journalBuilder)} can only be set when {nameof(mode)} is set to either {PersistenceMode.Both} or {PersistenceMode.Journal}");
+            
+            var journalOpt = new SqlServerJournalOptions(isDefaultPlugin)
+            {
+                ConnectionString = connectionString,
+                AutoInitialize = autoInitialize,
+                QueryRefreshInterval = TimeSpan.FromSeconds(1),
+            };
 
-            Config snapshotStoreConfig = @$"
-            akka.persistence {{
-                snapshot-store {{
-                    plugin = ""akka.persistence.snapshot-store.sql-server""
-                    sql-server {{
-                        connection-string = ""{connectionString}""
-                        auto-initialize = {autoInitialize.ToHocon()}
-                    }}
-                }}
-            }}";
+            var adapters = new AkkaPersistenceJournalBuilder(journalOpt.Identifier, builder);
+            journalBuilder?.Invoke(adapters);
+            journalOpt.Adapters = adapters;
 
-            return builder.WithSqlServerPersistence(journalConfiguration, snapshotStoreConfig, mode, configurator);
+            var snapshotOpt = new SqlServerSnapshotOptions(isDefaultPlugin)
+            {
+                ConnectionString = connectionString,
+                AutoInitialize = autoInitialize,
+            };
+
+            return mode switch
+            {
+                PersistenceMode.Journal => builder.WithSqlServerPersistence(journalOpt, null),
+                PersistenceMode.SnapshotStore => builder.WithSqlServerPersistence(null, snapshotOpt),
+                PersistenceMode.Both => builder.WithSqlServerPersistence(journalOpt, snapshotOpt),
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Invalid PersistenceMode defined.")
+            };
         }
 
         /// <summary>
@@ -72,40 +80,48 @@ namespace Akka.Persistence.SqlServer.Hosting
         /// <param name="builder">
         ///     The builder instance being configured.
         /// </param>
-        /// <param name="journalConfigurator">
+        /// <param name="journalOptionConfigurator">
         ///     An Action delegate to configure a <see cref="SqlServerJournalOptions"/> instance.
         /// </param>
-        /// <param name="snapshotConfigurator">
+        /// <param name="snapshotOptionConfigurator">
         ///     An Action delegate to configure a <see cref="SqlServerSnapshotOptions"/> instance.
         /// </param>
-        /// <param name="configurator">
-        ///     An Action delegate used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance.
+        /// <param name="isDefaultPlugin">
+        ///     <para>
+        ///         A <c>bool</c> flag to set the plugin as the default persistence plugin for the <see cref="ActorSystem"/>
+        ///     </para>
+        ///     <b>Default</b>: <c>true</c>
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
         /// <exception cref="ArgumentException">
-        ///     Thrown when both <paramref name="journalConfigurator"/> and <paramref name="snapshotConfigurator"/> are null.
+        ///     Thrown when both <paramref name="journalOptionConfigurator"/> and <paramref name="snapshotOptionConfigurator"/> are null.
         /// </exception>
         public static AkkaConfigurationBuilder WithSqlServerPersistence(
             this AkkaConfigurationBuilder builder,
-            Action<SqlServerJournalOptions>? journalConfigurator = null,
-            Action<SqlServerSnapshotOptions>? snapshotConfigurator = null,
-            Action<AkkaPersistenceJournalBuilder>? configurator = null)
+            Action<SqlServerJournalOptions>? journalOptionConfigurator = null,
+            Action<SqlServerSnapshotOptions>? snapshotOptionConfigurator = null,
+            bool isDefaultPlugin = true)
         {
-            var journalOptions = new SqlServerJournalOptions();
-            journalConfigurator?.Invoke(journalOptions);
-
-            var snapshotOptions = new SqlServerSnapshotOptions();
-            snapshotConfigurator?.Invoke(snapshotOptions);
-
-            return (journalConfigurator, snapshotConfigurator) switch
+            if (journalOptionConfigurator is null && snapshotOptionConfigurator is null)
+                throw new ArgumentException($"{nameof(journalOptionConfigurator)} and {nameof(snapshotOptionConfigurator)} could not both be null");
+            
+            SqlServerJournalOptions? journalOptions = null;
+            if (journalOptionConfigurator is { })
             {
-                (null, null) => throw new ArgumentException($"{nameof(journalConfigurator)} and {nameof(snapshotConfigurator)} could not both be null"),
-                (null, _) => builder.WithSqlServerPersistence(Config.Empty, snapshotOptions.ToConfig(), PersistenceMode.SnapshotStore, configurator),
-                (_, null) => builder.WithSqlServerPersistence(journalOptions.ToConfig(), Config.Empty, PersistenceMode.Journal, configurator),
-                (_, _) => builder.WithSqlServerPersistence(journalOptions.ToConfig(), snapshotOptions.ToConfig(), PersistenceMode.Both, configurator),
-            };
+                journalOptions = new SqlServerJournalOptions(isDefaultPlugin);
+                journalOptionConfigurator(journalOptions);
+            }
+
+            SqlServerSnapshotOptions? snapshotOptions = null;
+            if (snapshotOptionConfigurator is { })
+            {
+                snapshotOptions = new SqlServerSnapshotOptions(isDefaultPlugin);
+                snapshotOptionConfigurator(snapshotOptions);
+            }
+
+            return builder.WithSqlServerPersistence(journalOptions, snapshotOptions);
         }
 
         /// <summary>
@@ -120,9 +136,6 @@ namespace Akka.Persistence.SqlServer.Hosting
         /// <param name="snapshotOptions">
         ///     An <see cref="SqlServerSnapshotOptions"/> instance to configure the SqlServer snapshot store.
         /// </param>
-        /// <param name="configurator">
-        ///     An Action delegate used to configure a <see cref="AkkaPersistenceJournalBuilder"/> instance.
-        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
@@ -132,58 +145,32 @@ namespace Akka.Persistence.SqlServer.Hosting
         public static AkkaConfigurationBuilder WithSqlServerPersistence(
             this AkkaConfigurationBuilder builder,
             SqlServerJournalOptions? journalOptions = null,
-            SqlServerSnapshotOptions? snapshotOptions = null,
-            Action<AkkaPersistenceJournalBuilder>? configurator = null)
+            SqlServerSnapshotOptions? snapshotOptions = null)
         {
-            var mode = (journalOptions, snapshotOptions) switch
+            if (journalOptions is null && snapshotOptions is null)
+                throw new ArgumentException($"{nameof(journalOptions)} and {nameof(snapshotOptions)} could not both be null");
+            
+            return (journalOptions, snapshotOptions) switch
             {
-                (null, null) => throw new ArgumentException($"{nameof(journalOptions)} and {nameof(snapshotOptions)} could not both be null"),
-                (null, _) => PersistenceMode.SnapshotStore,
-                (_, null) => PersistenceMode.Journal,
-                (_, _) => PersistenceMode.Both
+                (null, null) => 
+                    throw new ArgumentException($"{nameof(journalOptions)} and {nameof(snapshotOptions)} could not both be null"),
+                
+                (_, null) => 
+                    builder
+                        .AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend)
+                        .AddHocon(SqlServerPersistence.DefaultConfiguration(), HoconAddMode.Append),
+                
+                (null, _) => 
+                    builder
+                        .AddHocon(snapshotOptions.ToConfig(), HoconAddMode.Prepend)
+                        .AddHocon(SqlServerPersistence.DefaultConfiguration(), HoconAddMode.Append),
+                
+                (_, _) => 
+                    builder
+                        .AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend)
+                        .AddHocon(snapshotOptions.ToConfig(), HoconAddMode.Prepend)
+                        .AddHocon(SqlServerPersistence.DefaultConfiguration(), HoconAddMode.Append),
             };
-            
-            return builder.WithSqlServerPersistence(
-                journalConfiguration: journalOptions?.ToConfig() ?? Config.Empty,
-                snapshotStoreConfig: snapshotOptions?.ToConfig() ?? Config.Empty,
-                mode: mode, 
-                configurator: configurator);
-        }
-        
-        private static AkkaConfigurationBuilder WithSqlServerPersistence(
-            this AkkaConfigurationBuilder builder,
-            Config journalConfiguration,
-            Config snapshotStoreConfig,
-            PersistenceMode mode = PersistenceMode.Both, 
-            Action<AkkaPersistenceJournalBuilder>? configurator = null)
-        {
-            switch (mode)
-            {
-                case PersistenceMode.Both:
-                    builder.AddHocon(journalConfiguration, HoconAddMode.Prepend);
-                    builder.AddHocon(snapshotStoreConfig, HoconAddMode.Prepend);
-                    builder.AddHocon(SqlReadJournal.DefaultConfiguration(), HoconAddMode.Append);
-                    break;
-                
-                case PersistenceMode.Journal:
-                    builder.AddHocon(journalConfiguration, HoconAddMode.Prepend);
-                    builder.AddHocon(SqlReadJournal.DefaultConfiguration(), HoconAddMode.Append);
-                    break;
-                
-                case PersistenceMode.SnapshotStore:
-                    builder.AddHocon(snapshotStoreConfig, HoconAddMode.Prepend);
-                    break;
-                
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mode), mode, "Invalid SqlPersistenceMode defined.");
-            }
-            
-            if (configurator != null) // configure event adapters
-            {
-                builder.WithJournal("sql-server", configurator);
-            }
-
-            return builder.AddHocon(SqlServerPersistence.DefaultConfiguration(), HoconAddMode.Append);
         }
     }
 }

--- a/src/Akka.Persistence.SqlServer.Hosting/AkkaPersistenceSqlServerHostingExtensions.cs
+++ b/src/Akka.Persistence.SqlServer.Hosting/AkkaPersistenceSqlServerHostingExtensions.cs
@@ -21,13 +21,29 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     Connection string used for database access.
         /// </param>
         /// <param name="autoInitialize">
-        ///     Should the SQL store table be initialized automatically.
+        ///     <para>
+        ///         Should the SQL store table be initialized automatically.
+        ///     </para>
+        ///     <i>Default</i>: <c>false</c>
         /// </param>
-        /// <param name="mode"></param>
+        /// <param name="mode">
+        ///     <para>
+        ///         Determines which settings should be added by this method call.
+        ///     </para>
+        ///     <i>Default</i>: <see cref="PersistenceMode.Both"/>
+        /// </param>
         /// <param name="journalBuilder">
-        ///     An Action delegate used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance.
+        ///     <para>
+        ///         An <see cref="Action{T}"/> used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance.
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
-        /// <param name="pluginIdentifier">The configuration identifier for the plugins</param>
+        /// <param name="pluginIdentifier">
+        ///     <para>
+        ///         The configuration identifier for the plugins
+        ///     </para>
+        ///     <i>Default</i>: <c>"sql-server"</c>
+        /// </param>
         /// <param name="isDefaultPlugin">
         ///     <para>
         ///         A <c>bool</c> flag to set the plugin as the default persistence plugin for the <see cref="ActorSystem"/>
@@ -37,7 +53,10 @@ namespace Akka.Persistence.SqlServer.Hosting
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     Thrown when <see cref="journalBuilder"/> is set and <see cref="mode"/> is set to
+        ///     <see cref="PersistenceMode.SnapshotStore"/>
+        /// </exception>
         public static AkkaConfigurationBuilder WithSqlServerPersistence(
             this AkkaConfigurationBuilder builder,
             string connectionString,
@@ -77,16 +96,25 @@ namespace Akka.Persistence.SqlServer.Hosting
         }
 
         /// <summary>
-        ///     Adds Akka.Persistence.SqlServer support to this <see cref="ActorSystem"/>.
+        ///     Adds Akka.Persistence.SqlServer support to this <see cref="ActorSystem"/>. At least one of the
+        ///     configurator delegate needs to be populated else this method will throw an exception.
         /// </summary>
         /// <param name="builder">
         ///     The builder instance being configured.
         /// </param>
         /// <param name="journalOptionConfigurator">
-        ///     An Action delegate to configure a <see cref="SqlServerJournalOptions"/> instance.
+        ///     <para>
+        ///         An <see cref="Action{T}"/> that modifies an instance of <see cref="SqlServerJournalOptions"/>,
+        ///         used to configure the journal plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <param name="snapshotOptionConfigurator">
-        ///     An Action delegate to configure a <see cref="SqlServerSnapshotOptions"/> instance.
+        ///     <para>
+        ///         An <see cref="Action{T}"/> that modifies an instance of <see cref="SqlServerSnapshotOptions"/>,
+        ///         used to configure the snapshot store plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <param name="isDefaultPlugin">
         ///     <para>
@@ -127,16 +155,23 @@ namespace Akka.Persistence.SqlServer.Hosting
         }
 
         /// <summary>
-        ///     Adds Akka.Persistence.SqlServer support to this <see cref="ActorSystem"/>.
+        ///     Adds Akka.Persistence.SqlServer support to this <see cref="ActorSystem"/>. At least one of the options
+        ///     have to be populated else this method will throw an exception.
         /// </summary>
         /// <param name="builder">
         ///     The builder instance being configured.
         /// </param>
         /// <param name="journalOptions">
-        ///     An <see cref="SqlServerJournalOptions"/> instance to configure the SqlServer journal.
+        ///     <para>
+        ///         An instance of <see cref="SqlServerJournalOptions"/>, used to configure the journal plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <param name="snapshotOptions">
-        ///     An <see cref="SqlServerSnapshotOptions"/> instance to configure the SqlServer snapshot store.
+        ///     <para>
+        ///         An instance of <see cref="SqlServerSnapshotOptions"/>, used to configure the snapshot store plugin
+        ///     </para>
+        ///     <i>Default</i>: <c>null</c>
         /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.

--- a/src/Akka.Persistence.SqlServer.Hosting/SqlServerOptions.cs
+++ b/src/Akka.Persistence.SqlServer.Hosting/SqlServerOptions.cs
@@ -13,10 +13,19 @@ using Akka.Persistence.Hosting;
 #nullable enable
 namespace Akka.Persistence.SqlServer.Hosting
 {
+    /// <summary>
+    /// Akka.Hosting options class to set up Microsoft SqlServer persistence journal.
+    /// </summary>
     public sealed class SqlServerJournalOptions: SqlJournalOptions
     {
-        internal static readonly Config Default = SqlServerPersistence.DefaultConfiguration();
+        private static readonly Config Default = SqlServerPersistence.DefaultConfiguration()
+            .GetConfig(SqlServerJournalSettings.ConfigPath);
         
+        /// <summary>
+        /// Create a new instance of <see cref="SqlServerJournalOptions"/>
+        /// </summary>
+        /// <param name="isDefaultPlugin">Indicates if this journal configuration should be the default configuration for all persistence</param>
+        /// <param name="identifier">The journal configuration identifier, <b>default</b>: "sql-server"</param>
         public SqlServerJournalOptions(bool isDefaultPlugin, string identifier = "sql-server") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -84,13 +93,10 @@ namespace Akka.Persistence.SqlServer.Hosting
         /// </summary>
         public TimeSpan QueryRefreshInterval { get; set; } = TimeSpan.FromSeconds(3);
 
-        public override Config DefaultConfig => Default;
+        protected override Config InternalDefaultConfig => Default;
 
         protected override StringBuilder Build(StringBuilder sb)
         {
-            sb.AppendLine("class = \"Akka.Persistence.SqlServer.Journal.SqlServerJournal, Akka.Persistence.SqlServer\"");
-            sb.AppendLine("plugin-dispatcher = \"akka.actor.default-dispatcher\"");
-            sb.AppendLine("timestamp-provider = \"Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common\"");
             sb.AppendLine($"use-constant-parameter-size = {UseConstantParameterSize.ToHocon()}");
             
             sb = base.Build(sb);
@@ -100,9 +106,20 @@ namespace Akka.Persistence.SqlServer.Hosting
         }
     }
 
+    /// <summary>
+    /// Akka.Hosting options class to set up Microsoft SqlServer persistence snapshot store.
+    /// </summary>
     public sealed class SqlServerSnapshotOptions: SqlSnapshotOptions
     {
-        public SqlServerSnapshotOptions(bool isDefault, string identifier = "sql-server") : base(isDefault)
+        private static readonly Config Default = SqlServerPersistence.DefaultConfiguration()
+            .GetConfig(SqlServerSnapshotSettings.ConfigPath);
+        
+        /// <summary>
+        /// Create a new instance of <see cref="SqlServerSnapshotOptions"/>
+        /// </summary>
+        /// <param name="isDefaultPlugin">Indicates if this snapshot store configuration should be the default configuration for all persistence</param>
+        /// <param name="identifier">The snapshot store configuration identifier, <b>default</b>: "sql-server"</param>
+        public SqlServerSnapshotOptions(bool isDefaultPlugin, string identifier = "sql-server") : base(isDefaultPlugin)
         {
             Identifier = identifier;
         }
@@ -148,7 +165,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         /// </summary>
         public bool UseConstantParameterSize { get; set; } = false;
 
-        public override Config DefaultConfig => SqlServerJournalOptions.Default;
+        protected override Config InternalDefaultConfig => Default;
 
         protected override StringBuilder Build(StringBuilder sb)
         {

--- a/src/Akka.Persistence.SqlServer.Hosting/SqlServerOptions.cs
+++ b/src/Akka.Persistence.SqlServer.Hosting/SqlServerOptions.cs
@@ -14,7 +14,7 @@ using Akka.Persistence.Hosting;
 namespace Akka.Persistence.SqlServer.Hosting
 {
     /// <summary>
-    /// Akka.Hosting options class to set up Microsoft SqlServer persistence journal.
+    ///     Akka.Hosting options class to set up Microsoft SqlServer persistence journal.
     /// </summary>
     public sealed class SqlServerJournalOptions: SqlJournalOptions
     {
@@ -22,10 +22,14 @@ namespace Akka.Persistence.SqlServer.Hosting
             .GetConfig(SqlServerJournalSettings.ConfigPath);
         
         /// <summary>
-        /// Create a new instance of <see cref="SqlServerJournalOptions"/>
+        ///     Create a new instance of <see cref="SqlServerJournalOptions"/>
         /// </summary>
-        /// <param name="isDefaultPlugin">Indicates if this journal configuration should be the default configuration for all persistence</param>
-        /// <param name="identifier">The journal configuration identifier, <b>default</b>: "sql-server"</param>
+        /// <param name="isDefaultPlugin">
+        ///     Indicates if this journal configuration should be the default configuration for all persistence
+        /// </param>
+        /// <param name="identifier">
+        ///     The journal configuration identifier. <i>Default</i>: "sql-server"
+        /// </param>
         public SqlServerJournalOptions(bool isDefaultPlugin, string identifier = "sql-server") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -35,7 +39,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         The plugin identifier for this persistence plugin
         ///     </para>
-        ///     <b>Default</b>: "sql-server"
+        ///     <b>Default</b>: <c>"sql-server"</c>
         /// </summary>
         public override string Identifier { get; set; }
         
@@ -43,7 +47,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         SQL schema name to table corresponding with persistent journal.
         ///     </para>
-        ///     <b>Default</b>: "dbo"
+        ///     <b>Default</b>: <c>"dbo"</c>
         /// </summary>
         public override string SchemaName { get; set; } = "dbo";
         
@@ -51,7 +55,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         SQL server table corresponding with persistent journal.
         ///     </para>
-        ///     <b>Default</b>: "EventJournal"
+        ///     <b>Default</b>: <c>"EventJournal"</c>
         /// </summary>
         public override string TableName { get; set; } = "EventJournal";
         
@@ -59,7 +63,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         SQL server table corresponding with persistent journal metadata.
         ///     </para>
-        ///     <b>Default</b>: "Metadata"
+        ///     <b>Default</b>: <c>"Metadata"</c>
         /// </summary>
         public override string MetadataTableName { get; set; } = "Metadata";
 
@@ -68,7 +72,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///         Uses the CommandBehavior.SequentialAccess when creating DB commands, providing a performance
         ///         improvement for reading large BLOBS.
         ///     </para>
-        ///     <b>Default</b>: true
+        ///     <b>Default</b>: <c>true</c>
         /// </summary>
         public override bool SequentialAccess { get; set; } = true;
         
@@ -79,16 +83,16 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///         If this parameter set to true, column sizes are loaded on journal startup from database schema, and 
         ///         string parameters have constant size which equals to corresponding column size.
         ///     </para>
-        ///     <b>Default</b>: false
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public bool UseConstantParameterSize { get; set; } = false;
         
         /// <summary>
-        /// <para>
-        ///     The SQL write journal is notifying the query side as soon as things
-        ///     are persisted, but for efficiency reasons the query side retrieves the events 
-        ///     in batches that sometimes can be delayed up to the configured <see cref="QueryRefreshInterval"/>.
-        /// </para>
+        ///     <para>
+        ///         The SQL write journal is notifying the query side as soon as things
+        ///         are persisted, but for efficiency reasons the query side retrieves the events 
+        ///         in batches that sometimes can be delayed up to the configured <see cref="QueryRefreshInterval"/>.
+        ///     </para>
         ///     <b>Default</b>: 3 seconds
         /// </summary>
         public TimeSpan QueryRefreshInterval { get; set; } = TimeSpan.FromSeconds(3);
@@ -115,10 +119,14 @@ namespace Akka.Persistence.SqlServer.Hosting
             .GetConfig(SqlServerSnapshotSettings.ConfigPath);
         
         /// <summary>
-        /// Create a new instance of <see cref="SqlServerSnapshotOptions"/>
+        ///     Create a new instance of <see cref="SqlServerSnapshotOptions"/>
         /// </summary>
-        /// <param name="isDefaultPlugin">Indicates if this snapshot store configuration should be the default configuration for all persistence</param>
-        /// <param name="identifier">The snapshot store configuration identifier, <b>default</b>: "sql-server"</param>
+        /// <param name="isDefaultPlugin">
+        ///     Indicates if this snapshot store configuration should be the default configuration for all persistence
+        /// </param>
+        /// <param name="identifier">
+        ///     The snapshot store configuration identifier. <i>Default</i>: "sql-server"
+        /// </param>
         public SqlServerSnapshotOptions(bool isDefaultPlugin, string identifier = "sql-server") : base(isDefaultPlugin)
         {
             Identifier = identifier;
@@ -128,7 +136,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         The plugin identifier for this persistence plugin
         ///     </para>
-        ///     <b>Default</b>: "sql-server"
+        ///     <b>Default</b>: <c>"sql-server"</c>
         /// </summary>
         public override string Identifier { get; set; }
         
@@ -136,7 +144,7 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         SQL server schema name to table corresponding with persistent snapshot store.
         ///     </para>
-        ///     <b>Default</b>: "dbo"
+        ///     <b>Default</b>: <c>"dbo"</c>
         /// </summary>
         public override string SchemaName { get; set; } = "dbo";
         
@@ -144,24 +152,24 @@ namespace Akka.Persistence.SqlServer.Hosting
         ///     <para>
         ///         SQL server table corresponding with persistent snapshot store.
         ///     </para>
-        ///     <b>Default</b>: "SnapshotStore"
+        ///     <b>Default</b>: <c>"SnapshotStore"</c>
         /// </summary>
         public override string TableName { get; set; } = "SnapshotStore";
         
         /// <summary>
         ///     Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance
         ///     improvement for reading large BLOBS.
-        ///     <b>Default</b>: true
+        ///     <b>Default</b>: <c>true</c>
         /// </summary>
         public override bool SequentialAccess { get; set; } = true;
 
         /// <summary>
         ///     <para>
         ///         By default, string parameter size in ADO.NET queries are set dynamically based on current parameter
-        ///         value size. If this parameter set to true, column sizes are loaded on journal startup from database schema, and 
-        ///         string parameters have constant size which equals to corresponding column size.
+        ///         value size. If this parameter set to true, column sizes are loaded on journal startup from database
+        ///         schema, and string parameters have constant size which equals to corresponding column size.
         ///     </para>
-        ///     <b>Default</b>: false
+        ///     <b>Default</b>: <c>false</c>
         /// </summary>
         public bool UseConstantParameterSize { get; set; } = false;
 

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Actors/Indexer.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Actors/Indexer.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Immutable;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.CustomJournalIdDemo.Messages;
+using Akka.Persistence.Query;
+using Akka.Persistence.Query.Sql;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Directive = Akka.Streams.Supervision.Directive;
+
+namespace Akka.Hosting.CustomJournalIdDemo.Actors;
+
+public sealed class Indexer : ReceiveActor
+{
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+    private readonly IActorRef _userActionsShardRegion;
+
+    private Dictionary<string, UserDescriptor> _users = new Dictionary<string, UserDescriptor>();
+
+    public Indexer(IActorRef userActionsShardRegion)
+    {
+        _userActionsShardRegion = userActionsShardRegion;
+
+        Receive<UserDescriptor>(d =>
+        {
+            _log.Info("Found {0}", d);
+            _users[d.UserId] = d;
+        });
+
+        Receive<FetchUsers>(f => { Sender.Tell(_users.Values.ToImmutableList()); });
+
+        Receive<string>(s => { _log.Info("Recorded completion of the stream"); });
+
+        Receive<UserCreatedEvent>(e =>
+        {
+            _userActionsShardRegion.Ask<UserDescriptor>(new FetchUser(e.UserId), TimeSpan.FromSeconds(1)).PipeTo(Self);
+        });
+    }
+
+
+    protected override void PreStart()
+    {
+        FetchIds();
+    }
+
+    private void FetchIds()
+    {
+        var readJournal = Context.System.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
+        readJournal.AllEvents()
+            .Where(e => e.Event is UserCreatedEvent)
+            .Select(uc => (UserCreatedEvent)uc.Event)
+            .WithAttributes(ActorAttributes.CreateSupervisionStrategy(e => Directive.Restart))
+            .RunWith(Sink.ActorRef<UserCreatedEvent>(Self, "complete"), Context.Materializer());
+    }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Actors/UserActionsEntity.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Actors/UserActionsEntity.cs
@@ -1,0 +1,49 @@
+﻿using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.CustomJournalIdDemo.Messages;
+using Akka.Persistence;
+
+namespace Akka.Hosting.CustomJournalIdDemo.Actors;
+
+public class UserActionsEntity : ReceivePersistentActor
+{
+    public static Props Props(string userId)
+    {
+        return Actor.Props.Create(() => new UserActionsEntity(userId));
+    }
+    
+    public UserActionsEntity(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CurrentState = UserDescriptor.Empty;
+        
+        Recover<UserCreatedEvent>(c =>
+        {
+            CurrentState = c.Descriptor;
+            _log.Info("Recovered {0}", c);
+        });
+
+        Command<CreateUser>(user =>
+        {
+            var e = new UserCreatedEvent(user.Descriptor, DateTime.UtcNow.Ticks);
+            Persist(e, evt =>
+            {
+                _log.Info("Persisted {0}", evt);
+                CurrentState = evt.Descriptor;
+                if(!Sender.IsNobody())
+                    Sender.Tell(new CommandResponse(ResponseKind.Success));
+            });
+        });
+
+        Command<FetchUser>(user =>
+        {
+            Sender.Tell(CurrentState);
+        });
+    }
+
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+
+    public override string PersistenceId { get; }
+    
+    public UserDescriptor CurrentState { get; private set; }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Akka.Hosting.CustomJournalIdDemo.csproj
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Akka.Hosting.CustomJournalIdDemo.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Akka.Cluster.Hosting\Akka.Cluster.Hosting.csproj" />
+      <ProjectReference Include="..\..\Akka.Persistence.SqlServer.Hosting\Akka.Persistence.SqlServer.Hosting.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/ConfigExtensions.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/ConfigExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Akka.Cluster.Sharding;
+
+namespace Akka.Hosting.CustomJournalIdDemo;
+
+public static class ShardSettings
+{
+    public static ClusterShardingSettings Default()
+    {
+        var shardingConfig = ClusterSharding.DefaultConfig();
+        var singletonConfig = shardingConfig.GetString("coordinator-singleton");
+        return ClusterShardingSettings.Create(shardingConfig.
+            GetConfig("akka.cluster.sharding"), shardingConfig.GetConfig(singletonConfig));
+    }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/IWithUserId.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/IWithUserId.cs
@@ -1,0 +1,9 @@
+﻿namespace Akka.Hosting.CustomJournalIdDemo.Messages;
+
+/// <summary>
+/// Marker interface for all user-related events and messages
+/// </summary>
+public interface IWithUserId
+{
+    string UserId { get; }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/UserCommands.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/UserCommands.cs
@@ -1,0 +1,31 @@
+﻿namespace Akka.Hosting.CustomJournalIdDemo.Messages;
+
+public record CreateUser(UserDescriptor Descriptor) : IWithUserId
+{
+    public string UserId => Descriptor.UserId;
+}
+
+public enum ResponseKind
+{
+    Success,
+    Failure,
+    Unknown
+}
+
+public record CommandResponse(ResponseKind ResponseKind);
+
+public sealed class FetchUsers
+{
+    public static readonly FetchUsers Instance = new FetchUsers();
+    private FetchUsers(){}
+}
+
+public sealed class FetchUser : IWithUserId
+{
+    public FetchUser(string userId)
+    {
+        UserId = userId;
+    }
+
+    public string UserId { get; }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/UserDescriptor.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/UserDescriptor.cs
@@ -1,0 +1,6 @@
+namespace Akka.Hosting.CustomJournalIdDemo.Messages;
+
+public record UserDescriptor(string UserId, string UserName) : IWithUserId
+{
+    public static readonly UserDescriptor Empty = new UserDescriptor(string.Empty, string.Empty);
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/UserEvents.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Messages/UserEvents.cs
@@ -1,0 +1,6 @@
+﻿namespace Akka.Hosting.CustomJournalIdDemo.Messages;
+
+public record UserCreatedEvent(UserDescriptor Descriptor, long Timestamp) : IWithUserId
+{
+    public string UserId => Descriptor.UserId;
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/Program.cs
@@ -1,0 +1,80 @@
+using Akka.Actor;
+using Akka.Cluster.Hosting;
+using Akka.Cluster.Sharding;
+using Akka.Hosting;
+using Akka.Hosting.CustomJournalIdDemo;
+using Akka.Hosting.CustomJournalIdDemo.Actors;
+using Akka.Hosting.CustomJournalIdDemo.Messages;
+using Akka.Persistence.SqlServer.Hosting;
+using Akka.Remote.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAkka("MyActorSystem", configurationBuilder =>
+    {
+        // Grab connection strings from appsettings.json
+        var localConn = builder.Configuration.GetConnectionString("sqlServerLocal");
+        var shardingConn = builder.Configuration.GetConnectionString("sqlServerSharding");
+
+        // Custom journal options with the id "sharding"
+        // The absolute id will be "akka.persistence.journal.sharding"
+        var shardingJournalOptions = new SqlServerJournalOptions(isDefaultPlugin: false)
+        {
+            Identifier = "sharding",
+            ConnectionString = shardingConn,
+            AutoInitialize = true
+        };
+        
+        // Custom snapshots options with the id "sharding"
+        // The absolute id will be "akka.persistence.snapshot-store.sharding"
+        var shardingSnapshotOptions = new SqlServerSnapshotOptions(isDefaultPlugin: false)
+        {
+            Identifier = "sharding",
+            ConnectionString = shardingConn,
+            AutoInitialize = true
+        };
+        
+        configurationBuilder
+            .WithRemoting("localhost", 8110)
+            .WithClustering(new ClusterOptions()
+            {
+                Roles = new[] { "myRole" },
+                SeedNodes = new[] { Address.Parse("akka.tcp://MyActorSystem@localhost:8110") }
+            })
+            .WithSqlServerPersistence(localConn) // Standard way to create a default persistence journal and snapshot
+            .WithSqlServerPersistence(shardingJournalOptions, shardingSnapshotOptions) // This is a custom persistence setup using the options instances we've set up earlier
+            .WithShardRegion<UserActionsEntity>("userActions", s => UserActionsEntity.Props(s),
+                new UserMessageExtractor(),
+                new ShardOptions
+                {
+                    StateStoreMode = StateStoreMode.Persistence, 
+                    Role = "myRole", 
+                    JournalPluginId = shardingJournalOptions.PluginId,
+                    SnapshotPluginId = shardingSnapshotOptions.PluginId 
+                })
+            .WithActors((system, registry) =>
+            {
+                var userActionsShard = registry.Get<UserActionsEntity>();
+                var indexer = system.ActorOf(Props.Create(() => new Indexer(userActionsShard)), "index");
+                registry.TryRegister<Index>(indexer); // register for DI
+            });
+    })
+    .AddHostedService<TestDataPopulatorService>();
+
+var app = builder.Build();
+
+app.MapGet("/", async (ActorRegistry registry) =>
+{
+    var index = registry.Get<Index>();
+    return await index.Ask<IEnumerable<UserDescriptor>>(FetchUsers.Instance, TimeSpan.FromSeconds(3))
+        .ConfigureAwait(false);
+});
+
+app.MapGet("/user/{userId}", async (string userId, ActorRegistry registry) =>
+{
+    var index = registry.Get<UserActionsEntity>();
+    return await index.Ask<UserDescriptor>(new FetchUser(userId), TimeSpan.FromSeconds(3))
+        .ConfigureAwait(false);
+});
+
+app.Run();

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/README.md
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/README.md
@@ -1,0 +1,7 @@
+# Akka.Hosting.CustomJournalIdDemo
+
+To begin, fire up SQL Server in Docker:
+
+```shell
+./launch-sqlserver.sh
+```

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/TestDataPopulatorService.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/TestDataPopulatorService.cs
@@ -1,0 +1,35 @@
+﻿using Akka.Actor;
+using Akka.Hosting.CustomJournalIdDemo.Actors;
+using Akka.Hosting.CustomJournalIdDemo.Messages;
+
+namespace Akka.Hosting.CustomJournalIdDemo;
+
+public sealed class TestDataPopulatorService : IHostedService
+{
+    private readonly ActorSystem _system;
+    private ICancelable? _cancelable;
+
+    public TestDataPopulatorService(ActorSystem system)
+    {
+        _system = system;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cancelable = _system.Scheduler.Advanced.ScheduleRepeatedlyCancelable(TimeSpan.Zero, TimeSpan.FromSeconds(1), () =>
+        {
+            var entityRegion = ActorRegistry.For(_system).Get<UserActionsEntity>();
+            var user = UserGenerator.CreateRandom();
+            entityRegion.Tell(new CreateUser(user));
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cancelable?.Cancel();
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/UserGenerator.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/UserGenerator.cs
@@ -1,0 +1,21 @@
+﻿using Akka.Hosting.CustomJournalIdDemo.Messages;
+using Akka.Util;
+
+namespace Akka.Hosting.CustomJournalIdDemo;
+
+public static class UserGenerator
+{
+    public static readonly string[] FirstNames = new[]
+        { "Yoda", "Obi-Wan", "Darth Vader", "Leia", "Luke", "R2D2", "Han", "Chewbacca", "Jabba", "Ardbeg", "Lando" };
+
+    public static readonly string[] LastNames = new[] { "Fat", "Kenobi", "Skywalker", "Solo", "Fett", "Calrissian" };
+    
+    private static T PickRandom<T>(T[] items) => items[ThreadLocalRandom.Current.Next(items.Length)];
+
+    public static UserDescriptor CreateRandom()
+    {
+        var userName = $"{PickRandom(FirstNames)} {PickRandom(LastNames)} v{ThreadLocalRandom.Current.Next(0,100)}";
+        var userId = MurmurHash.StringHash(userName);
+        return new UserDescriptor(userId.ToString(), userName);
+    }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/UserMessageExtractor.cs
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/UserMessageExtractor.cs
@@ -1,0 +1,25 @@
+﻿using Akka.Cluster.Sharding;
+using Akka.Hosting.CustomJournalIdDemo.Messages;
+
+namespace Akka.Hosting.CustomJournalIdDemo;
+
+public sealed class UserMessageExtractor : HashCodeMessageExtractor
+{
+    public UserMessageExtractor() : base(30)
+    {
+    }
+    
+    public UserMessageExtractor(int maxNumberOfShards) : base(maxNumberOfShards)
+    {
+    }
+
+    public override string EntityId(object message)
+    {
+        if (message is IWithUserId userId)
+        {
+            return userId.UserId;
+        }
+
+        return null!;
+    }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/appsettings.Development.json
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;",
+    "sqlServerSharding": "Server=localhost,1533;Database=AkkaSharding;User Id=sa;Password=l0lTh1sIsOpenSource;"
+  }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/appsettings.Production.json
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/appsettings.Production.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;",
+    "sqlServerSharding": "Server=localhost,1533;Database=AkkaSharding;User Id=sa;Password=l0lTh1sIsOpenSource;"
+  }
+}

--- a/src/Examples/Akka.Hosting.CustomJournalIdDemo/appsettings.json
+++ b/src/Examples/Akka.Hosting.CustomJournalIdDemo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Examples/Akka.Hosting.SqlSharding/Akka.Hosting.SqlSharding.csproj
+++ b/src/Examples/Akka.Hosting.SqlSharding/Akka.Hosting.SqlSharding.csproj
@@ -5,10 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);USE_OPTIONS</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\Akka.Cluster.Hosting\Akka.Cluster.Hosting.csproj" />
     <ProjectReference Include="..\..\Akka.Persistence.SqlServer.Hosting\Akka.Persistence.SqlServer.Hosting.csproj" />

--- a/src/Examples/Akka.Hosting.SqlSharding/Akka.Hosting.SqlSharding.csproj
+++ b/src/Examples/Akka.Hosting.SqlSharding/Akka.Hosting.SqlSharding.csproj
@@ -4,6 +4,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);USE_OPTIONS</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Akka.Cluster.Hosting\Akka.Cluster.Hosting.csproj" />

--- a/src/Examples/Akka.Hosting.SqlSharding/Program.cs
+++ b/src/Examples/Akka.Hosting.SqlSharding/Program.cs
@@ -1,8 +1,6 @@
 using Akka.Actor;
-using Akka.Actor.Dsl;
 using Akka.Cluster.Hosting;
 using Akka.Cluster.Sharding;
-using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Hosting.SqlSharding;
 using Akka.Hosting.SqlSharding.Actors;
@@ -12,53 +10,6 @@ using Akka.Remote.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
-#if USE_OPTIONS
-builder.Services.AddAkka("MyActorSystem", configurationBuilder =>
-    {
-        var localConn = builder.Configuration.GetConnectionString("sqlServerLocal");
-        var shardingConn = builder.Configuration.GetConnectionString("sqlServerSharding");
-
-        var shardingJournalOptions = new SqlServerJournalOptions(isDefaultPlugin: false)
-        {
-            Identifier = "sharding",
-            ConnectionString = shardingConn,
-            AutoInitialize = true
-        };
-        var shardingSnapshotOptions = new SqlServerSnapshotOptions(isDefaultPlugin: false)
-        {
-            Identifier = "sharding",
-            ConnectionString = shardingConn,
-            AutoInitialize = true
-        };
-        
-        configurationBuilder
-            .WithRemoting("localhost", 8110)
-            .WithClustering(new ClusterOptions()
-            {
-                Roles = new[] { "myRole" },
-                SeedNodes = new[] { Address.Parse("akka.tcp://MyActorSystem@localhost:8110") }
-            })
-            .WithSqlServerPersistence(localConn)
-            .WithSqlServerPersistence(shardingJournalOptions, shardingSnapshotOptions)
-            .WithShardRegion<UserActionsEntity>("userActions", s => UserActionsEntity.Props(s),
-                new UserMessageExtractor(),
-                new ShardOptions
-                {
-                    StateStoreMode = StateStoreMode.Persistence, 
-                    Role = "myRole", 
-                    JournalPluginId = shardingJournalOptions.PluginId,
-                    SnapshotPluginId = shardingSnapshotOptions.PluginId 
-                })
-            .WithActors((system, registry) =>
-            {
-                var userActionsShard = registry.Get<UserActionsEntity>();
-                var indexer = system.ActorOf(Props.Create(() => new Indexer(userActionsShard)), "index");
-                registry.TryRegister<Index>(indexer); // register for DI
-            });
-    })
-    .AddHostedService<TestDataPopulatorService>();
-
-#else
 builder.Services.AddAkka("MyActorSystem", configurationBuilder =>
 {
     configurationBuilder
@@ -80,8 +31,6 @@ builder.Services.AddAkka("MyActorSystem", configurationBuilder =>
         });
 })
     .AddHostedService<TestDataPopulatorService>();
-
-#endif
 
 var app = builder.Build();
 

--- a/src/Examples/Akka.Hosting.SqlSharding/appsettings.Development.json
+++ b/src/Examples/Akka.Hosting.SqlSharding/appsettings.Development.json
@@ -6,7 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;",
-    "sqlServerSharding": "Server=localhost,1533;Database=AkkaSharding;User Id=sa;Password=l0lTh1sIsOpenSource;"
+    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;"
   }
 }

--- a/src/Examples/Akka.Hosting.SqlSharding/appsettings.Development.json
+++ b/src/Examples/Akka.Hosting.SqlSharding/appsettings.Development.json
@@ -6,6 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;"
+    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;",
+    "sqlServerSharding": "Server=localhost,1533;Database=AkkaSharding;User Id=sa;Password=l0lTh1sIsOpenSource;"
   }
 }

--- a/src/Examples/Akka.Hosting.SqlSharding/appsettings.Production.json
+++ b/src/Examples/Akka.Hosting.SqlSharding/appsettings.Production.json
@@ -6,7 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;",
-    "sqlServerSharding": "Server=localhost,1533;Database=AkkaSharding;User Id=sa;Password=l0lTh1sIsOpenSource;"
+    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;"
   }
 }

--- a/src/Examples/Akka.Hosting.SqlSharding/appsettings.Production.json
+++ b/src/Examples/Akka.Hosting.SqlSharding/appsettings.Production.json
@@ -6,6 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;"
+    "sqlServerLocal": "Server=localhost,1533;Database=Akka;User Id=sa;Password=l0lTh1sIsOpenSource;",
+    "sqlServerSharding": "Server=localhost,1533;Database=AkkaSharding;User Id=sa;Password=l0lTh1sIsOpenSource;"
   }
 }


### PR DESCRIPTION
Part of #142

## Changes
- Add `JournalOption`
- Add `SnapshotOption`
- Add the ability to compose event adapters using `JournalOption.Adapters`
- Add the ability to inject journal and snapshot config without making it the default plugin
- Add the Ability to specify which journal and snapshot Sharding uses

Currently supported persistence plugins:
- PostgreSQL
- MS SQLServer

