### PR TITLE
Proper Akka.NET Dependency Injection: `IRequiredActor<TActor>`

### DIFF
--- a/src/Akka.Hosting.Tests/RequiredActorSpecs.cs
+++ b/src/Akka.Hosting.Tests/RequiredActorSpecs.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Akka.Hosting.Tests;
+
+public class RequiredActorSpecs
+{
+    public sealed class MyActorType : ReceiveActor
+    {
+        public MyActorType()
+        {
+            ReceiveAny(_ => Sender.Tell(_));
+        }
+    }
+
+    public sealed class MyConsumer
+    {
+        private readonly IActorRef _actor;
+
+        public MyConsumer(IRequiredActor<MyActorType> actor)
+        {
+            _actor = actor.ActorRef;
+        }
+
+        public async Task<string> Say(string word)
+        {
+            return await _actor.Ask<string>(word, TimeSpan.FromSeconds(3));
+        }
+    }
+    
+    [Fact]
+    public async Task ShouldRetrieveRequiredActorFromIServiceProvider()
+    {
+        // arrange
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddAkka("MySys", (builder, provider) =>
+                {
+                    builder.WithActors((system, registry) =>
+                    {
+                        var actor = system.ActorOf(Props.Create(() => new MyActorType()), "myactor");
+                        registry.Register<MyActorType>(actor);
+                    });
+                });
+                services.AddScoped<MyConsumer>();
+            })
+            .Build();
+            await host.StartAsync();
+
+        // act
+        var myConsumer = host.Services.GetRequiredService<MyConsumer>();
+        var input = "foo";
+        var spoken = await myConsumer.Say(input);
+
+        // assert
+        spoken.Should().Be(input);
+    }
+}

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -16,9 +16,16 @@ namespace Akka.Hosting
     /// </remarks>
     public interface IRequiredActor<TActor>
     {
+        /// <summary>
+        /// The underlying actor resolved via <see cref="ActorRegistry"/> using the given <see cref="TActor"/> key.
+        /// </summary>
         IActorRef ActorRef { get; }
     }
 
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    /// <typeparam name="TActor">The type key of the actor - corresponds to a matching entry inside the <see cref="IActorRegistry"/>.</typeparam>
     public sealed class RequiredActor<TActor> : IRequiredActor<TActor>
     {
         public RequiredActor(IReadOnlyActorRegistry registry)
@@ -26,6 +33,7 @@ namespace Akka.Hosting
             ActorRef = registry.Get<TActor>();
         }
 
+        /// <inheritdoc cref="IRequiredActor{TActor}.ActorRef"/>
         public IActorRef ActorRef { get; }
     } 
 

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -3,9 +3,32 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Akka.Actor;
+using Akka.Util;
 
 namespace Akka.Hosting
 {
+    /// <summary>
+    /// A strongly typed actor reference that can be used to send messages to an actor.
+    /// </summary>
+    /// <typeparam name="TActor">The type key of the actor - corresponds to a matching entry inside the <see cref="IActorRegistry"/>.</typeparam>
+    /// <remarks>
+    /// Designed to be used in combination with dependency injection to get references to specific actors inside your application.
+    /// </remarks>
+    public interface IRequiredActor<TActor>
+    {
+        IActorRef ActorRef { get; }
+    }
+
+    public sealed class RequiredActor<TActor> : IRequiredActor<TActor>
+    {
+        public RequiredActor(IReadOnlyActorRegistry registry)
+        {
+            ActorRef = registry.Get<TActor>();
+        }
+
+        public IActorRef ActorRef { get; }
+    } 
+
     /// <summary>
     /// INTERNAL API
     /// </summary>
@@ -74,9 +97,8 @@ namespace Akka.Hosting
     /// </remarks>
     public class ActorRegistry : IActorRegistry, IExtension
     {
-        private readonly ConcurrentDictionary<Type, IActorRef> _actorRegistrations =
-            new ConcurrentDictionary<Type, IActorRef>();
-
+        private readonly ConcurrentDictionary<Type, IActorRef> _actorRegistrations = new();
+        
         /// <inheritdoc cref="IActorRegistry.Register{TKey}"/>
         /// <exception cref="DuplicateActorRegistryException">Thrown when the same value is inserted twice and overwriting is not allowed.</exception>
         /// <exception cref="ArgumentNullException">Thrown when a <c>null</c> <see cref="IActorRef"/> is registered.</exception>

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -322,7 +322,7 @@ namespace Akka.Hosting
                 return sp.GetRequiredService<ActorRegistry>();
             });
 
-            ServiceCollection.AddScoped(typeof(IRequiredActor<>), typeof(RequiredActor<>));
+            ServiceCollection.AddSingleton(typeof(IRequiredActor<>), typeof(RequiredActor<>));
         }
 
         /// <summary>

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Actor.Dsl;
 using Akka.Actor.Setup;
 using Akka.Annotations;
 using Akka.Configuration;
@@ -14,6 +13,7 @@ using Akka.Hosting.Logging;
 using Akka.Serialization;
 using Akka.Util;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Akka.Hosting
@@ -321,6 +321,8 @@ namespace Akka.Hosting
             {
                 return sp.GetRequiredService<ActorRegistry>();
             });
+
+            ServiceCollection.AddScoped(typeof(IRequiredActor<>), typeof(RequiredActor<>));
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

This addresses one of the criticisms of Akka.Hosting we've heard from a number of current active users: the `ActorRegistry` is service location and that's a smelly pattern.

All of the work we've done on the `ActorRegistry` so far makes it feasible for us to now expose proper, strongly typed dependency injection to users who wish to integrate their Akka.NET actors with other popular technologies (i.e. ASP.NET) or even with other Akka.NET actors via Akka.DependencyInjection.

This PR introduces the `IRequiredActor<TActor>` type, which is designed to allow for real dependency injection rather than service location:

```csharp
public sealed class MyConsumer
{
    private readonly IActorRef _actor;

    public MyConsumer(IRequiredActor<MyActorType> actor)
    {
        _actor = actor.ActorRef;
    }

    public async Task<string> Say(string word)
    {
        return await _actor.Ask<string>(word, TimeSpan.FromSeconds(3));
    }
}
```

The `IRequiredActor<TActor>` exposes a single property:

```csharp
public interface IRequiredActor<TActor>
{
    /// <summary>
    /// The underlying actor resolved via <see cref="ActorRegistry"/> using the given <see cref="TActor"/> key.
    /// </summary>
    IActorRef ActorRef { get; }
}
```

We intentionally chose not to have `IRequiredActor<T>` inherit from `IActorRef` directly because that could cause some undesirable side effects (i.e. death watch not working properly out of the box). We think just returning the `IActorRef` in a property should be sufficient.

By default, you can automatically resolve any actors registered with the `ActorRegistry` without having to declare anything special on your `IServiceCollection`:

```csharp
using var host = new HostBuilder()
  .ConfigureServices(services =>
  {
      services.AddAkka("MySys", (builder, provider) =>
      {
          builder.WithActors((system, registry) =>
          {
              var actor = system.ActorOf(Props.Create(() => new MyActorType()), "myactor");
              registry.Register<MyActorType>(actor);
          });
      });
      services.AddScoped<MyConsumer>();
  })
  .Build();
  await host.StartAsync();
```

Adding your actor and your type key into the `ActorRegistry` is sufficient - no additional DI registration is required to access the `IRequiredActor<TActor>` for that type.

We went with the name `IRequiredActor<TActor>` in order to follow the "required services" pattern established by Microsoft.Extensions.DependencyInjection - in that same spirit, if you attempt to resolve a `TActor` that is not registered you will get a `MissingActorRegistryEntryException` thrown by Akka.Hosting.

We would love your feedback on this PR!

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #144
* [x] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.
