### PR TITLE
Change `TestKit.ConfigureAkka` method to be `void` rather than `Task`

### DIFF
--- a/src/Akka.Hosting.TestKit.Tests/HostingSpecSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/HostingSpecSpec.cs
@@ -26,14 +26,13 @@ namespace Akka.Hosting.TestKit.Tests
         {
         }
 
-        protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
             builder.WithActors((system, registry) =>
             {
                 var echo = system.ActorOf(Props.Create(() => new SimpleEchoActor()));
                 registry.Register<Echo>(echo);
             });
-            return Task.CompletedTask;
         }
 
         [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/NoImplicitSenderSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/NoImplicitSenderSpec.cs
@@ -17,9 +17,9 @@ namespace Akka.Hosting.TestKit.Tests;
 
 public class NoImplicitSenderSpec : TestKit, INoImplicitSender
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
+        
     }
 
     [Fact]
@@ -35,9 +35,9 @@ public class NoImplicitSenderSpec : TestKit, INoImplicitSender
 
 public class ImplicitSenderSpec : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
+        
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
@@ -38,9 +38,8 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
             Assert.True(OtherThread == null || OtherThread == Thread, "Thread");
         }
 
-        protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
-            return Task.CompletedTask;
         }
 
         protected override async Task BeforeTestStart()

--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
@@ -29,9 +29,8 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
             hs.Count.Should().Be(1);
         }
 
-        protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/ConfigTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/ConfigTests.cs
@@ -15,9 +15,8 @@ namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
 {
     public class ConfigTests : TestKit
     {
-        protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
-            return Task.CompletedTask;
         }
         
         [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -28,7 +28,7 @@ namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
 
         protected abstract void SendRawLogEventMessage(object message);
 
-        protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
             builder.ConfigureLoggers(logger =>
             {
@@ -36,8 +36,6 @@ namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
                 logger.ClearLoggers();
                 logger.AddLogger<ForwardAllEventsTestEventListener>();
             });
-            
-            return Task.CompletedTask;
         }
 
         protected override async Task BeforeTestStart()

--- a/src/Akka.Hosting.TestKit.Tests/TestFSMRefTests/TestFSMRefSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestFSMRefTests/TestFSMRefSpec.cs
@@ -15,9 +15,9 @@ namespace Akka.Hosting.TestKit.Tests.TestFSMRefTests;
 
 public class TestFSMRefSpec : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
+        
     }
     
     [Fact]
@@ -66,16 +66,16 @@ public class TestFSMRefSpec : TestKit
             {
                 var fsmEvent = e.FsmEvent;
                 if(Equals(fsmEvent, "go"))
-                    return GoTo(2, "go");
+                    return GoTo(2).Using("go");
                 if(fsmEvent is StateTimeout)
-                    return GoTo(2, "timeout");
+                    return GoTo(2).Using("timeout");
                 return null;
             });
             When(2, e =>
             {
                 var fsmEvent = e.FsmEvent;
                 if(Equals(fsmEvent, "back"))
-                    return GoTo(1, "back");
+                    return GoTo(1).Using("back");
                 return null;
             });
         }

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
@@ -17,9 +17,8 @@ public class AwaitAssertTests : TestKit
 {
     protected override Config Config { get; } = "akka.test.timefactor=2";
 
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
@@ -26,9 +26,8 @@ public class DilatedTests : TestKit
 
     protected override Config Config { get; } = $"akka.test.timefactor={TimeFactor}";
 
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
@@ -16,9 +16,8 @@ namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
 
 public class ExpectTests : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/IgnoreMessagesTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/IgnoreMessagesTests.cs
@@ -25,9 +25,8 @@ public class IgnoreMessagesTests : TestKit
         public string IgnoreMe { get; }
     }
 
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -18,9 +18,8 @@ namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
 
 public class ReceiveTests : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/RemainingTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/RemainingTests.cs
@@ -13,9 +13,9 @@ namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
 
 public class RemainingTests : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
+        
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/WithinTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKitBaseTests/WithinTests.cs
@@ -13,9 +13,9 @@ namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
 
 public class WithinTests : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
+        
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestKit_Config_Tests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestKit_Config_Tests.cs
@@ -17,9 +17,8 @@ namespace Akka.Hosting.TestKit.Tests;
 // ReSharper disable once InconsistentNaming
 public class TestKit_Config_Tests : TestKit
 {
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/src/Akka.Hosting.TestKit.Tests/TestSchedulerTests.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestSchedulerTests.cs
@@ -20,9 +20,9 @@ public class TestSchedulerTests : TestKit
 {
     private IActorRef _testReceiveActor;
 
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
-        return Task.CompletedTask;
+       
     }
 
     protected override async Task BeforeTestStart()

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -101,7 +101,7 @@ namespace Akka.Hosting.TestKit
                     });
                 }
 
-                await ConfigureAkka(builder, provider);
+                ConfigureAkka(builder, provider);
 
                 builder.AddStartup((system, registry) =>
                 {
@@ -116,7 +116,7 @@ namespace Akka.Hosting.TestKit
         protected virtual void ConfigureLogging(ILoggingBuilder builder)
         { }
 
-        protected abstract Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider);
+        protected abstract void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider);
         
         [InternalApi]
         public async Task InitializeAsync()

--- a/src/Akka.Persistence.Hosting.Tests/EventAdapterSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/EventAdapterSpecs.cs
@@ -79,7 +79,7 @@ public class EventAdapterSpecs: Akka.Hosting.TestKit.TestKit
         }
     }
     
-    protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     {
         builder.WithJournal("sql-server", journalBuilder =>
         {
@@ -89,8 +89,6 @@ public class EventAdapterSpecs: Akka.Hosting.TestKit.TestKit
             journalBuilder.AddWriteEventAdapter<Tagger>("tagger",
                 boundTypes: new Type[] { typeof(Event1), typeof(Event2) });
         });
-        
-        return Task.CompletedTask;
     }
     
     [Fact]

--- a/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
@@ -77,7 +77,7 @@ namespace Akka.Persistence.Hosting.Tests
             return host;
         }
         
-        protected override Task ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
         {
             builder
                 .WithInMemoryJournal()
@@ -87,8 +87,6 @@ namespace Akka.Persistence.Hosting.Tests
                     var myActor = system.ActorOf(Props.Create(() => new MyPersistenceActor("ac1")), "actor1");
                     registry.Register<MyPersistenceActor>(myActor);
                 });
-            
-            return Task.CompletedTask;
         }
 
         [Fact]


### PR DESCRIPTION
## Changes

No need to `await` anything inside the `ConfigureAkka` method, so might as well remove the boilerplate of returning `Task.CompletedTask`

Also - cleaned up some compiler warnings regarding using deprecated `FSM<T.State,TData>` methods.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Changes in public API reviewed, if any.