### PR TITLE
Akka.Cluster.Hosting.Testing: fix racy DData spec

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -35,7 +35,10 @@ public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
     {
         var cluster = Cluster.Get(Sys);
         await cluster.JoinAsync(cluster.SelfAddress);
-        cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
+        await AwaitAssertAsync(() => 
+                cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1),
+            interval: TimeSpan.FromMilliseconds(200),
+            duration: TimeSpan.FromSeconds(10));
         
         var settings = ReplicatorSettings.Create(Sys);
         var coordinatorName = settings.RestartReplicatorOnFailure ? $"{ReplicatorName}Supervisor" : ReplicatorName;


### PR DESCRIPTION
## Changes

Fixes race condition where we were evaluating cluster state too quickly after joining. Needed to just wrap the call inside an `AwaitAssert`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
