### PR TITLE
Update RELEASE_NOTES.md for 1.5.44 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.42 May 21st 2025 ####
+#### 1.5.44 June 23rd 2025 ####
 
-* [Bump AkkaVersion from 1.5.40 to 1.5.42](https://github.com/akkadotnet/akka.net/releases/tag/1.5.42)
-* [Fix `.WithDistributedData()` to start `DistributedDataProvider` automatically](https://github.com/akkadotnet/Akka.Hosting/pull/597)
+* [Bump AkkaVersion from 1.5.40 to 1.5.44](https://github.com/akkadotnet/akka.net/releases/tag/1.5.44)
+* [Add persistence testkit support](https://github.com/akkadotnet/Akka.Hosting/pull/610)


### PR DESCRIPTION
## 1.5.44 June 23rd 2025

* [Bump AkkaVersion from 1.5.40 to 1.5.44](https://github.com/akkadotnet/akka.net/releases/tag/1.5.44)
* [Add persistence testkit support](https://github.com/akkadotnet/Akka.Hosting/pull/610)
