### PR TITLE
Revert "Bump FluentAssertions from 5.10.3 to 6.12.0"

### DIFF
--- a/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
+++ b/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
@@ -9,7 +9,6 @@
 
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
     </ItemGroup>


### PR DESCRIPTION
Reverts akkadotnet/Akka.Hosting#484

This was a case of Dependabot adding package references where they are not explicitly needed.