### PR TITLE
Upgraded to Akka.NET v1.5.0-beta1

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -185,7 +185,6 @@ namespace Akka.Hosting.Logging
 {
     public class LoggerFactoryLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
-        public const string DefaultTimeStampFormat = "yy/MM/dd-HH:mm:ss.ffff";
         protected readonly Akka.Event.ILoggingAdapter InternalLogger;
         public LoggerFactoryLogger() { }
         protected virtual void Log(Akka.Event.LogEvent log, Akka.Actor.ActorPath path) { }

--- a/src/Akka.Hosting.Tests/Logging/LoggerConfigEnd2EndSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerConfigEnd2EndSpecs.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Hosting.Logging;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,120 @@
 ﻿<Project>
     <PropertyGroup>
-        <Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
+        <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
         <Authors>Akka.NET Team</Authors>
-        <VersionPrefix>1.0.3</VersionPrefix>
-        <PackageReleaseNotes>Version 1.0.3 fixes a bug in the HOCON configuration generator where it did not generate the proper escape characters for the generated HOCON string.
-* [Fix HOCON generator](https://github.com/akkadotnet/Akka.Hosting/pull/207)</PackageReleaseNotes>
+        <VersionPrefix>1.5.0-alpha4</VersionPrefix>
+        <PackageReleaseNotes><![CDATA[Version 1.5.0-alpha4 integrates Akka.NET v1.5 into Akka.Hosting
+• [Implement new cluster sharding options](https://github.com/akkadotnet/Akka.Hosting/pull/224)
+• [Add cluster sharding migration journal event adapter extension method](https://github.com/akkadotnet/Akka.Hosting/pull/226)
+• [Update Akka.NET to 1.5.0-alpha4](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0-alpha4)
+#### Upgrading From v1.4 To v1.5
+As noted in [the upgrade advisories](https://github.com/akkadotnet/akka.net/blob/c9ccc25207b5a4cfa963a5a23f96c0676fbbef10/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md)%2C there was a major change in Akka.Cluster.Sharding state storage. These notes contains the same documentation%2C but tailored for Akka.Hosting users
+The recommended settings for maximum ease-of-use for Akka.Cluster.Sharding in new applications going forward will be:
+csharp
+var options = new ShardOptions
+{
+    StateStoreMode = StateStoreMode.DData%2C
+    RememberEntitiesStore = RememberEntitiesStore.Eventsourced
+}%3B
+
+You will need to set these options manually because the default settings are set for backward compatibility.
+#### Migrating to New Sharding Storage From Akka.Persistence
+> **NOTE**
+> 
+> This section applies only to users who were using StateStoreMode = StateStoreMode.Persistence.
+Switching over to using RememberEntitiesStore = RememberEntitiesStore.Eventsourced will cause an initial migration of data from the ShardCoordinator's journal into separate event journals going forward.
+Upgrading to Akka.NET v1.5 will **cause an irreversible migration of Akka.Cluster.Sharding data*• for users who were previously running StateStoreMode = StateStoreMode.Persistence%2C so follow the steps below carefully:
+##### Step 1 • Upgrade to Akka.NET v1.5 With New Options Setup
+Update your Akka.Cluster.Sharding options to look like the following (adjust as necessary for your custom settings):
+csharp
+hostBuilder.Services.AddAkka("MyActorSystem"%2C builder =>
+{
+    var shardOptions = new ShardOptions
+    {
+        // If you don't run Akka.Cluster.Sharding with RememberEntities = true%2C
+        // then set this to false
+        RememberEntities = true%2C
+        RememberEntitiesStore = RememberEntitiesStore.Eventsourced%2C
+        StateStoreMode = StateStoreMode.Persistence%2C
+        //fail if upgrade doesn't succeed
+        FailOnInvalidEntityStateTransition = true
+    }%3B
+    // Modify these two options to suit your application%2C SqlServer used
+    // only as an illustration
+    var journalOptions = new SqlServerJournalOptions()%3B
+    var snapshotOptions = new SqlServerSnapshotOptions()%3B
+    builder
+        .WithClustering()
+        .WithSqlServerPersistence(journalOptions%2C snapshotOptions)
+        .WithShardRegion<UserActionsEntity>(
+            "userActions"%2C 
+            s => UserActionsEntity.Props(s)%2C
+            new UserMessageExtractor()%2C
+            // shardOptions is being used here
+            shardOptions)%3B
+    // Add the Akka.Cluster.Sharding migration journal event adapter
+    builder.WithClusterShardingJournalMigrationAdapter(journalOptions)%3B
+    // you can also declare the adapter by referencing the journal ID directly
+    builder.WithClusterShardingJournalMigrationAdapter("akka.persistence.journal.sql-server")%3B
+})
+
+With these HOCON settings in-place the following will happen:
+1. The old PersitentShardCoordinator state will be broken up • Remember entities data will be distributed to each of the PersistentShard actors%2C who will now use the new RememberEntitiesStore = RememberEntitiesStore.Eventsourced setting going forward%3B
+2. Old Akka.Cluster.Sharding.ShardCoordinator.IDomainEvent events will be upgraded to a new storage format via the injected Akka.Persistence event adapter%3B and
+3. The PersistentShardCoordinator will migrate its journal to the new format as well.
+##### Step 2 • Migrating Away From Persistence to DData
+Once your cluster has successfully booted up with these settings%2C you can now optionally move to using distributed data to store sharding state by changing StateStoreMode = StateStoreMode.DData and deploying a second time:
+csharp
+hostBuilder.Services.AddAkka("MyActorSystem"%2C builder =>
+{
+    var shardOptions = new ShardOptions
+    {
+        RememberEntities = true%2C
+        RememberEntitiesStore = RememberEntitiesStore.Eventsourced%2C
+        // Change this line of code
+        StateStoreMode = StateStoreMode.DData%2C
+        FailOnInvalidEntityStateTransition = true
+    }%3B
+    var journalOptions = new SqlServerJournalOptions()%3B
+    var snapshotOptions = new SqlServerSnapshotOptions()%3B
+    builder
+        .WithClustering()
+        .WithSqlServerPersistence(journalOptions%2C snapshotOptions)
+        .WithShardRegion<UserActionsEntity>(
+            "userActions"%2C 
+            s => UserActionsEntity.Props(s)%2C
+            new UserMessageExtractor()%2C
+            shardOptions)%3B
+    builder.WithClusterShardingJournalMigrationAdapter(journalOptions)%3B
+})
+
+Now you'll be running Akka.Cluster.Sharding with the recommended settings.
+#### Migrating to New Sharding Storage From Akka.DistributedData
+The migration process onto Akka.NET v1.5's new Cluster.Sharding storage system is less involved for users who were already using StateStoreMode = StateStoreMode.DData. All these users need to do is change the RememberEntitiesStore option to RememberEntitiesStore.Eventsourced
+csharp
+hostBuilder.Services.AddAkka("MyActorSystem"%2C builder =>
+{
+    var shardOptions = new ShardOptions
+    {
+        RememberEntities = true%2C
+        // Use this option setting
+        RememberEntitiesStore = RememberEntitiesStore.Eventsourced%2C
+        StateStoreMode = StateStoreMode.DData%2C
+        FailOnInvalidEntityStateTransition = true
+    }%3B
+    var journalOptions = new SqlServerJournalOptions()%3B
+    var snapshotOptions = new SqlServerSnapshotOptions()%3B
+    builder
+        .WithClustering()
+        .WithSqlServerPersistence(journalOptions%2C snapshotOptions)
+        .WithShardRegion<UserActionsEntity>(
+            "userActions"%2C 
+            s => UserActionsEntity.Props(s)%2C
+            new UserMessageExtractor()%2C
+            shardOptions)%3B
+    builder.WithClusterShardingJournalMigrationAdapter(journalOptions)%3B
+})
+]]></PackageReleaseNotes>
         <PackageIcon>akkalogo.png</PackageIcon>
         <PackageProjectUrl>
             https://github.com/akkadotnet/Akka.Hosting
@@ -26,7 +136,7 @@
         <TestSdkVersion>17.4.1</TestSdkVersion>
         <CoverletVersion>3.2.0</CoverletVersion>
 	    <XunitRunneVisualstudio>2.4.5</XunitRunneVisualstudio>
-        <AkkaVersion>1.5.0-alpha4</AkkaVersion>
+        <AkkaVersion>1.5.0-beta1</AkkaVersion>
         <MicrosoftExtensionsVersion>[3.0.0,)</MicrosoftExtensionsVersion>
     </PropertyGroup>
 

--- a/src/Examples/Akka.Hosting.LoggingDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.LoggingDemo/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider
             setup.AddLoggerFactory();
             
             // Example: Adding a serilog logger
-            //setup.AddLogger<SerilogLogger>();
+            //setup.AddLogger<SerilogLogger>(); // TODO: add back once upgraded to v1.5 APIs
         })
         .WithRemoting("localhost", 8110)
         .WithClustering(new ClusterOptions(){ Roles = new[]{ "myRole" }, 

--- a/src/Examples/Akka.Hosting.LoggingDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.LoggingDemo/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider
             setup.AddLoggerFactory();
             
             // Example: Adding a serilog logger
-            setup.AddLogger<SerilogLogger>();
+            //setup.AddLogger<SerilogLogger>();
         })
         .WithRemoting("localhost", 8110)
         .WithClustering(new ClusterOptions(){ Roles = new[]{ "myRole" }, 


### PR DESCRIPTION
## Changes

Had to rewrite the guts of the `LoggerFactoryLogger` - but it's a lot simpler now and more consistent with the rest of Akka.NET's loggers.

We'll need to update the Akka.Hosting.LoggingDemo to re-include Serilog support once https://github.com/akkadotnet/Akka.Logger.Serilog is also updated to support v1.5.0-beta1 or later.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.