### PR TITLE
[BACKPORT #225] Nuke.Common-6.3.0

### DIFF
--- a/.github/workflows/Windows_release.yml
+++ b/.github/workflows/Windows_release.yml
@@ -26,7 +26,7 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Make build.sh executable
         run: chmod +x ./build.sh
       - name: Make build.cmd executable
@@ -38,7 +38,7 @@ jobs:
         with:
           dotnet-version: 6.0.*
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -33,7 +33,7 @@ jobs:
     name: windows-latest
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Make build.sh executable
         run: chmod +x ./build.sh
       - name: Make build.cmd executable
@@ -45,7 +45,7 @@ jobs:
         with:
           dotnet-version: 6.0.*
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
@@ -53,11 +53,13 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd All'
         run: ./build.cmd All
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Make build.sh executable
         run: chmod +x ./build.sh
       - name: Make build.cmd executable
@@ -69,7 +71,7 @@ jobs:
         with:
           dotnet-version: 6.0.*
       - name: Cache .nuke/temp, ~/.nuget/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .nuke/temp
@@ -77,3 +79,5 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd All'
         run: ./build.cmd All
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -24,7 +24,7 @@ using Nuke.Common.Utilities;
     OnPushTags = new[] { "*" },
     AutoGenerate = false,
     InvokedTargets = new[] { nameof(NuGet) },
-    ImportSecrets = new[] { "Nuget_Key", "GITHUB_TOKEN" },
+    ImportSecrets = new[] { "Nuget_Key" },
     PublishArtifacts = true,
     EnableGitHubToken = true)
 ]

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -259,8 +259,7 @@ partial class Build : NukeBuild
         .Unlisted()
         .After(CreateNuget)
         .Before(PublishNuget)
-        .OnlyWhenDynamic(() => !SignClientSecret.IsNullOrWhiteSpace())
-        .OnlyWhenDynamic(() => !SignClientUser.IsNullOrWhiteSpace())
+        .OnlyWhenDynamic(() => !SignClientSecret.IsNullOrWhiteSpace() && !SignClientUser.IsNullOrWhiteSpace())
         .Executes(() =>
         {
             var assemblies = OutputNuget.GlobFiles("*.nupkg");
@@ -307,7 +306,7 @@ partial class Build : NukeBuild
         });
     Target All => _ => _
      .Description("Executes NBench, Tests and Nuget targets/commands")
-     .DependsOn(BuildRelease, RunTests, NBench, Nuget);
+     .DependsOn(BuildRelease, RunTests, NBench);
 
     Target NBench => _ => _
      .Description("Runs all BenchMarkDotNet tests")

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.2.1" />
-	  <PackageReference Include="docfx.console" Version="2.59.4" ExcludeAssets="build"/>
+    <PackageReference Include="Nuke.Common" Version="6.3.0" />
+	  <PackageReference Include="docfx.console" Version="2.59.4" ExcludeAssets="build" />
   </ItemGroup>
 
 </Project>

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -6,7 +6,7 @@
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Akka.Hosting/Akka.Hosting.csproj
+++ b/src/Akka.Hosting/Akka.Hosting.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,12 +2,9 @@
     <PropertyGroup>
         <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
         <Authors>Akka.NET Team</Authors>
-        <VersionPrefix>1.0.1</VersionPrefix>
-        <PackageReleaseNotes>Version 1.0.1 fixes options bug used in the cluster sharding Akka.Hosting extension method.
-* [Update Akka.NET from 1.4.45 to 1.4.48](https://github.com/akkadotnet/akka.net/releases/tag/1.4.48)
-* [Fix SimpleDemo project failing on `Development` environment](https://github.com/akkadotnet/Akka.Hosting/pull/184)
-* [Add F# CustomJournalIdDemo project](https://github.com/akkadotnet/Akka.Hosting/pull/183)
-* [Fix cluster sharding hosting extension method options bug](https://github.com/akkadotnet/Akka.Hosting/pull/186)</PackageReleaseNotes>
+        <VersionPrefix>1.0.3</VersionPrefix>
+        <PackageReleaseNotes>Version 1.0.3 fixes a bug in the HOCON configuration generator where it did not generate the proper escape characters for the generated HOCON string.
+* [Fix HOCON generator](https://github.com/akkadotnet/Akka.Hosting/pull/207)</PackageReleaseNotes>
         <PackageIcon>akkalogo.png</PackageIcon>
         <PackageProjectUrl>
             https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
* [updates] Nuke 6.3.0
- removed `ImportSecrets = new[] { "Nuget_Key", "GITHUB_TOKEN" }`
- add `ImportSecrets = new[] { "Nuget_Key"}`

* .NET 6.0

* `.OnlyWhenDynamic(() => !SignClientSecret.IsNullOrWhiteSpace() && !SignClientUser.IsNullOrWhiteSpace())`

* `pr_validation` not needed for `nuget`


