### PR TITLE
Update RELEASE_NOTES.md for 1.5.37

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <TestSdkVersion>17.11.1</TestSdkVersion>
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>2.8.1</XunitRunneVisualstudio>
-    <AkkaVersion>1.5.34</AkkaVersion>
+    <AkkaVersion>1.5.37</AkkaVersion>
     <MicrosoftExtensionsVersion>[6.0.0,)</MicrosoftExtensionsVersion>
     <SystemTextJsonVersion>[6.0.10,)</SystemTextJsonVersion>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
-#### 1.5.36 January 22nd 2025 ####
+#### 1.5.37 January 23rd 2025 ####
 
-* [Bump Akka.NET to 1.5.36](https://github.com/akkadotnet/akka.net/releases/tag/1.5.36)
+Moving all of our BCL dependencies to 8.0 created issues for our .NET 6-9 users when adopting Akka.NET packages that only targeted .NET Standard, so for the time being we're normalizing everything back to 6.0
+
+* [Bump Akka.NET to 1.5.37](https://github.com/akkadotnet/akka.net/releases/tag/1.5.37)


### PR DESCRIPTION
## 1.5.37 January 23rd 2025

Moving all of our BCL dependencies to 8.0 created issues for our .NET 6-9 users when adopting Akka.NET packages that only targeted .NET Standard, so for the time being we're normalizing everything back to 6.0

* [Bump Akka.NET to 1.5.37](https://github.com/akkadotnet/akka.net/releases/tag/1.5.37)
