### PR TITLE
Fix Hosting.TestKit logging problem

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -182,7 +182,9 @@ namespace Akka.Hosting.Logging
     public class LoggerFactoryLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
         public const string DefaultTimeStampFormat = "yy/MM/dd-HH:mm:ss.ffff";
+        protected readonly Akka.Event.ILoggingAdapter InternalLogger;
         public LoggerFactoryLogger() { }
+        protected virtual void Log(Akka.Event.LogEvent log, Akka.Actor.ActorPath path) { }
         protected override void PostStop() { }
         protected override bool Receive(object message) { }
     }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -1,5 +1,11 @@
-﻿namespace Akka.Hosting.TestKit.Internals
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Hosting.TestKit.Tests")]
+namespace Akka.Hosting.TestKit.Internals
 {
+    public class TestKitLoggerFactoryLogger : Akka.Hosting.Logging.LoggerFactoryLogger
+    {
+        public TestKitLoggerFactoryLogger() { }
+        protected override bool Receive(object message) { }
+    }
     public class XUnitLogger : Microsoft.Extensions.Logging.ILogger
     {
         public XUnitLogger(string category, Xunit.Abstractions.ITestOutputHelper helper, Microsoft.Extensions.Logging.LogLevel logLevel) { }

--- a/src/Akka.Hosting.TestKit.Tests/LoggerSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/LoggerSpec.cs
@@ -1,0 +1,82 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="LoggerSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.TestKit.Internals;
+using Xunit;
+using Xunit.Abstractions;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+public class LoggerSpec: TestKit
+{
+    public LoggerSpec(ITestOutputHelper output): base(output: output, logLevel: LogLevel.Debug)
+    {
+    }
+
+    internal override async Task LoggerHook(ActorSystem system, IActorRegistry registry)
+    {
+        var extSystem = (ExtendedActorSystem)system;
+        var logger = extSystem.SystemActorOf(Props.Create(() => new MockLogger()), "log-test");
+        registry.Register<MockLogger>(logger);
+        await logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream));
+    }
+    
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact(DisplayName = "TestKit ILoggerFactory logger should log messages")]
+    public void TestKitLoggerFactoryLoggerTest()
+    {
+        var loggerActor = ActorRegistry.Get<MockLogger>();
+        loggerActor.Tell(TestActor);
+
+        var logger = Event.Logging.GetLogger(Sys, "log-test");
+        
+        logger.Debug("debug");
+        ExpectMsg<Debug>(i => i.Message.ToString() == "debug");
+        
+        logger.Info("info");
+        ExpectMsg<Info>(i => i.Message.ToString() == "info");
+        
+        logger.Warning("warn");
+        ExpectMsg<Warning>(i => i.Message.ToString() == "warn");
+        
+        logger.Error("err");
+        ExpectMsg<Error>(i => i.Message.ToString() == "err");
+    }
+    
+    private class MockLogger: TestKitLoggerFactoryLogger
+    {
+        private IActorRef? _probe;
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case IActorRef actor:
+                    _probe = actor;
+                    return true;
+                default:
+                    return base.Receive(message);
+            }
+        }
+
+        protected override void Log(LogEvent log, ActorPath path)
+        {
+            if(log.LogSource.StartsWith("log-test"))
+                _probe.Tell(log);
+            base.Log(log, path);
+        }
+    }
+
+}

--- a/src/Akka.Hosting.TestKit/Internals/TestKitLoggerFactoryLogger.cs
+++ b/src/Akka.Hosting.TestKit/Internals/TestKitLoggerFactoryLogger.cs
@@ -1,0 +1,30 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="LoggerFactoryLogger.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.Logging;
+
+namespace Akka.Hosting.TestKit.Internals
+{
+    public class TestKitLoggerFactoryLogger: LoggerFactoryLogger
+    {
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            { 
+                case InitializeLogger init:
+                    InternalLogger.Info($"{nameof(TestKitLoggerFactoryLogger)} started");
+                    ((EventStream)init.LoggingBus).Subscribe<LogEvent>(Self);
+                    Sender.Tell(new LoggerInitialized());
+                    return true;
+                
+                default:
+                    return base.Receive(message);
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit/Properties/FriendsOf.cs
+++ b/src/Akka.Hosting.TestKit/Properties/FriendsOf.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.Hosting.TestKit.Tests")]

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -92,11 +92,9 @@ namespace Akka.Hosting.TestKit
 
                 if (Output is { })
                 {
-                    builder.StartActors(async (system, _) =>
+                    builder.StartActors(async (system, registry) =>
                     {
-                        var extSystem = (ExtendedActorSystem)system;
-                        var logger = extSystem.SystemActorOf(Props.Create(() => new LoggerFactoryLogger()), "log-test");
-                        await logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream));
+                        await LoggerHook(system, registry);
                     });
                 }
 
@@ -108,6 +106,13 @@ namespace Akka.Hosting.TestKit
                     _initialized.SetResult(Done.Instance);
                 });
             });
+        }
+
+        internal virtual async Task LoggerHook(ActorSystem system, IActorRegistry registry)
+        {
+            var extSystem = (ExtendedActorSystem)system;
+            var logger = extSystem.SystemActorOf(Props.Create(() => new TestKitLoggerFactoryLogger()), "log-test");
+            await logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream));
         }
 
         protected virtual Config? Config { get; } = null;

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -26,7 +26,7 @@ namespace Akka.Hosting.Logging
         /// <summary>
         /// only used when we're shutting down / spinning up
         /// </summary>
-        private readonly ILoggingAdapter _internalLogger = Akka.Event.Logging.GetLogger(Context.System.EventStream, nameof(LoggerFactoryLogger));
+        protected readonly ILoggingAdapter InternalLogger = Akka.Event.Logging.GetLogger(Context.System.EventStream, nameof(LoggerFactoryLogger));
         private readonly ILoggerFactory _loggerFactory;
         private ILogger<ActorSystem> _akkaLogger;
         private readonly string _messageFormat;
@@ -45,7 +45,7 @@ namespace Akka.Hosting.Logging
 
         protected override void PostStop()
         {
-            _internalLogger.Info($"{nameof(LoggerFactoryLogger)} stopped");
+            InternalLogger.Info($"{nameof(LoggerFactoryLogger)} stopped");
         }
 
         protected override bool Receive(object message)
@@ -53,7 +53,7 @@ namespace Akka.Hosting.Logging
             switch (message)
             { 
                 case InitializeLogger _:
-                    _internalLogger.Info($"{nameof(LoggerFactoryLogger)} started");
+                    InternalLogger.Info($"{nameof(LoggerFactoryLogger)} started");
                     Sender.Tell(new LoggerInitialized());
                     return true;
                 
@@ -66,7 +66,7 @@ namespace Akka.Hosting.Logging
             }
         }
         
-        private void Log(LogEvent log, ActorPath path)
+        protected virtual void Log(LogEvent log, ActorPath path)
         {
             var message = GetMessage(log.Message);
             _akkaLogger.Log(GetLogLevel(log.LogLevel()), log.Cause, _messageFormat, GetArgs(log, path, message));


### PR DESCRIPTION
Fixes #177

The way the logger works inside Akka.Hosting and Akka.Hosting.TestKit is different. TestKit logger needs to actually listen to the event bus because it is wired manually.

## Changes

- Make LoggerFactoryLogger methods virtual so it can be overriden
- Inharit LoggerFactoryLogger class in TestKit specialized logger and override the Receive method
