### PR TITLE
Automatically add default Akka.Streams HOCON

### DIFF
--- a/src/Akka.Hosting/Akka.Hosting.csproj
+++ b/src/Akka.Hosting/Akka.Hosting.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.DependencyInjection" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -83,8 +83,8 @@ namespace Akka.Hosting
     {
         internal readonly string ActorSystemName;
         internal readonly IServiceCollection ServiceCollection;
-        internal readonly HashSet<SerializerRegistration> Serializers = new HashSet<SerializerRegistration>();
-        internal readonly List<Type> Extensions = new List<Type>();
+        internal readonly HashSet<SerializerRegistration> Serializers = new();
+        internal readonly List<Type> Extensions = new();
 
         /// <summary>
         /// INTERNAL API.
@@ -95,7 +95,7 @@ namespace Akka.Hosting
         /// Use the provided <see cref="AddSetup"/> method instead.
         /// </summary>
         [InternalApi]
-        public readonly HashSet<Setup> Setups = new HashSet<Setup>();
+        public readonly HashSet<Setup> Setups = new();
         
         /// <summary>
         /// The currently configured <see cref="ProviderSelection"/>.

--- a/src/Akka.Hosting/AkkaHostingExtensions.cs
+++ b/src/Akka.Hosting/AkkaHostingExtensions.cs
@@ -5,6 +5,7 @@ using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.DependencyInjection;
 using Akka.Hosting.Configuration;
+using Akka.Streams;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -58,6 +59,12 @@ namespace Akka.Hosting
         public static IServiceCollection AddAkka<T>(this IServiceCollection services, string actorSystemName, Action<AkkaConfigurationBuilder, IServiceProvider> builder) where T:AkkaHostedService
         {
             var b = new AkkaConfigurationBuilder(services, actorSystemName);
+            
+            // add the default Akka.Streams configuration by default - hurts nothing, but
+            // ensures that StreamRefs work correctly out of the box in case users
+            // haven't attempted to materialize a stream yet
+            b.AddHocon(ActorMaterializer.DefaultConfig(), HoconAddMode.Append);
+            
             services.AddSingleton<AkkaConfigurationBuilder>(sp =>
             {
                 builder(b, sp);

--- a/src/Akka.Hosting/LoggerConfigBuilder.cs
+++ b/src/Akka.Hosting/LoggerConfigBuilder.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -17,7 +16,7 @@ namespace Akka.Hosting
 {
     public sealed class LoggerConfigBuilder
     {
-        private readonly List<Type> _loggers = new List<Type> { typeof(DefaultLogger) };
+        private readonly List<Type> _loggers = new() { typeof(DefaultLogger) };
         private Type _logMessageFormatter = typeof(DefaultLogMessageFormatter);
         internal AkkaConfigurationBuilder Builder { get; }
 


### PR DESCRIPTION
## Changes

This is in response to a customer issue where the following happened:

1. Using `StreamRef`s
2. Transmits a `StreamRef` to a node that has never called any materialization functions
3. Serialization error due to missing serializer definitions.

In normal Akka.NET you'd have to fix this by manually appending `ActorMaterializer.DefaultConfig()` as a fallback. In Akka.Hosting we can just do this automatically at startup.

I added a reference to Akka.Streams in the default Akka.Hosting module. There's not a lot of value in making a custom Akka.Streams.Hosting package as "add this config" is the only method that would be in it. If there's a good reason why we shouldn't add it to the default Akka.Hosting package, please say so in a review.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).