### PR TITLE
`WithDistributedData()` will start `DistributedDataProvider` extension automatically.

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.DistributedData;
@@ -33,17 +34,18 @@ public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
     public async Task WithDistributedDataStartsAutomaticallyTest()
     {
         var cluster = Cluster.Get(Sys);
-        cluster.Join(cluster.SelfAddress);
+        await cluster.JoinAsync(cluster.SelfAddress);
+        cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
         
         var settings = ReplicatorSettings.Create(Sys);
         var coordinatorName = settings.RestartReplicatorOnFailure ? $"{ReplicatorName}Supervisor" : ReplicatorName;
         
         var actorSelection = Sys.ActorSelection(new RootActorPath(cluster.SelfAddress) / "user" / coordinatorName);
         
-        await AwaitAssertAsync(() =>
+        await AwaitAssertAsync(async () =>
         {
             actorSelection.Tell(new Identify("coordinator"), TestActor);
-            var identity = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3));
+            var identity = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(3));
             
             // The DData replicator should be running
             // * This actor is created inside DistributedData extension .ctor

--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.DistributedData;
+using Akka.Hosting;
+using Akka.Remote.Hosting;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Hosting.Tests;
+
+public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
+{
+    private const string ReplicatorName = "dDataReplicator";
+    
+    public ClusterShardingDistributedDataSpecs(ITestOutputHelper output): base(output: output)
+    {
+    }
+    
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder
+            .WithRemoting()
+            .WithClustering()
+            .WithDistributedData(opt =>
+            {
+                opt.Name = ReplicatorName;
+            });
+    }
+
+    [Fact(DisplayName = "WithDistributedData should start DistributedData extension automatically")]
+    public async Task WithDistributedDataStartsAutomaticallyTest()
+    {
+        var cluster = Cluster.Get(Sys);
+        cluster.Join(cluster.SelfAddress);
+        
+        var settings = ReplicatorSettings.Create(Sys);
+        var coordinatorName = settings.RestartReplicatorOnFailure ? $"{ReplicatorName}Supervisor" : ReplicatorName;
+        
+        var actorSelection = Sys.ActorSelection(new RootActorPath(cluster.SelfAddress) / "user" / coordinatorName);
+        
+        await AwaitAssertAsync(() =>
+        {
+            actorSelection.Tell(new Identify("coordinator"), TestActor);
+            var identity = ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(3));
+            
+            // The DData replicator should be running
+            // * This actor is created inside DistributedData extension .ctor
+            // * Marks that the extension is running
+            // * We can't use DistributedData.Get() because that defeats the purpose.
+            identity.Subject.Should().NotBeNull();
+        });
+    }
+}

--- a/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
+++ b/src/Akka.Cluster.Hosting/AkkaClusterHostingExtensions.cs
@@ -14,6 +14,7 @@ using Akka.Configuration;
 using Akka.Coordination;
 using Akka.DependencyInjection;
 using Akka.Discovery;
+using Akka.DistributedData;
 using Akka.Hosting;
 using Akka.Hosting.Coordination;
 using Akka.Persistence.Hosting;
@@ -691,6 +692,7 @@ namespace Akka.Cluster.Hosting
         {
             options.Apply(builder);
             builder.AddHocon(DistributedData.DistributedData.DefaultConfig(), HoconAddMode.Append);
+            builder.WithExtension<DistributedDataProvider>();
             return builder;
         }
 


### PR DESCRIPTION
Fixes #594

## Changes

* Add `DistributedDataProvider` to auto-start extension list inside the `WithDistributedData()` extension method.
* Add unit test.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).