### PR TITLE
Add method to configure IHostBuilder in TestKit

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -38,6 +38,7 @@ namespace Akka.Hosting.TestKit
         protected virtual System.Threading.Tasks.Task BeforeTestStart() { }
         protected abstract void ConfigureAkka(Akka.Hosting.AkkaConfigurationBuilder builder, System.IServiceProvider provider);
         protected virtual void ConfigureAppConfiguration(Microsoft.Extensions.Hosting.HostBuilderContext context, Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { }
+        protected virtual void ConfigureHostBuilder(Microsoft.Extensions.Hosting.IHostBuilder builder) { }
         protected virtual void ConfigureHostConfiguration(Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { }
         protected virtual void ConfigureLogging(Microsoft.Extensions.Logging.ILoggingBuilder builder) { }
         protected virtual void ConfigureServices(Microsoft.Extensions.Hosting.HostBuilderContext context, Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -74,6 +74,9 @@ namespace Akka.Hosting.TestKit
         protected virtual void ConfigureServices(HostBuilderContext context, IServiceCollection services)
         { }
         
+        protected virtual void ConfigureHostBuilder(IHostBuilder builder)
+        { }
+        
         private void InternalConfigureServices(HostBuilderContext context, IServiceCollection services)
         {
             ConfigureServices(context, services);
@@ -144,8 +147,9 @@ namespace Akka.Hosting.TestKit
                 });
             hostBuilder
                 .ConfigureHostConfiguration(ConfigureHostConfiguration)
-                .ConfigureAppConfiguration(ConfigureAppConfiguration)
-                .ConfigureServices(InternalConfigureServices);
+                .ConfigureAppConfiguration(ConfigureAppConfiguration);
+            ConfigureHostBuilder(hostBuilder);
+            hostBuilder.ConfigureServices(InternalConfigureServices);
 
             _host = hostBuilder.Build();
 


### PR DESCRIPTION
## Changes

Add `ConfigureHostBuilder()` method to `Akka.Hosting.TestKit` so user can configure the `IHostBuilder` instance directly. Needed so that user can plug in other MS.EXT.Hosting extensions such as Castle Windsor that needed to access `IHostBuilder` to configure itself.