### PR TITLE
`ActorRegistry.Get<T>` now throws when there is no entry for `T`

### DIFF
--- a/src/Akka.Hosting.Tests/ActorRegistrySpecs.cs
+++ b/src/Akka.Hosting.Tests/ActorRegistrySpecs.cs
@@ -50,4 +50,24 @@ public class ActorRegistrySpecs
         // assert
         register.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void Should_throw_on_missing_entry_during_Get()
+    {
+        // arrange
+        var registry = new ActorRegistry();
+        
+        // assert
+        registry.Invoking(x => x.Get<Nobody>()).Should().Throw<MissingActorRegistryEntryException>();
+    }
+    
+    [Fact]
+    public void Should_not_throw_on_missing_entry_during_TryGet()
+    {
+        // arrange
+        var registry = new ActorRegistry();
+        
+        // assert
+        registry.Invoking(x => x.TryGet<Nobody>(out var actor)).Should().NotThrow<MissingActorRegistryEntryException>();
+    }
 }

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -18,14 +18,49 @@ namespace Akka.Hosting
     }
 
     /// <summary>
+    /// Generic <see cref="ActorRegistry"/> exception.
+    /// </summary>
+    public class ActorRegistryException : Exception
+    {
+        public ActorRegistryException(string message) : base(message)
+        {
+            
+        }
+        
+        public ActorRegistryException(string message, Exception innerException) : base(message, innerException)
+        {
+            
+        }
+    }
+
+    /// <summary>
     /// Thrown when the same key is used twice in the registry and overwriting is not allowed.
     /// </summary>
-    public sealed class DuplicateActorRegistryException : Exception
+    public sealed class DuplicateActorRegistryException : ActorRegistryException
     {
 
         public DuplicateActorRegistryException(string message) : base(message)
         {
             
+        }
+        
+        public DuplicateActorRegistryException(string message, Exception innerException) : base(message, innerException)
+        {
+            
+        }
+    }
+
+    /// <summary>
+    /// Thrown when a user attempts to retrieve a non-existent key from the <see cref="ActorRegistry"/>.
+    /// </summary>
+    public sealed class MissingActorRegistryEntryException : ActorRegistryException
+    {
+        public MissingActorRegistryEntryException(string message) : base(message)
+        {
+        }
+
+        public MissingActorRegistryEntryException(string message, Exception innerException) : base(message, innerException)
+        {
         }
     }
 
@@ -125,7 +160,7 @@ namespace Akka.Hosting
         {
             if (TryGet<TKey>(out var actor))
                 return actor;
-            return ActorRefs.Nobody;
+            throw new MissingActorRegistryEntryException("No actor registered for key " + typeof(TKey));
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

This is designed to make it easier to debug scenarios where the `ActorRegistry` is not configured directly - please use `ActorRegistry.TryGet<T>` if you want to avoid exceptions during `IActorRef` retrieval.

This is a **breaking behavior change** but it is a useful one - and worth doing before https://github.com/akkadotnet/Akka.Hosting/issues/142

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
