### PR TITLE
Fix how ClusterShardingSettings were applied

### DIFF
--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -279,7 +279,7 @@ namespace Akka.Cluster.Hosting
         /// <summary>
         ///     <para>
         ///         Settings for the Distributed Data replicator.
-        ///         The <see cref="DistributedData.Role"/> property is not used. The distributed-data
+        ///         The <see cref="ShardingDDataOptions.Role"/> property is not used. The distributed-data
         ///         role will be the same as <see cref="ShardOptions.Role"/>.
         ///         Note that there is one Replicator per role and it's not possible
         ///         to have different distributed-data settings for different sharding entity types.
@@ -287,6 +287,9 @@ namespace Akka.Cluster.Hosting
         ///     <b>NOTE</b> This setting is only used when <see cref="StateStoreMode"/> is set to
         ///     <see cref="Akka.Cluster.Sharding.StateStoreMode.DData"/>
         /// </summary>
+        [Obsolete("This property is not being applied to the ActorSystem anymore. " +
+                  "Use manual HOCON configuration to set \"akka.cluster.sharding.distributed-data\" values. " +
+                  "Since v1.5.27")]
         public ShardingDDataOptions DistributedData { get; } = new();
 
         /// <summary>
@@ -643,35 +646,6 @@ namespace Akka.Cluster.Hosting
         }
 
         /// <summary>
-        ///     Applies a default setting that, if not overriden, will be applied to all shard regions
-        /// </summary>
-        /// <param name="builder">
-        ///     The builder instance being configured.
-        /// </param>
-        /// <param name="shardOptions">
-        ///     The set of options for configuring <see cref="ClusterShardingSettings"/>
-        /// </param>
-        /// <returns>
-        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
-        /// </returns>
-        public static AkkaConfigurationBuilder WithDefaultClusterShardingSettings(
-            this AkkaConfigurationBuilder builder,
-            ShardOptions shardOptions)
-        {
-            shardOptions.DistributedData.Apply(builder);
-            
-            var sb = new StringBuilder(shardOptions.ToString());
-            if (sb.Length <= 0) 
-                return builder;
-            
-            sb.Insert(0, "akka.cluster.sharding {\n");
-            sb.AppendLine("}");
-            builder.AddHocon(sb.ToString(), HoconAddMode.Prepend);
-
-            return builder;
-        }
-        
-        /// <summary>
         ///     Starts a <see cref="ShardRegion"/> actor for the given entity <see cref="typeName"/>
         ///     and registers the ShardRegion <see cref="IActorRef"/> with <see cref="TKey"/> in the
         ///     <see cref="ActorRegistry"/> for this <see cref="ActorSystem"/>.
@@ -874,7 +848,6 @@ namespace Akka.Cluster.Hosting
             IMessageExtractor messageExtractor,
             ShardOptions shardOptions)
         {
-            shardOptions.DistributedData.Apply(builder);
             builder.AddHocon(
                 ClusterSharding.DefaultConfig().WithFallback(DistributedData.DistributedData.DefaultConfig()), 
                 HoconAddMode.Append);
@@ -940,7 +913,6 @@ namespace Akka.Cluster.Hosting
             ExtractShardId extractShardId,
             ShardOptions shardOptions)
         {
-            shardOptions.DistributedData.Apply(builder);
             builder.AddHocon(
                 ClusterSharding.DefaultConfig().WithFallback(DistributedData.DistributedData.DefaultConfig()), 
                 HoconAddMode.Append);

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -641,6 +641,35 @@ namespace Akka.Cluster.Hosting
             builder.AddHocon(DistributedData.DistributedData.DefaultConfig(), HoconAddMode.Append);
             return builder;
         }
+
+        /// <summary>
+        ///     Applies a default setting that, if not overriden, will be applied to all shard regions
+        /// </summary>
+        /// <param name="builder">
+        ///     The builder instance being configured.
+        /// </param>
+        /// <param name="shardOptions">
+        ///     The set of options for configuring <see cref="ClusterShardingSettings"/>
+        /// </param>
+        /// <returns>
+        ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
+        /// </returns>
+        public static AkkaConfigurationBuilder WithDefaultClusterShardingSettings(
+            this AkkaConfigurationBuilder builder,
+            ShardOptions shardOptions)
+        {
+            shardOptions.DistributedData.Apply(builder);
+            
+            var sb = new StringBuilder(shardOptions.ToString());
+            if (sb.Length <= 0) 
+                return builder;
+            
+            sb.Insert(0, "akka.cluster.sharding {\n");
+            sb.AppendLine("}");
+            builder.AddHocon(sb.ToString(), HoconAddMode.Prepend);
+
+            return builder;
+        }
         
         /// <summary>
         ///     Starts a <see cref="ShardRegion"/> actor for the given entity <see cref="typeName"/>

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
@@ -103,11 +103,11 @@ namespace Akka.Cluster.Hosting
         public bool? RememberEntities { get; set; }
         public Akka.Cluster.Sharding.RememberEntitiesStore? RememberEntitiesStore { get; set; }
         public string? Role { get; set; }
+        public System.TimeSpan? ShardRegionQueryTimeout { get; set; }
         public bool? ShouldPassivateIdleEntities { get; set; }
         public Akka.Persistence.Hosting.SnapshotOptions? SnapshotOptions { get; set; }
         public string? SnapshotPluginId { get; set; }
         public Akka.Cluster.Sharding.StateStoreMode? StateStoreMode { get; set; }
-        public Akka.Configuration.Config ToConfig() { }
         public override string ToString() { }
     }
     public sealed class ShardingDDataOptions : Akka.Cluster.Hosting.DDataOptions

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
@@ -8,7 +8,6 @@ namespace Akka.Cluster.Hosting
         public static Akka.Hosting.AkkaConfigurationBuilder WithClusterClient<TKey>(this Akka.Hosting.AkkaConfigurationBuilder builder, System.Collections.Generic.IEnumerable<Akka.Actor.Address> initialContactAddresses, string receptionistActorName = "receptionist") { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithClusterClientReceptionist(this Akka.Hosting.AkkaConfigurationBuilder builder, string name = "receptionist", string? role = null) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithClustering(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Cluster.Hosting.ClusterOptions? options = null) { }
-        public static Akka.Hosting.AkkaConfigurationBuilder WithDefaultClusterShardingSettings(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Cluster.Hosting.ShardOptions shardOptions) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithDistributedData(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Cluster.Hosting.DDataOptions options) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithDistributedData(this Akka.Hosting.AkkaConfigurationBuilder builder, System.Action<Akka.Cluster.Hosting.DDataOptions> configurator) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithDistributedPubSub(this Akka.Hosting.AkkaConfigurationBuilder builder, string role) { }
@@ -90,6 +89,9 @@ namespace Akka.Cluster.Hosting
     public sealed class ShardOptions
     {
         public ShardOptions() { }
+        [System.Obsolete("This property is not being applied to the ActorSystem anymore. Use manual HOCON c" +
+            "onfiguration to set \"akka.cluster.sharding.distributed-data\" values. Since v1.5." +
+            "27")]
         public Akka.Cluster.Hosting.ShardingDDataOptions DistributedData { get; }
         public bool? FailOnInvalidEntityStateTransition { get; set; }
         public object? HandOffStopMessage { get; set; }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCluster.verified.txt
@@ -8,6 +8,7 @@ namespace Akka.Cluster.Hosting
         public static Akka.Hosting.AkkaConfigurationBuilder WithClusterClient<TKey>(this Akka.Hosting.AkkaConfigurationBuilder builder, System.Collections.Generic.IEnumerable<Akka.Actor.Address> initialContactAddresses, string receptionistActorName = "receptionist") { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithClusterClientReceptionist(this Akka.Hosting.AkkaConfigurationBuilder builder, string name = "receptionist", string? role = null) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithClustering(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Cluster.Hosting.ClusterOptions? options = null) { }
+        public static Akka.Hosting.AkkaConfigurationBuilder WithDefaultClusterShardingSettings(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Cluster.Hosting.ShardOptions shardOptions) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithDistributedData(this Akka.Hosting.AkkaConfigurationBuilder builder, Akka.Cluster.Hosting.DDataOptions options) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithDistributedData(this Akka.Hosting.AkkaConfigurationBuilder builder, System.Action<Akka.Cluster.Hosting.DDataOptions> configurator) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithDistributedPubSub(this Akka.Hosting.AkkaConfigurationBuilder builder, string role) { }
@@ -104,6 +105,8 @@ namespace Akka.Cluster.Hosting
         public Akka.Persistence.Hosting.SnapshotOptions? SnapshotOptions { get; set; }
         public string? SnapshotPluginId { get; set; }
         public Akka.Cluster.Sharding.StateStoreMode? StateStoreMode { get; set; }
+        public Akka.Configuration.Config ToConfig() { }
+        public override string ToString() { }
     }
     public sealed class ShardingDDataOptions : Akka.Cluster.Hosting.DDataOptions
     {


### PR DESCRIPTION
Fixes #477

Previously, settings were applied directly to the HOCON configuration, setting up a cluster shard region using `ShardOptions` would not work because only the last `ShardOptions` would be applied to the HOCON configuration.

## Changes

* Make `ShardOptions` to be applied separately per `WithShardRegion()` call.

> [!Note]
> Distributed data settings for all shard regions are still stored as a single HOCON setting (`akka.cluster.sharding.distributed-data`), they are not applied on a per region basis.