### PR TITLE
Make sure `AkkaHostedService` failures are always visible

### DIFF
--- a/src/Akka.Hosting.Tests/StartFailureSpec.cs
+++ b/src/Akka.Hosting.Tests/StartFailureSpec.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Hosting.Tests;
+
+public class StartFailureSpec
+{
+    private readonly ITestOutputHelper _output;
+    
+    public StartFailureSpec(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+    
+    [Fact]
+    public async Task ShouldThrowWhenActorSystemFailedToStart()
+    {
+        // arrange
+        var host = new HostBuilder()
+            .ConfigureLogging(builder =>
+            {
+                builder.ClearProviders();
+                builder.AddProvider(new XUnitLoggerProvider(_output, LogLevel.Debug));
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddAkka("MySys", (builder, provider) =>
+                {
+                    builder.AddStartup((_, _) => throw new TestException("BOOM"));
+                });
+            })
+            .Build();
+
+        await Awaiting(async () => await host.StartAsync()).Should()
+            .ThrowExactlyAsync<TestException>().WithMessage("BOOM");
+    }
+
+    private class TestException: Exception
+    {
+        public TestException(string? message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Akka.Hosting/AkkaHostedService.cs
+++ b/src/Akka.Hosting/AkkaHostedService.cs
@@ -72,6 +72,9 @@ namespace Akka.Hosting
             catch (Exception ex)
             {
                 Logger.Log(LogLevel.Critical, ex, "Unable to start AkkaHostedService - shutting down application");
+                
+                // resolve https://github.com/akkadotnet/Akka.Hosting/issues/470 - never allow failures to be silent
+                Console.WriteLine($"Unable to start AkkaHostedService due to [{ex}] - shutting down application");
                 HostApplicationLifetime?.StopApplication();
             }
         }


### PR DESCRIPTION
## Changes

close #470 - application crashes and exits should always be explicitly logged someplace where they can be seen regardless of logging configuration.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #470