### PR TITLE
Update RELEASE_NOTES.md for 1.5.36 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,3 @@
-#### 1.5.35 January 13th 2025 ####
+#### 1.5.36 January 22nd 2025 ####
 
-* [Bump Akka.NET to 1.5.35](https://github.com/akkadotnet/akka.net/releases/tag/1.5.35)
-* [Bump Microsoft.Extensions.* packages to 8.0.X](https://github.com/akkadotnet/Akka.Hosting/pull/553)
-* [Bump Microsoft.Bcl.AsyncInterfaces to 8.0.X](https://github.com/akkadotnet/Akka.Hosting/pull/553)
-* [Bump System.Text.Json to 8.0.X](https://github.com/akkadotnet/Akka.Hosting/pull/553)
+* [Bump Akka.NET to 1.5.36](https://github.com/akkadotnet/akka.net/releases/tag/1.5.36)


### PR DESCRIPTION
## 1.5.36 January 22nd 2025 

* [Bump Akka.NET to 1.5.36](https://github.com/akkadotnet/akka.net/releases/tag/1.5.36)