### PR TITLE
added v1.5.6.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## [1.5.6.1] / 17 May 2023
+
+* [Akka.Hosting now throws `PlatformNotSupportedException`](https://github.com/akkadotnet/Akka.Hosting/pull/293) when attempting to run on Maui, due to https://github.com/dotnet/maui/issues/2244. Maui support will be added in https://github.com/akkadotnet/Akka.Hosting.Maui
+* [make `AkkaHostedService` `public` + `virtual` so it can be extended and customized](https://github.com/akkadotnet/Akka.Hosting/pull/306) - advanced feature.
+
 ## [1.5.6] / 10 May 2023
 
 * [Update Akka.NET to 1.5.6](https://github.com/akkadotnet/akka.net/releases/tag/1.5.6)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,9 @@
     <PropertyGroup>
         <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
         <Authors>Akka.NET Team</Authors>
-        <VersionPrefix>1.5.6</VersionPrefix>
-        <PackageReleaseNotes>• [Update Akka.NET to 1.5.6](https://github.com/akkadotnet/akka.net/releases/tag/1.5.6)</PackageReleaseNotes>
+        <VersionPrefix>1.5.6.1</VersionPrefix>
+        <PackageReleaseNotes>• [Akka.Hosting now throws PlatformNotSupportedException](https://github.com/akkadotnet/Akka.Hosting/pull/293) when attempting to run on Maui%2C due to https://github.com/dotnet/maui/issues/2244. Maui support will be added in https://github.com/akkadotnet/Akka.Hosting.Maui
+• [make AkkaHostedService public • virtual so it can be extended and customized](https://github.com/akkadotnet/Akka.Hosting/pull/306) • advanced feature.</PackageReleaseNotes>
         <PackageIcon>akkalogo.png</PackageIcon>
         <PackageProjectUrl>
             https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
## [1.5.6.1] / 17 May 2023

* [Akka.Hosting now throws `PlatformNotSupportedException`](https://github.com/akkadotnet/Akka.Hosting/pull/293) when attempting to run on Maui, due to https://github.com/dotnet/maui/issues/2244. Maui support will be added in https://github.com/akkadotnet/Akka.Hosting.Maui
* [make `AkkaHostedService` `public` + `virtual` so it can be extended and customized](https://github.com/akkadotnet/Akka.Hosting/pull/306) - advanced feature.