### PR TITLE
V1.5.37.1 release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <Copyright>Copyright © 2013-2025 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>1.5.37.1</VersionPrefix>
-    <PackageReleaseNotes>* Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging.</PackageReleaseNotes>
+    <PackageReleaseNotes>* [Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging](https://github.com/akkadotnet/Akka.Hosting/pull/570).</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,8 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2025 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.33</VersionPrefix>
-    <PackageReleaseNotes>* [Bump Akka.NET to 1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
-* Resolved `nullability` issues with Akka.Hosting.TestKit APIs</PackageReleaseNotes>
+    <VersionPrefix>1.5.37.1</VersionPrefix>
+    <PackageReleaseNotes>* Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging.</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
 #### 1.5.37.1 February 5th 2024 ####
 
-* Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging.
+* [Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging](https://github.com/akkadotnet/Akka.Hosting/pull/570).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,3 @@
-#### 1.5.37 January 23rd 2025 ####
+#### 1.5.37.1 February 5th 2024 ####
 
-Moving all of our BCL dependencies to 8.0 created issues for our .NET 6-9 users when adopting Akka.NET packages that only targeted .NET Standard, so for the time being we're normalizing everything back to 6.0
-
-* [Bump Akka.NET to 1.5.37](https://github.com/akkadotnet/akka.net/releases/tag/1.5.37)
+* Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging.


### PR DESCRIPTION
#### 1.5.37.1 February 5th 2024 ####

* [Akka.Hosting.TestKit: Fixed issue with `xUnitLogger` throwing `NotImplementedException` when used with scoped logging](https://github.com/akkadotnet/Akka.Hosting/pull/570).