### PR TITLE
Add debug logging options and `WithActorAskTimeout()` extension method

### DIFF
--- a/src/Akka.Hosting.Tests/HostingExtensionsSpec.cs
+++ b/src/Akka.Hosting.Tests/HostingExtensionsSpec.cs
@@ -1,0 +1,35 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HostingExtensionsSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Akka.Hosting.Tests;
+
+public class HostingExtensionsSpec
+{
+    [Fact(DisplayName = "WithActorAskTimeout should inject proper HOCON")]
+    public void WithActorAskTimeoutTest()
+    {
+        var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "fake")
+            .WithActorAskTimeout(10.Seconds());
+        builder.Configuration.HasValue.Should().BeTrue();
+        builder.Configuration.Value.GetTimeSpan("akka.actor.ask-timeout").Should().Be(10.Seconds());
+    }
+    
+    [Fact(DisplayName = "WithActorAskTimeout should be able to infer infinite timespan")]
+    public void WithActorAskTimeoutInfiniteTest()
+    {
+        var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "fake")
+            .WithActorAskTimeout(TimeSpan.Zero);
+        builder.Configuration.HasValue.Should().BeTrue();
+        builder.Configuration.Value.GetString("akka.actor.ask-timeout").Should().Be("infinite");
+    }
+}

--- a/src/Akka.Hosting.Tests/UtilSpec.cs
+++ b/src/Akka.Hosting.Tests/UtilSpec.cs
@@ -5,9 +5,11 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using Akka.Configuration;
 using FluentAssertions;
 using Xunit;
+using static FluentAssertions.FluentActions;
 
 namespace Akka.Hosting.Tests;
 
@@ -20,5 +22,31 @@ public class UtilSpec
         var moved = hocon.MoveTo("x.y.z");
         moved.GetInt("x.y.z.a").Should().Be(1);
         moved.GetInt("x.y.z.b.c").Should().Be(2);
+    }
+
+    [Fact(DisplayName = "HoconExtensions TimeSpan.ToHocon should work properly")]
+    public void TimeSpanToHoconSpec()
+    {
+        TimeSpan? nullTs = null;
+        Invoking(() => nullTs.ToHocon()).Should()
+            .Throw<ConfigurationException>()
+            .WithMessage("Value can not be null", "Null value is not allowed");
+
+        var ts = TimeSpan.Zero;
+        ts.ToHocon().Should().Be("0");
+        ts.ToHocon(true, false).Should().Be("0");
+        ts.ToHocon(true, true).Should().Be("infinite");
+        ts.ToHocon(false, false).Should().Be("0");
+        Invoking(() => ts.ToHocon(false, true)).Should()
+            .Throw<ConfigurationException>("Infinite value is not allowed", "Infinite value is not allowed, zero is considered as infinite");
+
+        ts = TimeSpan.FromTicks(-1);
+        ts.ToHocon(true, false).Should().Be("infinite");
+        ts.ToHocon(true, true).Should().Be("infinite");
+        Invoking(() => ts.ToHocon(false, true)).Should()
+            .Throw<ConfigurationException>("Infinite value is not allowed", "Infinite value is not allowed");
+        Invoking(() => ts.ToHocon(false, false)).Should()
+            .Throw<ConfigurationException>("Infinite value is not allowed", "Infinite value is not allowed");
+        
     }
 }

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -162,6 +162,11 @@ namespace Akka.Hosting
             return AddHocon(builder, hoconText, addMode);
         }
 
+        public static AkkaConfigurationBuilder WithActorAskTimeout(this AkkaConfigurationBuilder builder, TimeSpan timeout)
+        {
+            return AddHocon(builder, $"akka.actor.ask-timeout = {timeout.ToHocon(true, true)}", HoconAddMode.Prepend);
+        }
+        
         /// <summary>
         /// Configures the <see cref="ProviderSelection"/> for this <see cref="ActorSystem"/>. Can be used to
         /// configure whether or not Akka, Akka.Remote, or Akka.Cluster starts.

--- a/src/Akka.Hosting/AkkaOptions.cs
+++ b/src/Akka.Hosting/AkkaOptions.cs
@@ -1,0 +1,133 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AkkaOptions.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.Hosting;
+
+public enum TriStateValue
+{
+    None,
+    All,
+    Some
+}
+
+public class DeadLetterOptions
+{
+    /// <summary>
+    /// Flag to indicate if dead letter should be logged, or published to <see cref="ActorSystem.EventStream"/> as
+    /// <see cref="DeadLetter"/>, <see cref="Dropped"/>, or <see cref="UnhandledMessage"/>.
+    /// If set to <see cref="TriStateValue.Some"/>, only the first N number of dead letters will be logged,
+    /// where N is equal to <see cref="LogCount"/>.
+    /// </summary>
+    public TriStateValue ShouldLog { get; set; } = TriStateValue.Some;
+    
+    /// <summary>
+    /// Number of dead letter messages to be logged. Only effective if <see cref="ShouldLog"/> is set to
+    /// <see cref="TriStateValue.Some"/>
+    /// </summary>
+    public int LogCount { get; set; } = 10;
+    
+    /// <summary>
+    /// Flag to indicate that log letters should not be logged while the <see cref="ActorSystem"/> is shutting down.
+    /// </summary>
+    public bool? LogDuringShutdown { get; set; }
+    
+    /// <summary>
+    /// Time delay to re-enable dead letter logging when <see cref="ShouldLog"/> is set to
+    /// <see cref="TriStateValue.Some"/>. Suspends logging forever if set to less than or equal to 0, 
+    /// </summary>
+    public TimeSpan? LogSuspendDuration { get; set; }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("akka {");
+        sb.AppendLine($@"log-dead-letters = {ShouldLog switch
+        {
+            TriStateValue.All => "on",
+            TriStateValue.None => "off",
+            _ => LogCount
+        }}");
+        if (LogDuringShutdown is { })
+            sb.AppendLine($"log-dead-letters-during-shutdown = {LogDuringShutdown.ToHocon()}");
+        if (LogSuspendDuration is { })
+            sb.AppendLine($"log-dead-letters-suspend-duration = {LogSuspendDuration.ToHocon(allowInfinite: true, zeroIsInfinite: true)}");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}
+
+public class DebugOptions
+{
+    /// <summary>
+    /// Enable logging of any received message at <see cref="LogLevel.DebugLevel"/> level.
+    /// </summary>
+    public bool? Receive { get; set; }
+    
+    /// <summary>
+    /// Enable <see cref="LogLevel.DebugLevel"/> logging of all <see cref="IAutoReceivedMessage"/> messages
+    /// (for example, <see cref="Kill"/>, <see cref="PoisonPill"/>, etc).
+    /// </summary>
+    public bool? AutoReceive { get; set; }
+    
+    /// <summary>
+    /// Enable <see cref="LogLevel.DebugLevel"/> logging of actor lifecycle changes
+    /// </summary>
+    public bool? LifeCycle { get; set; }
+    
+    /// <summary>
+    /// Enable <see cref="LogLevel.DebugLevel"/> logging of <see cref="FSM{TState,TData}"/> for events, transitions
+    /// and timers.
+    /// </summary>
+    public bool? FiniteStateMachine { get; set; }
+    
+    /// <summary>
+    /// Enable <see cref="LogLevel.DebugLevel"/> logging of subscription changes on the
+    /// <see cref="ActorSystem.EventStream"/>
+    /// </summary>
+    public bool? EventStream { get; set; }
+    
+    /// <summary>
+    /// Enable <see cref="LogLevel.DebugLevel"/> logging of unhandled messages
+    /// </summary>
+    public bool? Unhandled { get; set; }
+    
+    /// <summary>
+    /// Enable <see cref="LogLevel.DebugLevel"/> logging of misconfigured routers
+    /// </summary>
+    public bool? RouterMisconfiguration { get; set; }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        if (Receive is { })
+            sb.AppendLine($"receive = {Receive.ToHocon()}");
+        if(AutoReceive is { })
+            sb.AppendLine($"autoreceive = {AutoReceive.ToHocon()}");
+        if (LifeCycle is { })
+            sb.AppendLine($"lifecycle = {LifeCycle.ToHocon()}");
+        if (FiniteStateMachine is { })
+            sb.AppendLine($"fsm = {FiniteStateMachine.ToHocon()}");
+        if (EventStream is { })
+            sb.AppendLine($"event-stream = {EventStream.ToHocon()}");
+        if (Unhandled is { })
+            sb.AppendLine($"unhandled = {Unhandled.ToHocon()}");
+        if (RouterMisconfiguration is { })
+            sb.AppendLine($"router-misconfiguration = {RouterMisconfiguration.ToHocon()}");
+        
+        if(sb.Length == 0)
+            return string.Empty;
+
+        sb.Insert(0, "akka.actor.debug {");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}

--- a/src/Akka.Hosting/HoconExtensions.cs
+++ b/src/Akka.Hosting/HoconExtensions.cs
@@ -35,15 +35,25 @@ namespace Akka.Hosting
         public static string ToHocon(this bool value)
             => value ? "on" : "off";
 
-        public static string ToHocon(this TimeSpan? value)
+        public static string ToHocon(this TimeSpan? value, bool allowInfinite = false, bool zeroIsInfinite = false)
         {
             if (value is null)
                 throw new ConfigurationException("Value can not be null");
-            
-            return value.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+            return value.Value.ToHocon(allowInfinite, zeroIsInfinite);
         }
 
-        public static string ToHocon(this TimeSpan value)
-            => value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+        public static string ToHocon(this TimeSpan value, bool allowInfinite = false, bool zeroIsInfinite = false)
+        {
+            if (!allowInfinite)
+            {
+                if ((zeroIsInfinite && value <= TimeSpan.Zero) || (!zeroIsInfinite && value < TimeSpan.Zero))
+                    throw new ConfigurationException("Infinite value is not allowed");
+            }
+
+            if ((zeroIsInfinite && value <= TimeSpan.Zero) || (!zeroIsInfinite && value < TimeSpan.Zero))
+                return "infinite";
+            
+            return value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+        }
     }
 }

--- a/src/Akka.Hosting/LoggerConfigBuilder.cs
+++ b/src/Akka.Hosting/LoggerConfigBuilder.cs
@@ -41,6 +41,10 @@ namespace Akka.Hosting
         /// </summary>
         public bool LogConfigOnStart { get; set; } = false;
 
+        public DeadLetterOptions? DeadLetterOptions { get; set; }
+
+        public DebugOptions? DebugOptions { get; set; }
+
         /// <summary>
         /// Clear all loggers currently registered.
         /// </summary>
@@ -80,6 +84,11 @@ namespace Akka.Hosting
                 .Append("akka.loglevel=").AppendLine(ParseLogLevel(LogLevel))
                 .Append("akka.loggers=[").Append(string.Join(",", _loggers.Select(t => $"\"{t.AssemblyQualifiedName}\""))).AppendLine("]")
                 .Append("akka.log-config-on-start=").AppendLine(LogConfigOnStart ? "true" : "false");
+            if (DebugOptions is { })
+                sb.AppendLine(DebugOptions.ToString());
+            if (DeadLetterOptions is { })
+                sb.AppendLine(DeadLetterOptions.ToString());
+            
             return ConfigurationFactory.ParseString(sb.ToString());
         }
 

--- a/src/Akka.Hosting/Properties/FriendsOf.cs
+++ b/src/Akka.Hosting/Properties/FriendsOf.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.Hosting.Tests")]


### PR DESCRIPTION
Fixes #106

## Changes

- Add options to modify how dead letters are logged in the logger builder
- Add options to modify how actor debug messages are logged in the logger builder
- Add `WithActorAskTimeout()` extension method
