### PR TITLE
Guard the failing TestKit EventFilterTestBase

### DIFF
--- a/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -47,7 +47,16 @@ namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
             var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
             // ReSharper disable once DoNotCallOverridableMethodsInConstructor
             SendRawLogEventMessage(initLoggerMessage);
-            ExpectMsg("OK");
+            try
+            {
+                ExpectMsg("OK");
+            }
+            catch (Exception e)
+            {
+                throw new Exception(
+                    "Failed to receive an OK signal from ForwardAllEventsTestEventListener logger during test start " +
+                    $"inside EventFilterTestBase. Running loggers: [{string.Join(", ", Sys.Settings.Loggers)}]", e);
+            }
             //From now on we know that all messages will be forwarded to TestActor
         }
 


### PR DESCRIPTION
TestEventListenerTests is failing at this line: https://github.com/akkadotnet/Akka.Hosting/blob/491e8a1eb1bfc34844bacbaeafa582c01840a8af/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs#L50

Its not clear what is the cause of the failure, the `TestActor` was not receiving the "OK" signal from the custom `ForwardAllEventsTestEventListener` logger. Putting a guard code here to fish for possible future failure.

## Changes

Add a guard around the failing line
