### PR TITLE
Set version range for Akka.Hosting Msft.Ext to [3,)

### DIFF
--- a/src/Akka.Hosting/Akka.Hosting.csproj
+++ b/src/Akka.Hosting/Akka.Hosting.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
No need for us to target .NET 7.0 APIs so tightly.