### PR TITLE
Return non-zero exit code when `CoordinatedShutdown` indicates problems

### DIFF
--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -47,6 +47,19 @@ namespace Akka.Hosting
                 async Task TerminationHook()
                 {
                     await ActorSystem.WhenTerminated.ConfigureAwait(false);
+                    
+                    /*
+                     * Set a non-zero exit code in the event that we get a known, confirmed unclean shutdown
+                     * from the ActorSystem / CoordinatedShutdown
+                     */
+                    switch (CoordinatedShutdown.ShutdownReason)
+                    {
+                        case CoordinatedShutdown.ClusterDowningReason _:
+                        case CoordinatedShutdown.ClusterLeavingReason _:
+                            Environment.ExitCode = -1;
+                            break;
+                    }
+
                     HostApplicationLifetime?.StopApplication();
                 }
 


### PR DESCRIPTION
Fixes #328

## Changes

add a non-zero exit code in the event of an unclean shutdown

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #328