### PR TITLE
Add `GetAync` method to `IRequiredActor<TActor>` to resolve issues where actor is not available upon injection (i.e. `BackgroundService`s)

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -124,6 +124,7 @@ namespace Akka.Hosting
     public interface IRequiredActor<TActor>
     {
         Akka.Actor.IActorRef ActorRef { get; }
+        System.Threading.Tasks.Task<Akka.Actor.IActorRef> GetAsync(System.Threading.CancellationToken cancellationToken = default);
     }
     public sealed class LoggerConfigBuilder
     {
@@ -152,6 +153,7 @@ namespace Akka.Hosting
     {
         public RequiredActor(Akka.Hosting.IReadOnlyActorRegistry registry) { }
         public Akka.Actor.IActorRef ActorRef { get; }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> GetAsync(System.Threading.CancellationToken cancellationToken = default) { }
     }
     public delegate System.Threading.Tasks.Task StartupTask(Akka.Actor.ActorSystem system, Akka.Hosting.IActorRegistry registry);
     public enum TriStateValue

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Akka.Hosting.TestKit\Akka.Hosting.TestKit.csproj" />
     <ProjectReference Include="..\Akka.Hosting\Akka.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/Akka.Hosting.Tests/Bugfix208Specs.cs
+++ b/src/Akka.Hosting.Tests/Bugfix208Specs.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Akka.Hosting.Tests;
+
+public class Bugfix208Specs : TestKit.TestKit
+{
+    private class MyTestActor : ReceiveActor
+    {
+        public record SetData(string Data);
+
+        public record GetData();
+        
+        private string _data = string.Empty;
+        
+        public MyTestActor()
+        {
+            Receive<SetData>(s =>
+            {
+                _data = s.Data;
+            });
+            
+            Receive<GetData>(g =>
+            {
+                Sender.Tell(_data);
+            });
+        }
+    }
+    
+    private class TestActorKey{}
+    
+    private class MyBackgroundService : BackgroundService
+    {
+        private readonly IActorRef _testActor;
+
+        public MyBackgroundService(IRequiredActor<TestActorKey> requiredActor)
+        {
+            _testActor = requiredActor.ActorRef;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _testActor.Tell("BackgroundService started");
+            return Task.CompletedTask;
+        }
+    }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddHostedService<MyBackgroundService>();
+        base.ConfigureServices(context, services);
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithActors((system, registry, arg3) =>
+        {
+            registry.Register<TestActorKey>(system.ActorOf(Props.Create(() => new MyTestActor()), "test-actor"));
+        });
+    }
+
+    /// <summary>
+    /// Reproduction for https://github.com/akkadotnet/Akka.Hosting/issues/208
+    /// </summary>
+    [Fact]
+    public async Task ShouldStartHostedServiceThatDependsOnActor()
+    {
+        // arrange
+        var testActorRef = ActorRegistry.Get<TestActorKey>();
+
+        // act
+
+        // assert
+        await AwaitAssertAsync(async () =>
+        {
+            var r = await testActorRef.Ask<string>(new MyTestActor.GetData(), TimeSpan.FromMilliseconds(100));
+            r.Should().Be("BackgroundService started");
+        });
+    }
+}

--- a/src/Akka.Hosting.Tests/Logging/LogMessageFormatterSpec.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogMessageFormatterSpec.cs
@@ -40,7 +40,7 @@ public class LogMessageFormatterSpec
         try
         {
             var sys = host.Services.GetRequiredService<ActorSystem>();
-            var testKit = new TestKit.Xunit2.TestKit(sys);
+            var testKit = new Akka.TestKit.Xunit2.TestKit(sys);
 
             var probe = testKit.CreateTestProbe();
             sys.EventStream.Subscribe(probe, typeof(Error));

--- a/src/Akka.Hosting.Tests/Logging/LoggerConfigEnd2EndSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerConfigEnd2EndSpecs.cs
@@ -13,7 +13,7 @@ using static Akka.Hosting.Tests.TestHelpers;
 
 namespace Akka.Hosting.Tests.Logging;
 
-public class LoggerConfigEnd2EndSpecs : TestKit.Xunit2.TestKit
+public class LoggerConfigEnd2EndSpecs : Akka.TestKit.Xunit2.TestKit
 {
     private class CustomLoggingProvider : ILoggerProvider
     {

--- a/src/Akka.Hosting/ActorRegistry.cs
+++ b/src/Akka.Hosting/ActorRegistry.cs
@@ -36,18 +36,7 @@ namespace Akka.Hosting
         /// <returns>A Task that will return the <see cref="IActorRef"/> using the given key.</returns>
         Task<IActorRef> GetAsync(CancellationToken cancellationToken = default);
     }
-
-    /// <summary>
-    /// INTERNAL API
-    /// </summary>
-    internal static class RequiredActorDefaults
-    {
-        /// <summary>
-        /// Used to timeout sync-over-async operations used when retrieving actors from the registry.
-        /// </summary>
-        public static readonly TimeSpan ActorFetchTimeout = TimeSpan.FromSeconds(5);
-    }
-
+    
     /// <summary>
     /// INTERNAL API
     /// </summary>


### PR DESCRIPTION
## Changes

Fixes #208 - working on fix to ensure that other `BackgroundService` / `IHostedService` implementations can still depend on `IRequiredActor<TActor>` without getting blown up by MSFT.EXT.DI while it waits for the `AkkaService` to start.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #208 