### PR TITLE
ensure TestActor is created on main test thread context

### DIFF
--- a/src/Akka.Hosting.TestKit.Tests/DiPropsFailTest.cs
+++ b/src/Akka.Hosting.TestKit.Tests/DiPropsFailTest.cs
@@ -7,6 +7,7 @@
 using System;
 using Akka.Actor;
 using Akka.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,20 +20,26 @@ public class DiPropsFailTest: TestKit
     public DiPropsFailTest(ITestOutputHelper output) : base(nameof(DiPropsFailTest), output)
     {}
     
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.AddLogging();
+    }
+    
     protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
     { }
 
     [Fact]
     public void DiTest()
     {
-        var actor = Sys.ActorOf(NonRootActorWithDi.Props());
+        var actor = Sys.ActorOf(NonRootActorWithDi.Props(Sys));
         actor.Tell("test");
         ExpectMsg<string>("test");
     }
     
     private class NonRootActorWithDi: ReceiveActor
     {
-        public static Props Props() => DependencyResolver.For(Context.System).Props<NonRootActorWithDi>();
+        public static Props Props(ActorSystem system) => DependencyResolver.For(system).Props<NonRootActorWithDi>();
         
         public NonRootActorWithDi(ILogger<NonRootActorWithDi> log)
         {

--- a/src/Akka.Hosting.TestKit.Tests/DiPropsFailTest.cs
+++ b/src/Akka.Hosting.TestKit.Tests/DiPropsFailTest.cs
@@ -8,6 +8,7 @@ using System;
 using Akka.Actor;
 using Akka.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,9 +21,9 @@ public class DiPropsFailTest: TestKit
     public DiPropsFailTest(ITestOutputHelper output) : base(nameof(DiPropsFailTest), output)
     {}
     
-    protected override void ConfigureServices(IServiceCollection services)
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
     {
-        base.ConfigureServices(services);
+        base.ConfigureServices(context, services);
         services.AddLogging();
     }
     

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -115,7 +115,8 @@ namespace Akka.Hosting.TestKit
         {
             var extSystem = (ExtendedActorSystem)system;
             var logger = extSystem.SystemActorOf(Props.Create(() => new TestKitLoggerFactoryLogger()), "log-test");
-            await logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream));
+            // Add timeout to prevent deadlock when multiple tests run in parallel
+            await logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream), TimeSpan.FromSeconds(5));
         }
 
         protected virtual Config? Config { get; } = null;
@@ -161,7 +162,35 @@ namespace Akka.Hosting.TestKit
             
             var system = _host.Services.GetRequiredService<ActorSystem>();
             var registry = _host.Services.GetRequiredService<ActorRegistry>();
-            base.InitializeTest(system, (ActorSystemSetup)null!, null, null);
+            
+            // Initialize TestActor on the current synchronization context to preserve
+            // the implicit sender thread context (fixes #458)
+            // We need to capture the current synchronization context before any await
+            var currentContext = SynchronizationContext.Current;
+            if (currentContext != null)
+            {
+                // Post the initialization to the current context to ensure it runs on the correct thread
+                var tcs = new TaskCompletionSource<bool>();
+                currentContext.Post(_ =>
+                {
+                    try
+                    {
+                        base.InitializeTest(system, (ActorSystemSetup)null!, null, null);
+                        tcs.SetResult(true);
+                    }
+                    catch (Exception ex)
+                    {
+                        tcs.SetException(ex);
+                    }
+                }, null);
+                await tcs.Task;
+            }
+            else
+            {
+                // No synchronization context, run directly
+                base.InitializeTest(system, (ActorSystemSetup)null!, null, null);
+            }
+            
             registry.Register<TestProbe>(TestActor);
             
             if (this is not INoImplicitSender && InternalCurrentActorCellKeeper.Current is null)

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -102,19 +102,6 @@ namespace Akka.Hosting.TestKit
                     });
                 }
 
-                builder.StartActors((system, registry) =>
-                {
-                    try
-                    {
-                        base.InitializeTest(system, (ActorSystemSetup)null!, null, null);
-                        registry.Register<TestProbe>(TestActor);
-                    }
-                    catch (Exception e)
-                    {
-                        _initialized.SetException(e);
-                    }
-                });
-
                 ConfigureAkka(builder, provider);
 
                 builder.AddStartup((_, _) =>
@@ -171,6 +158,11 @@ namespace Akka.Hosting.TestKit
             }
 
             await _initialized.Task;
+            
+            var system = _host.Services.GetRequiredService<ActorSystem>();
+            var registry = _host.Services.GetRequiredService<ActorRegistry>();
+            base.InitializeTest(system, (ActorSystemSetup)null!, null, null);
+            registry.Register<TestProbe>(TestActor);
             
             if (this is not INoImplicitSender && InternalCurrentActorCellKeeper.Current is null)
                 InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;


### PR DESCRIPTION
## Changes

fix #458 - this should ensure that the `TestActor` is present on the main implicit thread context the same way that it is in the normal `TestKit`s.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #458
