### PR TITLE
Akka.Hosting.TestKit: added `NullScope` to `xUnitLogger`

### DIFF
--- a/src/Akka.Hosting.TestKit/Internals/XUnitLogger.cs
+++ b/src/Akka.Hosting.TestKit/Internals/XUnitLogger.cs
@@ -70,7 +70,7 @@ namespace Akka.Hosting.TestKit.Internals
 
         public IDisposable BeginScope<TState>(TState state) 
         {
-            throw new NotImplementedException();
+            return NullScope.Instance;
         }
         
         private static bool TryFormatMessage<TState>(
@@ -90,6 +90,13 @@ namespace Akka.Hosting.TestKit.Internals
             
             result = formattedMessage;
             return true;
+        }
+
+        private class NullScope : IDisposable
+        {
+            private NullScope() { }
+            public static NullScope Instance { get; } = new NullScope();
+            public void Dispose() { }
         }
     }    
 }


### PR DESCRIPTION
## Changes

This prevents a `NotImplementedException` from being thrown inside some test cases when working with other components that depend on scopes via Microsoft.Extensions.Logging

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
