### PR TITLE
added v1.5.33 release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2024 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.30.1</VersionPrefix>
-    <PackageReleaseNotes>* [Fix ActorRegistry.GetAsync() returning Nobody](https://github.com/akkadotnet/Akka.Hosting/pull/501)</PackageReleaseNotes>
+    <VersionPrefix>1.5.33</VersionPrefix>
+    <PackageReleaseNotes>* [Bump Akka.NET to 1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
+* Resolved `nullability` issues with Akka.Hosting.TestKit APIs</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,4 @@
-#### 1.5.32 December 4th 2024 ####
+#### 1.5.33 December 24th 2024 ####
 
-* [Bump Akka.NET to 1.5.32](https://github.com/akkadotnet/akka.net/releases/tag/1.5.32)
-* [Cluster: Add global scoped DData setting extension method](https://github.com/akkadotnet/Akka.Hosting/pull/527)
-* [Core: Fix CVE-2024-43485](https://github.com/akkadotnet/Akka.Hosting/pull/529)
+* [Bump Akka.NET to 1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
+* Resolved `nullability` issues with Akka.Hosting.TestKit APIs


### PR DESCRIPTION
#### 1.5.33 December 24th 2024 ####

* [Bump Akka.NET to 1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
* Resolved `nullability` issues with Akka.Hosting.TestKit APIs