### PR TITLE
Fix `PassivateIdleEntityAfter` to not override HOCON settings

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
@@ -81,6 +81,7 @@ namespace Akka.Cluster.Hosting
         public bool? RememberEntities { get; set; }
         public Akka.Cluster.Sharding.RememberEntitiesStore? RememberEntitiesStore { get; set; }
         public string? Role { get; set; }
+        public bool? ShouldPassivateIdleEntities { get; set; }
         public Akka.Persistence.Hosting.SnapshotOptions? SnapshotOptions { get; set; }
         public string? SnapshotPluginId { get; set; }
         public Akka.Cluster.Sharding.StateStoreMode? StateStoreMode { get; set; }


### PR DESCRIPTION
Fixes #303

## Changes
* Make `PassivateIdleEntityAfter` default value to null
* Add `ShouldPassivateIdleEntities` property to disable idle entity passivation