### PR TITLE
Make `AkkaHostedService` public

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -45,10 +45,26 @@ namespace Akka.Hosting
             where T : Akka.Actor.IExtensionId { }
         public Akka.Hosting.AkkaConfigurationBuilder WithExtensions(params System.Type[] extensions) { }
     }
+    public abstract class AkkaHostedService : Microsoft.Extensions.Hosting.IHostedService
+    {
+        protected AkkaHostedService(Akka.Hosting.AkkaConfigurationBuilder configurationBuilder, System.IServiceProvider serviceProvider, Microsoft.Extensions.Logging.ILogger<Akka.Hosting.AkkaHostedService> logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime) { }
+        protected Akka.Actor.ActorSystem ActorSystem { get; }
+        protected Akka.Actor.CoordinatedShutdown CoordinatedShutdown { get; }
+        protected Microsoft.Extensions.Hosting.IHostApplicationLifetime HostApplicationLifetime { get; }
+        protected bool Initialized { get; }
+        protected Microsoft.Extensions.Logging.ILogger<Akka.Hosting.AkkaHostedService> Logger { get; }
+        protected System.IServiceProvider ServiceProvider { get; }
+        protected System.Threading.Tasks.Task StartAkkaAsync(System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) { }
+        protected System.Threading.Tasks.Task StopAkkaAsync(System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { }
+    }
     public static class AkkaHostingExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAkka(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string actorSystemName, System.Action<Akka.Hosting.AkkaConfigurationBuilder> builder) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAkka(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string actorSystemName, System.Action<Akka.Hosting.AkkaConfigurationBuilder, System.IServiceProvider> builder) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAkka<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string actorSystemName, System.Action<Akka.Hosting.AkkaConfigurationBuilder, System.IServiceProvider> builder)
+            where T : Akka.Hosting.AkkaHostedService { }
         public static Akka.Hosting.AkkaConfigurationBuilder AddHocon(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Configuration.Config hocon, Akka.Hosting.HoconAddMode addMode) { }
         public static Akka.Hosting.AkkaConfigurationBuilder AddHocon(this Akka.Hosting.AkkaConfigurationBuilder builder, Microsoft.Extensions.Configuration.IConfiguration configuration, Akka.Hosting.HoconAddMode addMode) { }
         public static Akka.Hosting.AkkaConfigurationBuilder AddHoconFile(this Akka.Hosting.AkkaConfigurationBuilder builder, string hoconFilePath, Akka.Hosting.HoconAddMode addMode) { }

--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -8,66 +8,109 @@ using Microsoft.Extensions.Logging;
 
 namespace Akka.Hosting
 {
-    /// <summary>
-    /// INTERNAL API
-    /// </summary>
-    internal sealed class AkkaHostedService : IHostedService
+    public abstract class AkkaHostedService : IHostedService
     {
         private ActorSystem? _actorSystem;
         private CoordinatedShutdown? _coordinatedShutdown; // grab a reference to CoordinatedShutdown early
-        private readonly IServiceProvider _serviceProvider;
+        
+        protected IServiceProvider ServiceProvider { get; }
+        protected IHostApplicationLifetime HostApplicationLifetime { get; }
+        protected ILogger<AkkaHostedService> Logger { get; }
+        
         private readonly AkkaConfigurationBuilder _configurationBuilder;
-        private readonly IHostApplicationLifetime _hostApplicationLifetime;
-        private readonly ILogger<AkkaHostedService> _logger;
 
-        public AkkaHostedService(AkkaConfigurationBuilder configurationBuilder, IServiceProvider serviceProvider,
+        protected AkkaHostedService(AkkaConfigurationBuilder configurationBuilder, IServiceProvider serviceProvider,
             ILogger<AkkaHostedService> logger, IHostApplicationLifetime applicationLifetime)
         {
             _configurationBuilder = configurationBuilder;
-            _hostApplicationLifetime = applicationLifetime;
-            _serviceProvider = serviceProvider;
-            _logger = logger;
+            HostApplicationLifetime = applicationLifetime;
+            ServiceProvider = serviceProvider;
+            Logger = logger;
         }
-
-        public async Task StartAsync(CancellationToken cancellationToken)
+        
+        protected ActorSystem ActorSystem
         {
-            try
+            get
             {
-                _actorSystem = _serviceProvider.GetRequiredService<ActorSystem>();
-                _coordinatedShutdown = CoordinatedShutdown.Get(_actorSystem);
-                await _configurationBuilder.StartAsync(_actorSystem);
-
-                async Task TerminationHook()
-                {
-                    await _actorSystem.WhenTerminated.ConfigureAwait(false);
-                    _hostApplicationLifetime.StopApplication();
-                }
-
-                // terminate the application if the Sys is terminated first
-                // this can happen in instances such as Akka.Cluster membership changes
-#pragma warning disable CS4014
-                TerminationHook();
-#pragma warning restore CS4014
-            }
-            catch (Exception ex)
-            {
-                _logger.Log(LogLevel.Critical, ex, "Unable to start AkkaHostedService - shutting down application");
-                _hostApplicationLifetime.StopApplication();
+                if (_actorSystem is null)
+                    throw new Exception("ActorSystem has not been initialized");
+                return _actorSystem;
             }
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
+        protected CoordinatedShutdown CoordinatedShutdown
+        {
+            get
+            {
+                if (_coordinatedShutdown is null)
+                    throw new Exception("ActorSystem has not been initialized");
+                return _coordinatedShutdown;
+            }
+        }
+
+        protected bool Initialized => _coordinatedShutdown is not null;
+
+        protected async Task StartAkkaAsync(CancellationToken cancellationToken)
+        {
+            _actorSystem = ServiceProvider.GetRequiredService<ActorSystem>();
+            _coordinatedShutdown = CoordinatedShutdown.Get(_actorSystem);
+            await _configurationBuilder.StartAsync(_actorSystem);
+
+            async Task TerminationHook()
+            {
+                await _actorSystem.WhenTerminated.ConfigureAwait(false);
+                HostApplicationLifetime.StopApplication();
+            }
+
+            // terminate the application if the Sys is terminated first
+            // this can happen in instances such as Akka.Cluster membership changes
+#pragma warning disable CS4014
+            TerminationHook();
+#pragma warning restore CS4014
+        }
+
+        protected async Task StopAkkaAsync(CancellationToken cancellationToken)
         {
             // ActorSystem may have failed to start - skip shutdown sequence if that's the case
             // so error message doesn't get conflated.
-            if (_coordinatedShutdown == null)
-            {
+            if (!Initialized)
                 return;
-            }
             
             // run full CoordinatedShutdown on the Sys
-            await _coordinatedShutdown.Run(CoordinatedShutdown.ClrExitReason.Instance)
+            await CoordinatedShutdown.Run(CoordinatedShutdown.ClrExitReason.Instance)
                 .ConfigureAwait(false);
         }
+        
+        public virtual async Task StartAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await StartAkkaAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(LogLevel.Critical, ex, "Unable to start AkkaHostedService - shutting down application");
+                HostApplicationLifetime.StopApplication();
+            }
+        }
+        
+        public virtual async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await StopAkkaAsync(cancellationToken);
+        }
+    }
+    
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal sealed class AkkaHostedServiceImpl : AkkaHostedService
+    {
+        public AkkaHostedServiceImpl(
+            AkkaConfigurationBuilder configurationBuilder,
+            IServiceProvider serviceProvider,
+            ILogger<AkkaHostedService> logger,
+            IHostApplicationLifetime applicationLifetime)
+        : base(configurationBuilder, serviceProvider, logger, applicationLifetime)
+        { }
     }
 }

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -51,7 +51,17 @@ namespace Akka.Hosting
         /// Starts a background <see cref="IHostedService"/> that runs the <see cref="ActorSystem"/>
         /// and manages its lifecycle in accordance with Akka.NET best practices.
         /// </remarks>
-        public static IServiceCollection AddAkka(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, IServiceProvider> builder)
+        public static IServiceCollection AddAkka(
+            this IServiceCollection services, 
+            string actorSystemName,
+            Action<AkkaConfigurationBuilder, IServiceProvider> builder)
+            => AddAkka<AkkaHostedServiceImpl>(services, actorSystemName, builder);
+        
+        public static IServiceCollection AddAkka<T>(
+            this IServiceCollection services,
+            string actorSystemName,
+            Action<AkkaConfigurationBuilder, IServiceProvider> builder)
+            where T: AkkaHostedService
         {
             var b = new AkkaConfigurationBuilder(services, actorSystemName);
             services.AddSingleton<AkkaConfigurationBuilder>(sp =>
@@ -64,7 +74,7 @@ namespace Akka.Hosting
             b.Bind();
             
             // start the IHostedService which will run Akka.NET
-            services.AddHostedService<AkkaHostedService>();
+            services.AddHostedService<T>();
 
             return services;
         }


### PR DESCRIPTION
Fixes #298

## Changes

* Convert `AkkaHostingService` to `public abstract` and expose some of the properties as `protected`.
* Add a new `AddAkka` extension method that have this method fingerprint:
  ```
        public static IServiceCollection AddAkka<T>(
            this IServiceCollection services,
            string actorSystemName,
            Action<AkkaConfigurationBuilder, IServiceProvider> builder)
            where T: AkkaHostedService
  ```