### PR TITLE
Add persistence support and related tests

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -22,6 +22,26 @@ namespace Akka.Hosting.TestKit.Internals
 }
 namespace Akka.Hosting.TestKit
 {
+    public abstract class PersistenceTestKit : Akka.Hosting.TestKit.TestKit
+    {
+        public PersistenceTestKit(Akka.Configuration.Config? config = null, string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        protected override Akka.Configuration.Config? Config { get; }
+        public Akka.Persistence.TestKit.ITestJournal? Journal { get; set; }
+        public Akka.Actor.IActorRef? JournalActorRef { get; set; }
+        public Akka.Persistence.TestKit.ITestSnapshotStore? Snapshots { get; set; }
+        public Akka.Actor.IActorRef? SnapshotsActorRef { get; set; }
+        protected override void ConfigureAkka(Akka.Hosting.AkkaConfigurationBuilder builder, System.IServiceProvider provider) { }
+        public System.Threading.Tasks.Task WithJournalRecovery(System.Func<Akka.Persistence.TestKit.JournalRecoveryBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
+        public System.Threading.Tasks.Task WithJournalRecovery(System.Func<Akka.Persistence.TestKit.JournalRecoveryBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }
+        public System.Threading.Tasks.Task WithJournalWrite(System.Func<Akka.Persistence.TestKit.JournalWriteBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
+        public System.Threading.Tasks.Task WithJournalWrite(System.Func<Akka.Persistence.TestKit.JournalWriteBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }
+        public System.Threading.Tasks.Task WithSnapshotDelete(System.Func<Akka.Persistence.TestKit.SnapshotStoreDeleteBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
+        public System.Threading.Tasks.Task WithSnapshotDelete(System.Func<Akka.Persistence.TestKit.SnapshotStoreDeleteBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }
+        public System.Threading.Tasks.Task WithSnapshotLoad(System.Func<Akka.Persistence.TestKit.SnapshotStoreLoadBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
+        public System.Threading.Tasks.Task WithSnapshotLoad(System.Func<Akka.Persistence.TestKit.SnapshotStoreLoadBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }
+        public System.Threading.Tasks.Task WithSnapshotSave(System.Func<Akka.Persistence.TestKit.SnapshotStoreSaveBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
+        public System.Threading.Tasks.Task WithSnapshotSave(System.Func<Akka.Persistence.TestKit.SnapshotStoreSaveBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }
+    }
     public abstract class TestKit : Akka.TestKit.TestKitBase, Xunit.IAsyncLifetime
     {
         protected TestKit(string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null, System.TimeSpan? startupTimeout = default, Microsoft.Extensions.Logging.LogLevel logLevel = 2) { }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -24,12 +24,12 @@ namespace Akka.Hosting.TestKit
 {
     public abstract class PersistenceTestKit : Akka.Hosting.TestKit.TestKit
     {
-        public PersistenceTestKit(Akka.Configuration.Config? config = null, string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
-        protected override Akka.Configuration.Config? Config { get; }
-        public Akka.Persistence.TestKit.ITestJournal? Journal { get; set; }
-        public Akka.Actor.IActorRef? JournalActorRef { get; set; }
-        public Akka.Persistence.TestKit.ITestSnapshotStore? Snapshots { get; set; }
-        public Akka.Actor.IActorRef? SnapshotsActorRef { get; set; }
+        public static readonly Akka.Configuration.Config DefaultConfiguration;
+        public PersistenceTestKit(string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null, System.TimeSpan? startupTimeout = default, Microsoft.Extensions.Logging.LogLevel logLevel = 2) { }
+        public Akka.Persistence.TestKit.ITestJournal Journal { get; }
+        public Akka.Actor.IActorRef JournalActorRef { get; }
+        public Akka.Persistence.TestKit.ITestSnapshotStore Snapshots { get; }
+        public Akka.Actor.IActorRef SnapshotsActorRef { get; }
         protected override void ConfigureAkka(Akka.Hosting.AkkaConfigurationBuilder builder, System.IServiceProvider provider) { }
         public System.Threading.Tasks.Task WithJournalRecovery(System.Func<Akka.Persistence.TestKit.JournalRecoveryBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
         public System.Threading.Tasks.Task WithJournalRecovery(System.Func<Akka.Persistence.TestKit.JournalRecoveryBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }

--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/PersistActor.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/PersistActor.cs
@@ -1,0 +1,72 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
+{
+    using System;
+    using Actor;
+
+    public class PersistActor : UntypedPersistentActor
+    {
+        public PersistActor(IActorRef probe)
+        {
+            _probe = probe;
+        }
+
+        private readonly IActorRef _probe;
+
+        public override string PersistenceId => "foo";
+
+        protected override void OnCommand(object message)
+        {
+            switch (message)
+            {
+                case WriteMessage msg:
+                    Persist(msg.Data, _ =>
+                    {
+                        _probe.Tell("ack");
+                    });
+
+                    break;
+
+                default:
+                    return;
+            }
+        }
+
+        protected override void OnRecover(object message)
+        {
+            _probe.Tell(message);
+        }
+
+        protected override void OnPersistFailure(Exception cause, object @event, long sequenceNr)
+        {
+            _probe.Tell("failure");
+
+            base.OnPersistFailure(cause, @event, sequenceNr);
+        }
+
+        protected override void OnPersistRejected(Exception cause, object @event, long sequenceNr)
+        {
+            _probe.Tell("rejected");
+
+            base.OnPersistRejected(cause, @event, sequenceNr);
+        }
+
+        public class WriteMessage
+        {
+            public string Data { get; }
+
+            public WriteMessage(string data)
+            {
+                Data = data;
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/SnapshotActor.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/SnapshotActor.cs
@@ -1,0 +1,100 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.Persistence.TestKit.Tests
+{
+    using System;
+    using Actor;
+
+    public class SnapshotActor : UntypedPersistentActor
+    {
+        public SnapshotActor(IActorRef probe)
+        {
+            _probe = probe;
+        }
+
+        private readonly IActorRef _probe;
+
+        public override string PersistenceId => "bar";
+
+        protected override void OnCommand(object message)
+        {
+            switch (message)
+            {
+                case "save":
+                    SaveSnapshot(message);
+                    return;
+
+                case DeleteOne del:
+                    DeleteSnapshot(del.SequenceNr);
+                    return;
+
+                case DeleteMany del:
+                    DeleteSnapshots(del.Criteria);
+                    return;
+
+                case SaveSnapshotSuccess _:
+                case SaveSnapshotFailure _:
+                case DeleteSnapshotSuccess _:
+                case DeleteSnapshotFailure _:
+                case DeleteSnapshotsSuccess _:
+                case DeleteSnapshotsFailure _:
+                    _probe.Tell(message);
+                    return;
+
+                default:
+                    return;
+            }
+        }
+
+        protected override void OnRecover(object message)
+        {
+            if (message is SnapshotOffer snapshot)
+            {
+                _probe.Tell(message);
+            }
+        }
+
+        protected override void OnRecoveryFailure(Exception reason, object message)
+        {
+            _probe.Tell(new RecoveryFailure(reason, message));
+            base.OnRecoveryFailure(reason, message);
+        }
+
+        public class DeleteOne
+        {
+            public DeleteOne(long sequenceNr)
+            {
+                SequenceNr = sequenceNr;
+            }
+
+            public long SequenceNr { get; }
+        }
+
+        public class DeleteMany
+        {
+            public DeleteMany(SnapshotSelectionCriteria criteria)
+            {
+                Criteria = criteria;
+            }
+
+            public SnapshotSelectionCriteria Criteria { get; }
+        }
+
+        public class RecoveryFailure
+        {
+            public RecoveryFailure(Exception reason, object message)
+            {
+                Reason = reason;
+                Message = message;
+            }
+
+            public Exception Reason { get; }
+            public object Message { get; }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
@@ -1,0 +1,163 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+using Akka.Hosting.TestKit.Tests.TestActorRefTests;
+using Akka.Persistence;
+using Akka.Persistence.TestKit;
+using Akka.TestKit;
+using FluentAssertions;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests
+{
+
+    public class TestJournalSpec : PersistenceTestKit
+    {
+        // Expect should be passing by default, need to make them less sencitive to timing
+        private static readonly Config DefaultTimeoutConfig = "akka.test.single-expect-default = 30s";
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            base.ConfigureAkka(builder, provider);
+            builder.WithActors((system, registry) =>
+            {
+                probe = CreateTestProbe();
+                var echo = system.ActorOf(Props.Create(() => new PersistActor(probe)));
+                registry.Register<PersistActor>(echo);
+            });
+        }
+
+        private TestProbe? probe;
+
+        public TestJournalSpec() : base(DefaultTimeoutConfig)
+        {
+        }
+
+        [Fact]
+        public void must_have_journal_and_snapshot()
+        {
+            probe.Should().NotBeNull();
+            Journal.Should().NotBeNull();
+            JournalActorRef.Should().NotBeNull();
+            Snapshots.Should().NotBeNull();
+            SnapshotsActorRef.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task must_return_ack_after_new_write_interceptor_is_set()
+        {
+            JournalActorRef!.Tell(new TestJournal.UseWriteInterceptor(null), TestActor);
+
+            await ExpectMsgAsync<TestJournal.Ack>(TimeSpan.FromSeconds(3));
+        }
+
+        [Fact]
+        public async Task works_as_memory_journal_by_default()
+        {
+            var actor = ActorRegistry.Get<PersistActor>();
+            await probe!.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal!.OnWrite.Pass();
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+            await probe.ExpectMsgAsync("ack");
+        }
+
+        [Fact]
+        public async Task must_recover_restarted_actor()
+        {
+            var actor = ActorRegistry.Get<PersistActor>();
+            Watch(actor);
+            await probe!.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal!.OnRecovery.Pass();
+            actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
+            await probe.ExpectMsgAsync("ack");
+            actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
+            await probe.ExpectMsgAsync("ack");
+
+            await actor.GracefulStop(TimeSpan.FromSeconds(1));
+            await ExpectTerminatedAsync(actor);
+
+            ActorOf(() => new PersistActor(probe));
+            await probe.ExpectMsgAsync("1");
+            await probe.ExpectMsgAsync("2");
+            await probe.ExpectMsgAsync<RecoveryCompleted>();
+        }
+
+        [Fact]
+        public async Task when_fail_on_write_is_set_all_writes_to_journal_will_fail()
+        {
+            var actor = ActorRegistry.Get<PersistActor>();
+            Watch(actor);
+            await probe!.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal!.OnWrite.Fail();
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+            await probe.ExpectMsgAsync("failure");
+            await ExpectTerminatedAsync(actor);
+        }
+
+        [Fact]
+        public async Task must_recover_failed_actor()
+        {
+            var actor = ActorRegistry.Get<PersistActor>();
+            Watch(actor);
+            await probe!.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal!.OnRecovery.Pass();
+            actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
+            await probe.ExpectMsgAsync("ack");
+            actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
+            await probe.ExpectMsgAsync("ack");
+
+            await Journal.OnWrite.Fail();
+            actor.Tell(new PersistActor.WriteMessage("3"), TestActor);
+
+            await probe.ExpectMsgAsync("failure");
+            await ExpectTerminatedAsync(actor);
+
+            ActorOf(() => new PersistActor(probe));
+            await probe.ExpectMsgAsync("1");
+            await probe.ExpectMsgAsync("2");
+            await probe.ExpectMsgAsync<RecoveryCompleted>();
+        }
+
+        [Fact]
+        public async Task when_reject_on_write_is_set_all_writes_to_journal_will_be_rejected()
+        {
+            var actor = ActorRegistry.Get<PersistActor>();
+            Watch(actor);
+            await probe!.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal!.OnWrite.Reject();
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+            await probe.ExpectMsgAsync("rejected");
+        }
+
+        [Fact]
+        public async Task journal_must_reset_state_to_pass()
+        {
+            await WithJournalWrite(write => write.Fail(), async () =>
+            {
+                var actor = ActorRegistry.Get<PersistActor>();
+                Watch(actor);
+                await probe!.ExpectMsgAsync<RecoveryCompleted>();
+
+                actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+                await probe.ExpectMsgAsync("failure");
+                await ExpectTerminatedAsync(actor);
+            });
+
+            var actor2 = ActorOf(() => new PersistActor(probe!));
+            Watch(actor2);
+
+            await probe!.ExpectMsgAsync<RecoveryCompleted>();
+            actor2.Tell(new PersistActor.WriteMessage("write"), TestActor);
+            await probe.ExpectMsgAsync("ack");
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
@@ -8,156 +8,149 @@ using FluentAssertions;
 using System;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
-namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests
+namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests;
+
+public class TestJournalSpec : PersistenceTestKit
 {
+    private TestProbe _probe = null!; 
 
-    public class TestJournalSpec : PersistenceTestKit
+    public TestJournalSpec(ITestOutputHelper output) : base(nameof(TestJournalSpec), output)
     {
-        // Expect should be passing by default, need to make them less sencitive to timing
-        private static readonly Config DefaultTimeoutConfig = "akka.test.single-expect-default = 30s";
+    }
 
-        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    // Expect should be passing by default, need to make them less sensitive to timing
+    protected override Config? Config => "akka.test.single-expect-default = 30s";
+
+    protected override Task BeforeTestStart()
+    {
+        _probe = CreateTestProbe();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public void must_have_journal_and_snapshot()
+    {
+        Journal.Should().NotBeNull();
+        JournalActorRef.Should().NotBeNull();
+        Snapshots.Should().NotBeNull();
+        SnapshotsActorRef.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task must_return_ack_after_new_write_interceptor_is_set()
+    {
+        JournalActorRef.Tell(new TestJournal.UseWriteInterceptor(null), TestActor);
+
+        await ExpectMsgAsync<TestJournal.Ack>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task works_as_memory_journal_by_default()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnWrite.Pass();
+        actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+        await _probe.ExpectMsgAsync("ack");
+    }
+
+    [Fact]
+    public async Task must_recover_restarted_actor()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnRecovery.Pass();
+        actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+        actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+
+        await actor.GracefulStop(TimeSpan.FromSeconds(1));
+        await ExpectTerminatedAsync(actor);
+
+        ActorOf(() => new PersistActor(_probe));
+        await _probe.ExpectMsgAsync("1");
+        await _probe.ExpectMsgAsync("2");
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+    }
+
+    [Fact]
+    public async Task when_fail_on_write_is_set_all_writes_to_journal_will_fail()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnWrite.Fail();
+        actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+        await _probe.ExpectMsgAsync("failure");
+        await ExpectTerminatedAsync(actor);
+    }
+
+    [Fact]
+    public async Task must_recover_failed_actor()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnRecovery.Pass();
+        actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+        actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+
+        await Journal.OnWrite.Fail();
+        actor.Tell(new PersistActor.WriteMessage("3"), TestActor);
+
+        await _probe.ExpectMsgAsync("failure");
+        await ExpectTerminatedAsync(actor);
+
+        ActorOf(() => new PersistActor(_probe));
+        await _probe.ExpectMsgAsync("1");
+        await _probe.ExpectMsgAsync("2");
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+    }
+
+    [Fact]
+    public async Task when_reject_on_write_is_set_all_writes_to_journal_will_be_rejected()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnWrite.Reject();
+        actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+        await _probe.ExpectMsgAsync("rejected");
+    }
+
+    [Fact]
+    public async Task journal_must_reset_state_to_pass()
+    {
+        await WithJournalWrite(write => write.Fail(), async () =>
         {
-            base.ConfigureAkka(builder, provider);
-            builder.WithActors((system, registry) =>
-            {
-                probe = CreateTestProbe();
-                var echo = system.ActorOf(Props.Create(() => new PersistActor(probe)));
-                registry.Register<PersistActor>(echo);
-            });
-        }
+            var actor = ActorOf(() => new PersistActor(_probe));
+            await WatchAsync(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
 
-        private TestProbe? probe;
-
-        public TestJournalSpec() : base(DefaultTimeoutConfig)
-        {
-        }
-
-        [Fact]
-        public void must_have_journal_and_snapshot()
-        {
-            probe.Should().NotBeNull();
-            Journal.Should().NotBeNull();
-            JournalActorRef.Should().NotBeNull();
-            Snapshots.Should().NotBeNull();
-            SnapshotsActorRef.Should().NotBeNull();
-        }
-
-        [Fact]
-        public async Task must_return_ack_after_new_write_interceptor_is_set()
-        {
-            JournalActorRef!.Tell(new TestJournal.UseWriteInterceptor(null), TestActor);
-
-            await ExpectMsgAsync<TestJournal.Ack>(TimeSpan.FromSeconds(3));
-        }
-
-        [Fact]
-        public async Task works_as_memory_journal_by_default()
-        {
-            var actor = ActorRegistry.Get<PersistActor>();
-            await probe!.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal!.OnWrite.Pass();
             actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
-
-            await probe.ExpectMsgAsync("ack");
-        }
-
-        [Fact]
-        public async Task must_recover_restarted_actor()
-        {
-            var actor = ActorRegistry.Get<PersistActor>();
-            Watch(actor);
-            await probe!.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal!.OnRecovery.Pass();
-            actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
-            await probe.ExpectMsgAsync("ack");
-            actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
-            await probe.ExpectMsgAsync("ack");
-
-            await actor.GracefulStop(TimeSpan.FromSeconds(1));
+            await _probe.ExpectMsgAsync("failure");
             await ExpectTerminatedAsync(actor);
+        });
 
-            ActorOf(() => new PersistActor(probe));
-            await probe.ExpectMsgAsync("1");
-            await probe.ExpectMsgAsync("2");
-            await probe.ExpectMsgAsync<RecoveryCompleted>();
-        }
+        var actor2 = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor2);
 
-        [Fact]
-        public async Task when_fail_on_write_is_set_all_writes_to_journal_will_fail()
-        {
-            var actor = ActorRegistry.Get<PersistActor>();
-            Watch(actor);
-            await probe!.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal!.OnWrite.Fail();
-            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
-
-            await probe.ExpectMsgAsync("failure");
-            await ExpectTerminatedAsync(actor);
-        }
-
-        [Fact]
-        public async Task must_recover_failed_actor()
-        {
-            var actor = ActorRegistry.Get<PersistActor>();
-            Watch(actor);
-            await probe!.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal!.OnRecovery.Pass();
-            actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
-            await probe.ExpectMsgAsync("ack");
-            actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
-            await probe.ExpectMsgAsync("ack");
-
-            await Journal.OnWrite.Fail();
-            actor.Tell(new PersistActor.WriteMessage("3"), TestActor);
-
-            await probe.ExpectMsgAsync("failure");
-            await ExpectTerminatedAsync(actor);
-
-            ActorOf(() => new PersistActor(probe));
-            await probe.ExpectMsgAsync("1");
-            await probe.ExpectMsgAsync("2");
-            await probe.ExpectMsgAsync<RecoveryCompleted>();
-        }
-
-        [Fact]
-        public async Task when_reject_on_write_is_set_all_writes_to_journal_will_be_rejected()
-        {
-            var actor = ActorRegistry.Get<PersistActor>();
-            Watch(actor);
-            await probe!.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal!.OnWrite.Reject();
-            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
-
-            await probe.ExpectMsgAsync("rejected");
-        }
-
-        [Fact]
-        public async Task journal_must_reset_state_to_pass()
-        {
-            await WithJournalWrite(write => write.Fail(), async () =>
-            {
-                var actor = ActorRegistry.Get<PersistActor>();
-                Watch(actor);
-                await probe!.ExpectMsgAsync<RecoveryCompleted>();
-
-                actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
-                await probe.ExpectMsgAsync("failure");
-                await ExpectTerminatedAsync(actor);
-            });
-
-            var actor2 = ActorOf(() => new PersistActor(probe!));
-            Watch(actor2);
-
-            await probe!.ExpectMsgAsync<RecoveryCompleted>();
-            actor2.Tell(new PersistActor.WriteMessage("write"), TestActor);
-            await probe.ExpectMsgAsync("ack");
-        }
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+        actor2.Tell(new PersistActor.WriteMessage("write"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
     }
 }

--- a/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
@@ -1,0 +1,116 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestSnapshotStoreSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests
+{
+    using Actor;
+    using Akka.Persistence;
+    using Akka.Persistence.TestKit;
+    using Akka.Persistence.TestKit.Tests;
+    using Akka.TestKit;
+    using System;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public sealed class TestSnapshotStoreSpec : PersistenceTestKit
+    {
+        public TestSnapshotStoreSpec(ITestOutputHelper output) : base(nameof(TestSnapshotStoreSpec), output: output)
+        {
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            base.ConfigureAkka(builder, provider);
+            builder.WithActors((system, registry) =>
+            {
+                probe = CreateTestProbe();
+                var echo = system.ActorOf(Props.Create(() => new SnapshotActor(probe)));
+                registry.Register<SnapshotActor>(echo);
+            });
+        }
+
+        private TestProbe? probe;
+
+        [Fact]
+        public async Task send_ack_after_load_interceptor_is_set()
+        {
+            SnapshotsActorRef!.Tell(new TestSnapshotStore.UseLoadInterceptor(null), TestActor);
+            await ExpectMsgAsync<TestSnapshotStore.Ack>();
+        }
+
+        [Fact]
+        public async Task send_ack_after_save_interceptor_is_set()
+        {
+            SnapshotsActorRef!.Tell(new TestSnapshotStore.UseSaveInterceptor(null), TestActor);
+            await ExpectMsgAsync<TestSnapshotStore.Ack>();
+        }
+
+        [Fact]
+        public async Task send_ack_after_delete_interceptor_is_set()
+        {
+            SnapshotsActorRef!.Tell(new TestSnapshotStore.UseDeleteInterceptor(null), TestActor);
+            await ExpectMsgAsync<TestSnapshotStore.Ack>();
+        }
+
+        [Fact]
+        public async Task after_load_behavior_was_executed_store_is_back_to_pass_mode()
+        {
+            // create snapshot
+            var actor = ActorRegistry.Get<SnapshotActor>();
+            actor.Tell("save");
+            await probe!.ExpectMsgAsync<SaveSnapshotSuccess>();
+            await actor.GracefulStop(TimeSpan.FromSeconds(3));
+
+            await WithSnapshotLoad(load => load.Fail(), async () =>
+            {
+                ActorOf(() => new SnapshotActor(probe!));
+                await probe!.ExpectMsgAsync<SnapshotActor.RecoveryFailure>();
+            });
+
+            ActorOf(() => new SnapshotActor(probe!));
+            await probe!.ExpectMsgAsync<SnapshotOffer>();
+        }
+
+        [Fact]
+        public async Task after_save_behavior_was_executed_store_is_back_to_pass_mode()
+        {
+            // create snapshot
+            var actor = ActorRegistry.Get<SnapshotActor>();
+
+            await WithSnapshotSave(save => save.Fail(), async () =>
+            {
+                actor.Tell("save");
+                await probe!.ExpectMsgAsync<SaveSnapshotFailure>();
+            });
+
+            actor.Tell("save");
+            await probe!.ExpectMsgAsync<SaveSnapshotSuccess>();
+        }
+
+        [Fact]
+        public async Task after_delete_behavior_was_executed_store_is_back_to_pass_mode()
+        {
+            // create snapshot
+            var actor = ActorRegistry.Get<SnapshotActor>();
+            actor.Tell("save");
+
+            var success = await probe!.ExpectMsgAsync<SaveSnapshotSuccess>();
+            var nr = success.Metadata.SequenceNr;
+
+            await WithSnapshotDelete(del => del.Fail(), async () =>
+            {
+                actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
+                await probe!.ExpectMsgAsync<DeleteSnapshotFailure>();
+            });
+
+            actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
+            await probe!.ExpectMsgAsync<DeleteSnapshotSuccess>();
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
@@ -7,110 +7,104 @@
 
 using Xunit.Abstractions;
 
-namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests
+namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests;
+
+using Actor;
+using Akka.Persistence;
+using Akka.Persistence.TestKit;
+using Akka.Persistence.TestKit.Tests;
+using Akka.TestKit;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+public sealed class TestSnapshotStoreSpec : PersistenceTestKit
 {
-    using Actor;
-    using Akka.Persistence;
-    using Akka.Persistence.TestKit;
-    using Akka.Persistence.TestKit.Tests;
-    using Akka.TestKit;
-    using System;
-    using System.Threading.Tasks;
-    using Xunit;
-
-    public sealed class TestSnapshotStoreSpec : PersistenceTestKit
+    public TestSnapshotStoreSpec(ITestOutputHelper output) : base(nameof(TestSnapshotStoreSpec), output: output)
     {
-        public TestSnapshotStoreSpec(ITestOutputHelper output) : base(nameof(TestSnapshotStoreSpec), output: output)
-        {
-        }
+    }
 
-        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-        {
-            base.ConfigureAkka(builder, provider);
-            builder.WithActors((system, registry) =>
-            {
-                probe = CreateTestProbe();
-                var echo = system.ActorOf(Props.Create(() => new SnapshotActor(probe)));
-                registry.Register<SnapshotActor>(echo);
-            });
-        }
+    protected override Task BeforeTestStart()
+    {
+        _probe = CreateTestProbe();
+        return Task.CompletedTask;
+    }
 
-        private TestProbe? probe;
+    private TestProbe _probe = null!;
 
-        [Fact]
-        public async Task send_ack_after_load_interceptor_is_set()
-        {
-            SnapshotsActorRef!.Tell(new TestSnapshotStore.UseLoadInterceptor(null), TestActor);
-            await ExpectMsgAsync<TestSnapshotStore.Ack>();
-        }
+    [Fact]
+    public async Task send_ack_after_load_interceptor_is_set()
+    {
+        SnapshotsActorRef.Tell(new TestSnapshotStore.UseLoadInterceptor(null), TestActor);
+        await ExpectMsgAsync<TestSnapshotStore.Ack>();
+    }
 
-        [Fact]
-        public async Task send_ack_after_save_interceptor_is_set()
-        {
-            SnapshotsActorRef!.Tell(new TestSnapshotStore.UseSaveInterceptor(null), TestActor);
-            await ExpectMsgAsync<TestSnapshotStore.Ack>();
-        }
+    [Fact]
+    public async Task send_ack_after_save_interceptor_is_set()
+    {
+        SnapshotsActorRef.Tell(new TestSnapshotStore.UseSaveInterceptor(null), TestActor);
+        await ExpectMsgAsync<TestSnapshotStore.Ack>();
+    }
 
-        [Fact]
-        public async Task send_ack_after_delete_interceptor_is_set()
-        {
-            SnapshotsActorRef!.Tell(new TestSnapshotStore.UseDeleteInterceptor(null), TestActor);
-            await ExpectMsgAsync<TestSnapshotStore.Ack>();
-        }
+    [Fact]
+    public async Task send_ack_after_delete_interceptor_is_set()
+    {
+        SnapshotsActorRef.Tell(new TestSnapshotStore.UseDeleteInterceptor(null), TestActor);
+        await ExpectMsgAsync<TestSnapshotStore.Ack>();
+    }
 
-        [Fact]
-        public async Task after_load_behavior_was_executed_store_is_back_to_pass_mode()
+    [Fact]
+    public async Task after_load_behavior_was_executed_store_is_back_to_pass_mode()
+    {
+        // create snapshot
+        var actor = ActorOf(() => new SnapshotActor(_probe));
+        actor.Tell("save");
+        await _probe.ExpectMsgAsync<SaveSnapshotSuccess>();
+        await actor.GracefulStop(TimeSpan.FromSeconds(3));
+
+        await WithSnapshotLoad(load => load.Fail(), async () =>
         {
-            // create snapshot
-            var actor = ActorRegistry.Get<SnapshotActor>();
+            ActorOf(() => new SnapshotActor(_probe));
+            await _probe.ExpectMsgAsync<SnapshotActor.RecoveryFailure>();
+        });
+
+        ActorOf(() => new SnapshotActor(_probe));
+        await _probe.ExpectMsgAsync<SnapshotOffer>();
+    }
+
+    [Fact]
+    public async Task after_save_behavior_was_executed_store_is_back_to_pass_mode()
+    {
+        // create snapshot
+        var actor = ActorOf(() => new SnapshotActor(_probe));
+
+        await WithSnapshotSave(save => save.Fail(), async () =>
+        {
             actor.Tell("save");
-            await probe!.ExpectMsgAsync<SaveSnapshotSuccess>();
-            await actor.GracefulStop(TimeSpan.FromSeconds(3));
+            await _probe.ExpectMsgAsync<SaveSnapshotFailure>();
+        });
 
-            await WithSnapshotLoad(load => load.Fail(), async () =>
-            {
-                ActorOf(() => new SnapshotActor(probe!));
-                await probe!.ExpectMsgAsync<SnapshotActor.RecoveryFailure>();
-            });
+        actor.Tell("save");
+        await _probe.ExpectMsgAsync<SaveSnapshotSuccess>();
+    }
 
-            ActorOf(() => new SnapshotActor(probe!));
-            await probe!.ExpectMsgAsync<SnapshotOffer>();
-        }
+    [Fact]
+    public async Task after_delete_behavior_was_executed_store_is_back_to_pass_mode()
+    {
+        // create snapshot
+        var actor = ActorOf(() => new SnapshotActor(_probe));
+        actor.Tell("save");
 
-        [Fact]
-        public async Task after_save_behavior_was_executed_store_is_back_to_pass_mode()
+        var success = await _probe.ExpectMsgAsync<SaveSnapshotSuccess>();
+        var nr = success.Metadata.SequenceNr;
+
+        await WithSnapshotDelete(del => del.Fail(), async () =>
         {
-            // create snapshot
-            var actor = ActorRegistry.Get<SnapshotActor>();
-
-            await WithSnapshotSave(save => save.Fail(), async () =>
-            {
-                actor.Tell("save");
-                await probe!.ExpectMsgAsync<SaveSnapshotFailure>();
-            });
-
-            actor.Tell("save");
-            await probe!.ExpectMsgAsync<SaveSnapshotSuccess>();
-        }
-
-        [Fact]
-        public async Task after_delete_behavior_was_executed_store_is_back_to_pass_mode()
-        {
-            // create snapshot
-            var actor = ActorRegistry.Get<SnapshotActor>();
-            actor.Tell("save");
-
-            var success = await probe!.ExpectMsgAsync<SaveSnapshotSuccess>();
-            var nr = success.Metadata.SequenceNr;
-
-            await WithSnapshotDelete(del => del.Fail(), async () =>
-            {
-                actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
-                await probe!.ExpectMsgAsync<DeleteSnapshotFailure>();
-            });
-
             actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
-            await probe!.ExpectMsgAsync<DeleteSnapshotSuccess>();
-        }
+            await _probe.ExpectMsgAsync<DeleteSnapshotFailure>();
+        });
+
+        actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
+        await _probe.ExpectMsgAsync<DeleteSnapshotSuccess>();
     }
 }

--- a/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
+++ b/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
@@ -18,6 +19,7 @@
     
     <ItemGroup>
       <ProjectReference Include="..\Akka.Hosting\Akka.Hosting.csproj" />
+      <ProjectReference Include="..\Akka.Persistence.Hosting\Akka.Persistence.Hosting.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Akka.Hosting.TestKit/PersistenceTestKit.cs
+++ b/src/Akka.Hosting.TestKit/PersistenceTestKit.cs
@@ -1,0 +1,306 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HostingSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.TestKit;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit
+{
+    public abstract class PersistenceTestKit : TestKit
+    {
+        /// <summary>
+        /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+        /// A new system with the specified configuration will be created.
+        /// </summary>
+        /// <param name="config">Test ActorSystem configuration</param>
+        /// <param name="actorSystemName">Optional: The name of the actor system</param>
+        /// <param name="output">TBD</param>
+        public PersistenceTestKit(Config? config = null, string? actorSystemName = null, ITestOutputHelper? output = null)
+            : base(actorSystemName, output)
+        {
+            _config = GetConfig(config ?? Config.Empty);
+        }
+
+        /// <summary>
+        /// Actor reference to persistence Journal used by current actor system.
+        /// </summary>
+        public IActorRef? JournalActorRef { get; set; }
+
+        /// <summary>
+        /// Actor reference to persistence Snapshot Store used by current actor system.
+        /// </summary>
+        public IActorRef? SnapshotsActorRef { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ITestJournal? Journal { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ITestSnapshotStore? Snapshots { get; set; }
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public async Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Func<Task> execution)
+        {
+            if (Journal == null) throw new ArgumentNullException(nameof(Journal));
+            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            try
+            {
+                await behaviorSelector(Journal.OnRecovery);
+                await execution();
+            }
+            finally
+            {
+                await Journal.OnRecovery.Pass();
+            }
+        }
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public async Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Func<Task> execution)
+        {
+            if (Journal == null) throw new ArgumentNullException(nameof(Journal));
+            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            try
+            {
+                await behaviorSelector(Journal.OnWrite);
+                await execution();
+            }
+            finally
+            {
+                await Journal.OnWrite.Pass();
+            }
+        }
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+        /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Action execution)
+            => WithJournalRecovery(behaviorSelector, () =>
+            {
+                if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+                execution();
+                return Task.FromResult(new object());
+            });
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+        /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Action execution)
+            => WithJournalWrite(behaviorSelector, () =>
+            {
+                if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+                execution();
+                return Task.FromResult(new object());
+            });
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public async Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Func<Task> execution)
+        {
+            if (Snapshots == null) throw new ArgumentNullException(nameof(Journal));
+            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            try
+            {
+                await behaviorSelector(Snapshots.OnSave);
+                await execution();
+            }
+            finally
+            {
+                await Snapshots.OnSave.Pass();
+            }
+        }
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public async Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Func<Task> execution)
+        {
+            if (Snapshots == null) throw new ArgumentNullException(nameof(Journal));
+            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            try
+            {
+                await behaviorSelector(Snapshots.OnLoad);
+                await execution();
+            }
+            finally
+            {
+                await Snapshots.OnLoad.Pass();
+            }
+        }
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public async Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Func<Task> execution)
+        {
+            if (Snapshots == null) throw new ArgumentNullException(nameof(Journal));
+            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            try
+            {
+                await behaviorSelector(Snapshots.OnDelete);
+                await execution();
+            }
+            finally
+            {
+                await Snapshots.OnDelete.Pass();
+            }
+        }
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+        /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Action execution)
+            => WithSnapshotSave(behaviorSelector, () =>
+            {
+                if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+                execution();
+                return Task.FromResult(true);
+            });
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Action execution)
+            => WithSnapshotLoad(behaviorSelector, () =>
+            {
+                if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+                execution();
+                return Task.FromResult(true);
+            });
+
+        /// <summary>
+        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+        /// </summary>
+        /// <remarks>
+        ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+        /// </remarks>
+        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+        /// <returns><see cref="Task"/> which must be awaited.</returns>
+        public Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Action execution)
+            => WithSnapshotDelete(behaviorSelector, () =>
+            {
+                if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+                execution();
+                return Task.FromResult(true);
+            });
+
+        private readonly Config _config;
+        protected override Config? Config => _config;
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            if (_config is not null)
+            {
+                builder.AddHocon(_config, HoconAddMode.Append);
+
+                builder.AddStartup((system, registry) =>
+                {
+                    var persistenceExtension = Persistence.Persistence.Instance.Apply(system);
+                    JournalActorRef = persistenceExtension.JournalFor(null);
+                    Journal = TestJournal.FromRef(JournalActorRef);
+                    SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
+                    Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
+                });
+            }
+        }
+
+        /// <summary>
+        ///     Loads from embedded resources actor system persistence configuration with <see cref="TestJournal"/> and
+        ///     <see cref="TestSnapshotStore"/> configured as default persistence plugins.
+        /// </summary>
+        /// <param name="customConfig">Custom configuration that was passed in the constructor.</param>
+        /// <returns>Actor system configuration object.</returns>
+        /// <seealso cref="Config"/>
+        private static Config GetConfig(Config customConfig)
+        {
+            var defaultConfig = ConfigurationFactory.FromResource<TestJournal>("Akka.Persistence.TestKit.config.conf");
+            if (customConfig == Config.Empty) return defaultConfig;
+            else return defaultConfig.SafeWithFallback(customConfig);
+        }
+    }
+}
+

--- a/src/Akka.Hosting.TestKit/PersistenceTestKit.cs
+++ b/src/Akka.Hosting.TestKit/PersistenceTestKit.cs
@@ -9,298 +9,271 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.TestKit;
+using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
-namespace Akka.Hosting.TestKit
+namespace Akka.Hosting.TestKit;
+
+public abstract class PersistenceTestKit : TestKit
 {
-    public abstract class PersistenceTestKit : TestKit
+    public static readonly Config DefaultConfiguration = ConfigurationFactory.FromResource<TestJournal>("Akka.Persistence.TestKit.config.conf");
+        
+    /// <summary>
+    /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+    /// A new system with the specified configuration will be created.
+    /// </summary>
+    public PersistenceTestKit(string? actorSystemName = null, ITestOutputHelper? output = null, TimeSpan? startupTimeout = null, LogLevel logLevel = LogLevel.Information)
+        : base(actorSystemName, output, startupTimeout, logLevel)
     {
-        /// <summary>
-        /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
-        /// A new system with the specified configuration will be created.
-        /// </summary>
-        /// <param name="config">Test ActorSystem configuration</param>
-        /// <param name="actorSystemName">Optional: The name of the actor system</param>
-        /// <param name="output">TBD</param>
-        public PersistenceTestKit(Config? config = null, string? actorSystemName = null, ITestOutputHelper? output = null)
-            : base(actorSystemName, output)
+    }
+
+    /// <summary>
+    /// Actor reference to persistence Journal used by current actor system.
+    /// </summary>
+    public IActorRef JournalActorRef { get; private set; } = null!;
+
+    /// <summary>
+    /// Actor reference to persistence Snapshot Store used by current actor system.
+    /// </summary>
+    public IActorRef SnapshotsActorRef { get; private set; } = null!;
+
+    /// <summary>
+    /// Current journal IActorRef wrapped inside a TestJournal
+    /// </summary>
+    public ITestJournal Journal { get; private set; } = null!;
+
+    /// <summary>
+    /// Current snapshot store IActorRef wrapped inside a TestSnapshotStore
+    /// </summary>
+    public ITestSnapshotStore Snapshots { get; private set; } = null!;
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
         {
-            _config = GetConfig(config ?? Config.Empty);
+            await behaviorSelector(Journal.OnRecovery);
+            await execution();
         }
-
-        /// <summary>
-        /// Actor reference to persistence Journal used by current actor system.
-        /// </summary>
-        public IActorRef? JournalActorRef { get; set; }
-
-        /// <summary>
-        /// Actor reference to persistence Snapshot Store used by current actor system.
-        /// </summary>
-        public IActorRef? SnapshotsActorRef { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public ITestJournal? Journal { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public ITestSnapshotStore? Snapshots { get; set; }
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public async Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Func<Task> execution)
+        finally
         {
-            if (Journal == null) throw new ArgumentNullException(nameof(Journal));
-            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
-            if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-            try
-            {
-                await behaviorSelector(Journal.OnRecovery);
-                await execution();
-            }
-            finally
-            {
-                await Journal.OnRecovery.Pass();
-            }
-        }
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public async Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Func<Task> execution)
-        {
-            if (Journal == null) throw new ArgumentNullException(nameof(Journal));
-            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
-            if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-            try
-            {
-                await behaviorSelector(Journal.OnWrite);
-                await execution();
-            }
-            finally
-            {
-                await Journal.OnWrite.Pass();
-            }
-        }
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
-        /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Action execution)
-            => WithJournalRecovery(behaviorSelector, () =>
-            {
-                if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-                execution();
-                return Task.FromResult(new object());
-            });
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
-        /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Action execution)
-            => WithJournalWrite(behaviorSelector, () =>
-            {
-                if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-                execution();
-                return Task.FromResult(new object());
-            });
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public async Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Func<Task> execution)
-        {
-            if (Snapshots == null) throw new ArgumentNullException(nameof(Journal));
-            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
-            if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-            try
-            {
-                await behaviorSelector(Snapshots.OnSave);
-                await execution();
-            }
-            finally
-            {
-                await Snapshots.OnSave.Pass();
-            }
-        }
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public async Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Func<Task> execution)
-        {
-            if (Snapshots == null) throw new ArgumentNullException(nameof(Journal));
-            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
-            if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-            try
-            {
-                await behaviorSelector(Snapshots.OnLoad);
-                await execution();
-            }
-            finally
-            {
-                await Snapshots.OnLoad.Pass();
-            }
-        }
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public async Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Func<Task> execution)
-        {
-            if (Snapshots == null) throw new ArgumentNullException(nameof(Journal));
-            if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
-            if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-            try
-            {
-                await behaviorSelector(Snapshots.OnDelete);
-                await execution();
-            }
-            finally
-            {
-                await Snapshots.OnDelete.Pass();
-            }
-        }
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
-        /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Action execution)
-            => WithSnapshotSave(behaviorSelector, () =>
-            {
-                if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-                execution();
-                return Task.FromResult(true);
-            });
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Action execution)
-            => WithSnapshotLoad(behaviorSelector, () =>
-            {
-                if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-                execution();
-                return Task.FromResult(true);
-            });
-
-        /// <summary>
-        ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
-        /// </summary>
-        /// <remarks>
-        ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
-        /// </remarks>
-        /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
-        /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
-        /// <returns><see cref="Task"/> which must be awaited.</returns>
-        public Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Action execution)
-            => WithSnapshotDelete(behaviorSelector, () =>
-            {
-                if (execution == null) throw new ArgumentNullException(nameof(execution));
-
-                execution();
-                return Task.FromResult(true);
-            });
-
-        private readonly Config _config;
-        protected override Config? Config => _config;
-
-        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
-        {
-            if (_config is not null)
-            {
-                builder.AddHocon(_config, HoconAddMode.Append);
-
-                builder.AddStartup((system, registry) =>
-                {
-                    var persistenceExtension = Persistence.Persistence.Instance.Apply(system);
-                    JournalActorRef = persistenceExtension.JournalFor(null);
-                    Journal = TestJournal.FromRef(JournalActorRef);
-                    SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
-                    Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
-                });
-            }
-        }
-
-        /// <summary>
-        ///     Loads from embedded resources actor system persistence configuration with <see cref="TestJournal"/> and
-        ///     <see cref="TestSnapshotStore"/> configured as default persistence plugins.
-        /// </summary>
-        /// <param name="customConfig">Custom configuration that was passed in the constructor.</param>
-        /// <returns>Actor system configuration object.</returns>
-        /// <seealso cref="Config"/>
-        private static Config GetConfig(Config customConfig)
-        {
-            var defaultConfig = ConfigurationFactory.FromResource<TestJournal>("Akka.Persistence.TestKit.config.conf");
-            if (customConfig == Config.Empty) return defaultConfig;
-            else return defaultConfig.SafeWithFallback(customConfig);
+            await Journal.OnRecovery.Pass();
         }
     }
-}
 
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Journal.OnWrite);
+            await execution();
+        }
+        finally
+        {
+            await Journal.OnWrite.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Action execution)
+        => WithJournalRecovery(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(new object());
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Action execution)
+        => WithJournalWrite(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(new object());
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnSave);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnSave.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnLoad);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnLoad.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnDelete);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnDelete.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotSave(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotLoad(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotDelete(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.AddHocon(DefaultConfiguration, HoconAddMode.Append);
+
+        builder.AddStartup((system, registry) =>
+        {
+            var persistenceExtension = Persistence.Persistence.Instance.Apply(system);
+            
+            JournalActorRef = persistenceExtension.JournalFor(null);
+            Journal = TestJournal.FromRef(JournalActorRef);
+            SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
+            Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
+        });
+    }
+}


### PR DESCRIPTION
Fixes #609 

## Changes

Please provide a brief description of the changes here.

- Add `PersistenceTestKit` with methods for testing journal and snapshot behaviors, enabling effective simulation of persistence scenarios.
- Updated `Akka.Hosting.TestKit.csproj` to include `Akka.Persistence.TestKit` and a reference to `Akka.Persistence.Hosting`.
- Add `TestJournalSpec` and `TestSnapshotStoreSpec` with tests for new persistence functionality, covering various scenarios like successful writes and recovery.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
