### PR TITLE
make sure Akka.Hosting.API.Tests uses the same runtime as everything else

### DIFF
--- a/src/Akka.Hosting.API.Tests/Akka.Hosting.API.Tests.csproj
+++ b/src/Akka.Hosting.API.Tests/Akka.Hosting.API.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
Should clear up some of the build issues that started happening over the past 1-2 days resulting from .NET 6 no longer being available on GHA build agents