### PR TITLE
Better string to HOCON literal conversion, accounting for all illegal characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Akka.Hosting
 
-> **BETA**: this project is currently in beta status as part of the [Akka.NET v1.5 development effort](https://getakka.net/community/whats-new/akkadotnet-v1.5.html), but the packages published in this repository will be backwards compatible for Akka.NET v1.4 users.
+> This package is now stable.
 
 HOCON-less configuration, application lifecycle management, `ActorSystem` startup, and actor instantiation for [Akka.NET](https://getakka.net/).
 

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -95,7 +95,7 @@ namespace Akka.Hosting
     {
         public static string ToHocon(this bool value) { }
         public static string ToHocon(this bool? value) { }
-        public static string ToHocon(this string text) { }
+        public static string ToHocon(this string? text) { }
         public static string ToHocon(this System.TimeSpan value, bool allowInfinite = false, bool zeroIsInfinite = false) { }
         public static string ToHocon(this System.TimeSpan? value, bool allowInfinite = false, bool zeroIsInfinite = false) { }
     }

--- a/src/Akka.Hosting.Tests/UtilSpec.cs
+++ b/src/Akka.Hosting.Tests/UtilSpec.cs
@@ -49,4 +49,41 @@ public class UtilSpec
             .Throw<ConfigurationException>("Infinite value is not allowed", "Infinite value is not allowed");
         
     }
+
+    [InlineData("$")]
+    [InlineData("\"")]
+    [InlineData("{")]
+    [InlineData("}")]
+    [InlineData("[")]
+    [InlineData("]")]
+    [InlineData(":")]
+    [InlineData("=")]
+    [InlineData(",")]
+    [InlineData("#")]
+    [InlineData("`")]
+    [InlineData("^")]
+    [InlineData("?")]
+    [InlineData("!")]
+    [InlineData("@")]
+    [InlineData("*")]
+    [InlineData("&")]
+    [InlineData("\\")]
+    [Theory(DisplayName = "HoconExtensions String.ToHocon should put illegal characters in quotes")]
+    public void StringToHoconTest(string input)
+    {
+        var result = input.ToHocon();
+        result.Length.Should().Be(3);
+        result.Should().StartWith("\"").And.EndWith("\"");
+    }
+    
+    [InlineData("ab\ncd")]
+    [InlineData("ab\r\ncd")]
+    [Theory(DisplayName = "HoconExtensions String.ToHocon should put new lines in triple double quotes")]
+    public void StringToHoconNewlineTest(string input)
+    {
+        var result = input.ToHocon();
+        result.Should().Contain(input);
+        result.Should().StartWith("\"\"\"").And.EndWith("\"\"\"");
+    }
+    
 }

--- a/src/Akka.Hosting/HoconExtensions.cs
+++ b/src/Akka.Hosting/HoconExtensions.cs
@@ -27,7 +27,7 @@ namespace Akka.Hosting
                 return $"\"\"\"{text}\"\"\"";
 
             // Not going to bother to check quote validity
-            if (text.StartsWith("\"") && text.EndsWith("\""))
+            if (text.Length > 1 && text.StartsWith("\"") && text.EndsWith("\""))
                 return text;
             
             // double quote support

--- a/src/Akka.Hosting/HoconExtensions.cs
+++ b/src/Akka.Hosting/HoconExtensions.cs
@@ -14,14 +14,24 @@ namespace Akka.Hosting
 {
     public static class HoconExtensions
     {
-        private static readonly Regex EscapeRegex = new Regex("[ \t:]{1}", RegexOptions.Compiled);
+        private static readonly Regex EscapeRegex = new ("[][$\"\\\\{}:=,#`^?!@*&]{1}", RegexOptions.Compiled);
         
-        public static string ToHocon(this string text)
+        public static string ToHocon(this string? text)
         {
+            // nullable literal value support
             if (text is null)
-                throw new ConfigurationException("Value can not be null");
+                return "null";
+
+            // triple double quote multi line support
+            if (text.Contains("\n") && !text.StartsWith("\"\"\"") && !text.EndsWith("\"\"\""))
+                return $"\"\"\"{text}\"\"\"";
+
+            // Not going to bother to check quote validity
+            if (text.StartsWith("\"") && text.EndsWith("\""))
+                return text;
             
-            return EscapeRegex.IsMatch(text) || text == string.Empty ? $"\"{text}\"" : text;
+            // double quote support
+            return text == string.Empty || EscapeRegex.IsMatch(text) ? $"\"{text}\"" : text;
         }
 
         public static string ToHocon(this bool? value)


### PR DESCRIPTION
## Changes
Better string to HOCON literal conversion:
- accounts for all illegal characters
- support for triple quote
- support for null