### PR TITLE
make AkkaHostedService `public` + `virtual`

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -46,10 +46,25 @@ namespace Akka.Hosting
             where T : Akka.Actor.IExtensionId { }
         public Akka.Hosting.AkkaConfigurationBuilder WithExtensions(params System.Type[] extensions) { }
     }
+    [Akka.Annotations.InternalApi]
+    public class AkkaHostedService : Microsoft.Extensions.Hosting.IHostedService
+    {
+        protected Akka.Actor.ActorSystem? ActorSystem;
+        protected readonly Akka.Hosting.AkkaConfigurationBuilder ConfigurationBuilder;
+        protected Akka.Actor.CoordinatedShutdown? CoordinatedShutdown;
+        protected readonly Microsoft.Extensions.Hosting.IHostApplicationLifetime? HostApplicationLifetime;
+        protected readonly Microsoft.Extensions.Logging.ILogger<Akka.Hosting.AkkaHostedService> Logger;
+        protected readonly System.IServiceProvider ServiceProvider;
+        public AkkaHostedService(Akka.Hosting.AkkaConfigurationBuilder configurationBuilder, System.IServiceProvider serviceProvider, Microsoft.Extensions.Logging.ILogger<Akka.Hosting.AkkaHostedService> logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime? applicationLifetime) { }
+        public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) { }
+        public virtual System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { }
+    }
     public static class AkkaHostingExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAkka(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string actorSystemName, System.Action<Akka.Hosting.AkkaConfigurationBuilder> builder) { }
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAkka(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string actorSystemName, System.Action<Akka.Hosting.AkkaConfigurationBuilder, System.IServiceProvider> builder) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAkka<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string actorSystemName, System.Action<Akka.Hosting.AkkaConfigurationBuilder, System.IServiceProvider> builder)
+            where T : Akka.Hosting.AkkaHostedService { }
         public static Akka.Hosting.AkkaConfigurationBuilder AddHocon(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Configuration.Config hocon, Akka.Hosting.HoconAddMode addMode) { }
         public static Akka.Hosting.AkkaConfigurationBuilder AddHocon(this Akka.Hosting.AkkaConfigurationBuilder builder, Microsoft.Extensions.Configuration.IConfiguration configuration, Akka.Hosting.HoconAddMode addMode) { }
         public static Akka.Hosting.AkkaConfigurationBuilder AddHoconFile(this Akka.Hosting.AkkaConfigurationBuilder builder, string hoconFilePath, Akka.Hosting.HoconAddMode addMode) { }

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -52,30 +52,7 @@ namespace Akka.Hosting
         /// </remarks>
         public static IServiceCollection AddAkka(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, IServiceProvider> builder)
         {
-            var b = new AkkaConfigurationBuilder(services, actorSystemName);
-            services.AddSingleton<AkkaConfigurationBuilder>(sp =>
-            {
-                builder(b, sp);
-                return b;
-            });
-            
-            // registers the hosted services and begins execution
-            b.Bind();
-            
-            if (Util.IsRunningInMaui)
-            {
-                // blow up Maui users who are about to footgun
-                throw new PlatformNotSupportedException(
-                    "Due to https://github.com/dotnet/maui/issues/2244, normal Akka.Hosting.AddAkka method will not work." +
-                    "Instead, you need to install Akka.Hosting.Maui and use the AddAkkaMaui extension method instead.");
-            }
-            else
-            {
-                // start the IHostedService which will run Akka.NET
-                services.AddHostedService<AkkaHostedService>();
-            }
-
-            return services;
+            return AddAkka<AkkaHostedService>(services, actorSystemName, builder);
         }
         
         public static IServiceCollection AddAkka<T>(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, IServiceProvider> builder) where T:AkkaHostedService

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -77,6 +77,34 @@ namespace Akka.Hosting
 
             return services;
         }
+        
+        public static IServiceCollection AddAkka<T>(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, IServiceProvider> builder) where T:AkkaHostedService
+        {
+            var b = new AkkaConfigurationBuilder(services, actorSystemName);
+            services.AddSingleton<AkkaConfigurationBuilder>(sp =>
+            {
+                builder(b, sp);
+                return b;
+            });
+            
+            // registers the hosted services and begins execution
+            b.Bind();
+            
+            if (Util.IsRunningInMaui)
+            {
+                // blow up Maui users who are about to footgun
+                throw new PlatformNotSupportedException(
+                    "Due to https://github.com/dotnet/maui/issues/2244, normal Akka.Hosting.AddAkka method will not work." +
+                    "Instead, you need to install Akka.Hosting.Maui and use the AddAkkaMaui extension method instead.");
+            }
+            else
+            {
+                // start the IHostedService which will run Akka.NET
+                services.AddHostedService<T>();
+            }
+
+            return services;
+        }
 
         /// <summary>
         /// Adds a new <see cref="Setup"/> to this builder.


### PR DESCRIPTION
Fixes #298

## Changes

Re-implementation of https://github.com/akkadotnet/Akka.Hosting/pull/299 - no abstract base classes, just made the main one public + virtual in order to keep things simple for Akka.Hosting.Maui et 

Made clear in XML-DOC comment, this is a "there be dragons" use case for end-users. We're not going to provide you with much support beyond making this possible. Best of luck.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #298
* [x] Changes in public API reviewed, if any.