### PR TITLE
Update RELEASE_NOTES.md for 1.5.32 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
-#### 1.5.31.1 November 15th 2024 ####
+#### 1.5.32 December 4th 2024 ####
 
-* [Cluster: Fix `WithSingleton` and `WithSingletonProxy` API](https://github.com/akkadotnet/Akka.Hosting/pull/520)
-* [Cluster: Fix `WithShardedDaemonProcess` throws `NullReferenceException`](https://github.com/akkadotnet/Akka.Hosting/pull/522)
+* [Bump Akka.NET to 1.5.32](https://github.com/akkadotnet/akka.net/releases/tag/1.5.32)
+* [Cluster: Add global scoped DData setting extension method](https://github.com/akkadotnet/Akka.Hosting/pull/527)
+* [Core: Fix CVE-2024-43485](https://github.com/akkadotnet/Akka.Hosting/pull/529)


### PR DESCRIPTION
## 1.5.32 December 4th 2024

* [Bump Akka.NET to 1.5.32](https://github.com/akkadotnet/akka.net/releases/tag/1.5.32)
* [Cluster: Add global scoped DData setting extension method](https://github.com/akkadotnet/Akka.Hosting/pull/527)
* [Core: Fix CVE-2024-43485](https://github.com/akkadotnet/Akka.Hosting/pull/529)