### PR TITLE
TestActor startup deadlock

### DIFF
--- a/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
@@ -61,7 +61,7 @@ public class TestActorStartupDeadlockSpec
         var startTimeout   = TimeSpan.FromSeconds(7); // pre-fix should trip this quickly
         var expectTimeout  = TimeSpan.FromSeconds(5);
         var stopTimeout    = TimeSpan.FromSeconds(5);
-        var concurrentHosts = 40;
+        var concurrentHosts = 30;
 
         // Spin up N independent hosts concurrently inside the same theory
         var runners = Enumerable.Range(0, concurrentHosts)

--- a/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
@@ -61,7 +61,7 @@ public class TestActorStartupDeadlockSpec
         var startTimeout   = TimeSpan.FromSeconds(7); // pre-fix should trip this quickly
         var expectTimeout  = TimeSpan.FromSeconds(5);
         var stopTimeout    = TimeSpan.FromSeconds(5);
-        var concurrentHosts = Environment.ProcessorCount * 2;
+        var concurrentHosts = 40;
 
         // Spin up N independent hosts concurrently inside the same theory
         var runners = Enumerable.Range(0, concurrentHosts)
@@ -77,7 +77,7 @@ public class TestActorStartupDeadlockSpec
 
             // --- START (bounded) ---
             var startTask = kit.StartAsync();
-            var startDone = await Task.WhenAny(startTask, Task.Delay(startTimeout)).ConfigureAwait(false);
+            var startDone = await Task.WhenAny(startTask, Task.Delay(startTimeout));
             if (startDone != startTask)
             {
                 // Fail fast with a clear message rather than timing out the entire test method
@@ -86,25 +86,35 @@ public class TestActorStartupDeadlockSpec
                     "This indicates the known startup deadlock (TestKit initialized inline on the startup thread).");
             }
             // propagate any exception from StartAsync (e.g., watchdog TimeoutException)
-            await startTask.ConfigureAwait(false);
+            try
+            {
+                await startTask;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.StartsWith("Timeout waiting for test actor"))
+                    _output.WriteLine($"Original issue detected: {ex.Message}");
+                
+                throw;
+            }
 
             try
             {
                 // --- EXPECT (bounded) ---
                 var expectTask = kit.ExpectStartupAsync(expectTimeout);
-                var expectDone = await Task.WhenAny(expectTask, Task.Delay(expectTimeout)).ConfigureAwait(false);
+                var expectDone = await Task.WhenAny(expectTask, Task.Delay(expectTimeout));
                 if (expectDone != expectTask)
                     Assert.Fail($"Did not receive startup ping within {expectTimeout}.");
 
-                await expectTask.ConfigureAwait(false);
+                await expectTask;
             }
             finally
             {
                 // --- STOP (bounded) ---
                 var stopTask = kit.StopAsync();
-                var stopDone = await Task.WhenAny(stopTask, Task.Delay(stopTimeout)).ConfigureAwait(false);
+                var stopDone = await Task.WhenAny(stopTask, Task.Delay(stopTimeout));
                 if (stopDone == stopTask)
-                    await stopTask.ConfigureAwait(false);
+                    await stopTask;
                 // else: swallow to avoid hanging the test process on shutdown in pre-fix scenarios
             }
         }

--- a/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
@@ -54,15 +54,14 @@ public class TestActorStartupDeadlockSpec
     }
     
     // Give the overall test plenty of time; we enforce our own short, per-step timeouts below.
-    [Theory(Timeout = 20000)]
-    [InlineData(20)]
-    [InlineData(40)]
-    public async Task parallel_host_start_should_not_deadlock(int concurrentHosts)
+    [Fact(Timeout = 20000)]
+    public async Task parallel_host_start_should_not_deadlock()
     {
         // Per-runner bounded timeouts
         var startTimeout   = TimeSpan.FromSeconds(7); // pre-fix should trip this quickly
         var expectTimeout  = TimeSpan.FromSeconds(5);
         var stopTimeout    = TimeSpan.FromSeconds(5);
+        var concurrentHosts = Environment.ProcessorCount * 2;
 
         // Spin up N independent hosts concurrently inside the same theory
         var runners = Enumerable.Range(0, concurrentHosts)

--- a/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
@@ -1,0 +1,113 @@
+﻿using Akka.TestKit;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Actor;
+using Hosting;
+using Akka.Hosting.TestKit;
+using Xunit;
+
+file sealed class StartupPinger(IRequiredActor<TestProbe> testActorReq) : ReceiveActor
+{
+    protected override void PreStart()
+    {
+        var testActor = testActorReq.GetAsync().GetAwaiter().GetResult();
+        testActor.Tell("startup-ping");
+    }
+}
+
+file sealed class HostedTestKitRunner : TestKit, IAsyncLifetime  // TestKit already implements IAsyncLifetime, but we expose it here for clarity
+{
+    public HostedTestKitRunner(ITestOutputHelper output) 
+        : base($"{Guid.NewGuid():N}", startupTimeout: TimeSpan.FromSeconds(20), output: output, logLevel: LogLevel.Error)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithActors((system, _, resolver) =>
+        {
+            system.ActorOf(resolver.Props<StartupPinger>(), "pinger");
+        });
+    }
+
+    // Optional convenience wrappers so the test code reads cleanly
+    public Task StartAsync() => InitializeAsync();
+    public Task StopAsync()  => DisposeAsync();
+
+    public Task ExpectStartupAsync(TimeSpan? timeout = null)
+        => ExpectMsgAsync("startup-ping", timeout ?? TimeSpan.FromSeconds(5)).AsTask();
+}
+
+public class TestActorStartupDeadlockSpec
+{
+    private readonly ITestOutputHelper _output;
+
+    public TestActorStartupDeadlockSpec(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+    
+    // Give the overall test plenty of time; we enforce our own short, per-step timeouts below.
+    [Theory(Timeout = 20000)]
+    [InlineData(20)]
+    [InlineData(40)]
+    public async Task parallel_host_start_should_not_deadlock(int concurrentHosts)
+    {
+        // Per-runner bounded timeouts
+        var startTimeout   = TimeSpan.FromSeconds(7); // pre-fix should trip this quickly
+        var expectTimeout  = TimeSpan.FromSeconds(5);
+        var stopTimeout    = TimeSpan.FromSeconds(5);
+
+        // Spin up N independent hosts concurrently inside the same theory
+        var runners = Enumerable.Range(0, concurrentHosts)
+                                .Select(_ => Task.Run(RunOneAsync))
+                                .ToArray();
+
+        await Task.WhenAll(runners);
+        return;
+
+        async Task RunOneAsync()
+        {
+            var kit = new HostedTestKitRunner(_output);
+
+            // --- START (bounded) ---
+            var startTask = kit.StartAsync();
+            var startDone = await Task.WhenAny(startTask, Task.Delay(startTimeout)).ConfigureAwait(false);
+            if (startDone != startTask)
+            {
+                // Fail fast with a clear message rather than timing out the entire test method
+                Assert.Fail(
+                    $"Host did not start within {startTimeout}. " +
+                    "This indicates the known startup deadlock (TestKit initialized inline on the startup thread).");
+            }
+            // propagate any exception from StartAsync (e.g., watchdog TimeoutException)
+            await startTask.ConfigureAwait(false);
+
+            try
+            {
+                // --- EXPECT (bounded) ---
+                var expectTask = kit.ExpectStartupAsync(expectTimeout);
+                var expectDone = await Task.WhenAny(expectTask, Task.Delay(expectTimeout)).ConfigureAwait(false);
+                if (expectDone != expectTask)
+                    Assert.Fail($"Did not receive startup ping within {expectTimeout}.");
+
+                await expectTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                // --- STOP (bounded) ---
+                var stopTask = kit.StopAsync();
+                var stopDone = await Task.WhenAny(stopTask, Task.Delay(stopTimeout)).ConfigureAwait(false);
+                if (stopDone == stopTask)
+                    await stopTask.ConfigureAwait(false);
+                // else: swallow to avoid hanging the test process on shutdown in pre-fix scenarios
+            }
+        }
+    }
+}


### PR DESCRIPTION
Explanation by ChatGPT:

### TL;DR

`Akka.Hosting.TestKit` currently calls **`TestKitBase.InitializeTest` inside a `WithActors` startup callback**.
`InitializeTest` creates the **TestActor on the CallingThreadDispatcher** (or otherwise thread-affine behavior), _while the host startup thread is waiting for that callback to return_. In parallel, your actor wiring (also running in `WithActors`) constructs actors that (directly or indirectly) **send to the TestActor / EventStream** during their `PreStart`/DI initialization.

Because the TestActor is bound to the “calling thread” (the startup thread) and that thread is **blocked until the callback returns**, any message that needs the TestActor to run won’t be processed → circular wait → **deadlock**. Turning timeouts up doesn’t help because nothing is running.

This shows up only under **parallel** test execution because you get **concurrent hosts** doing the above at the same time, increasing the chance that one host’s startup thread is the same thread that a second host needs to run a TestActor turn on.

---

### Why this happens (step-by-step)

1. **Host starts → ActorSystem created.**
   `Akka.Hosting` executes all `WithActors((system, registry) => …)` callbacks **synchronously** as part of startup.

2. **Hosting.TestKit’s callback** runs and calls `TestKitBase.InitializeTest(system, …)` inside that same callback.

3. `InitializeTest` creates **TestActor** (and wires event stream subscriptions). In classic TestKit this actor is usually constructed so that it behaves **calling-thread-synchronously** (CallingThreadDispatcher semantics) to make `Expect…` deterministic.

4. Your actor wiring (same `WithActors` batch) constructs application actors. During `PreStart` / registry setup they:
   * log (event stream),
   * Watch/unwatch,
   * or (some test infra) send to the TestActor.

5. Those sends require the TestActor to **run on the startup thread** (calling-thread semantics), but that thread is **blocked** waiting for the `WithActors` callback(s) to finish.
   → **Circular wait**: startup thread can’t return because work wants to run on it; the work can’t run because the thread is blocked.

Parallel execution amplifies this because multiple hosts share the same thread pool; chances of the above interleaving go way up.

> You don’t need Akka.Remote for this to happen; it’s entirely local and dispatcher/thread-affinity driven.

## Changes

* Add reproduction/regression test