### PR TITLE
Akka.Hosting v1.5.14 Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
-## [1.5.13] / 27 September 2023
+## [1.5.14] / 09 January 2024
 
-* [Update Akka.NET to 1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)
+* [Update Akka.NET to 1.5.14](https://github.com/akkadotnet/akka.net/releases/tag/1.5.14)
+* [Akka.Cluster.Hosting: don't use sharding delegates](https://github.com/akkadotnet/Akka.Hosting/pull/424)
+* [Akka.Hosting.TestKit: Add method to configure `IHostBuilder`](https://github.com/akkadotnet/Akka.Hosting/pull/423)
 
 ## [1.5.12.1] / 31 August 2023
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,11 @@
-<Project>
+﻿<Project>
     <PropertyGroup>
         <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
         <Authors>Akka.NET Team</Authors>
-        <VersionPrefix>1.5.6.1</VersionPrefix>
-        <PackageReleaseNotes>• [Akka.Hosting now throws PlatformNotSupportedException](https://github.com/akkadotnet/Akka.Hosting/pull/293) when attempting to run on Maui%2C due to https://github.com/dotnet/maui/issues/2244. Maui support will be added in https://github.com/akkadotnet/Akka.Hosting.Maui
-• [make AkkaHostedService public • virtual so it can be extended and customized](https://github.com/akkadotnet/Akka.Hosting/pull/306) • advanced feature.</PackageReleaseNotes>
+        <VersionPrefix>1.5.14</VersionPrefix>
+        <PackageReleaseNotes>• [Update Akka.NET to 1.5.14](https://github.com/akkadotnet/akka.net/releases/tag/1.5.14)
+• [Akka.Cluster.Hosting: don't use sharding delegates](https://github.com/akkadotnet/Akka.Hosting/pull/424)
+• [Akka.Hosting.TestKit: Add method to configure IHostBuilder](https://github.com/akkadotnet/Akka.Hosting/pull/423)</PackageReleaseNotes>
         <PackageIcon>akkalogo.png</PackageIcon>
         <PackageProjectUrl>
             https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
## [1.5.14] / 09 January 2024

* [Update Akka.NET to 1.5.14](https://github.com/akkadotnet/akka.net/releases/tag/1.5.14)
* [Akka.Cluster.Hosting: don't use sharding delegates](https://github.com/akkadotnet/Akka.Hosting/pull/424)
* [Akka.Hosting.TestKit: Add method to configure `IHostBuilder`](https://github.com/akkadotnet/Akka.Hosting/pull/423)