### PR TITLE
Fix string.ToHocon() backslash escape character compatibility

### DIFF
--- a/src/Akka.Hosting.Tests/UtilSpec.cs
+++ b/src/Akka.Hosting.Tests/UtilSpec.cs
@@ -72,18 +72,22 @@ public class UtilSpec
     public void StringToHoconTest(string input)
     {
         var result = input.ToHocon();
-        result.Length.Should().Be(3);
+
+        switch (input)
+        {
+            case "\"":
+                // special case for quote
+                result.Length.Should().Be(4);
+                break;
+            case "\\":
+                // special case for backslash
+                result.Length.Should().Be(4);
+                break;
+            default:
+                result.Length.Should().Be(3);
+                break;
+        }
+        
         result.Should().StartWith("\"").And.EndWith("\"");
     }
-    
-    [InlineData("ab\ncd")]
-    [InlineData("ab\r\ncd")]
-    [Theory(DisplayName = "HoconExtensions String.ToHocon should put new lines in triple double quotes")]
-    public void StringToHoconNewlineTest(string input)
-    {
-        var result = input.ToHocon();
-        result.Should().Contain(input);
-        result.Should().StartWith("\"\"\"").And.EndWith("\"\"\"");
-    }
-    
 }


### PR DESCRIPTION
## Changes
* Add escape character compatibility to string.ToHocon()
* Remove triple quote support, not needed because we now use escape characters