### PR TITLE
added v1.5.15 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## [1.5.15] / 10 January 2024
+
+* [Update Akka.NET to 1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
+* Marked all Akka.Cluster.Hosting methods that accept deprecated sharding delegates as `Obsolete`
+
 ## [1.5.14] / 09 January 2024
 
 * [Update Akka.NET to 1.5.14](https://github.com/akkadotnet/akka.net/releases/tag/1.5.14)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,10 +2,9 @@
     <PropertyGroup>
         <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
         <Authors>Akka.NET Team</Authors>
-        <VersionPrefix>1.5.14</VersionPrefix>
-        <PackageReleaseNotes>• [Update Akka.NET to 1.5.14](https://github.com/akkadotnet/akka.net/releases/tag/1.5.14)
-• [Akka.Cluster.Hosting: don't use sharding delegates](https://github.com/akkadotnet/Akka.Hosting/pull/424)
-• [Akka.Hosting.TestKit: Add method to configure IHostBuilder](https://github.com/akkadotnet/Akka.Hosting/pull/423)</PackageReleaseNotes>
+        <VersionPrefix>1.5.15</VersionPrefix>
+        <PackageReleaseNotes>• [Update Akka.NET to 1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
+• Marked all Akka.Cluster.Hosting methods that accept deprecated sharding delegates as Obsolete</PackageReleaseNotes>
         <PackageIcon>akkalogo.png</PackageIcon>
         <PackageProjectUrl>
             https://github.com/akkadotnet/Akka.Hosting


### PR DESCRIPTION
## [1.5.15] / 10 January 2024

* [Update Akka.NET to 1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
* Marked all Akka.Cluster.Hosting methods that accept deprecated sharding delegates as `Obsolete`