### PR TITLE
Remove FluentAssertions from Akka.Cluster.Hosting.Tests

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -5,7 +5,6 @@
 
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />

--- a/src/Akka.Cluster.Hosting.Tests/ClusterClientDiscoverySpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterClientDiscoverySpecs.cs
@@ -10,11 +10,8 @@ using Akka.Cluster.Tools.Client;
 using Akka.Configuration;
 using Akka.Discovery;
 using Akka.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Cluster.Hosting.Tests;
 
@@ -36,16 +33,16 @@ public class ClusterClientDiscoverySpecs
         var config = ConfigurationFactory.ParseString(options.ToString())
             .WithFallback(systemConfig.GetConfig("akka.cluster.client"));
 
-        config.GetBoolean("use-initial-contacts-discovery").Should().BeTrue();
-        config.GetString("discovery.method").Should().Be(ConfigServiceDiscoveryOptions.DefaultPath);
-        config.GetString("discovery.service-name").Should().Be("whatever");
+        Assert.True(config.GetBoolean("use-initial-contacts-discovery"));
+        Assert.Equal(ConfigServiceDiscoveryOptions.DefaultPath, config.GetString("discovery.method"));
+        Assert.Equal("whatever", config.GetString("discovery.service-name"));
         
         defaultConfig.AssertSameString(config, "discovery.port-name");
         defaultConfig.AssertSameInt(config, "discovery.number-of-contacts");
         defaultConfig.AssertSameTimeSpan(config, "discovery.interval");
         defaultConfig.AssertSameTimeSpan(config, "discovery.resolve-timeout");
 
-        systemConfig.GetString("akka.discovery.method").Should().Be("config");
+        Assert.Equal("config", systemConfig.GetString("akka.discovery.method"));
     }
     
     [Fact(DisplayName = "ClusterClientDiscoverySettings should be set correctly")]
@@ -81,78 +78,72 @@ public class ClusterClientDiscoverySpecs
             .WithFallback(systemConfig.GetConfig("akka.cluster.client"));
         var settings = ClusterClientSettings.Create(config);
 
-        config.GetString("discovery.method").Should().Be("custom");
-        config.GetBoolean("use-initial-contacts-discovery").Should().BeTrue();
-        settings.InitialContacts.Should().BeEmpty();
-        settings.DiscoverySettings.ServiceName.Should().Be("testService");
-        settings.DiscoverySettings.PortName.Should().Be("testPort");
-        settings.DiscoverySettings.ResolveTimeout.Should().Be(1.Seconds());
-        settings.DiscoverySettings.Interval.Should().Be(2.Seconds());
-        settings.DiscoverySettings.NumberOfContacts.Should().Be(10);
+        Assert.Equal("custom", config.GetString("discovery.method"));
+        Assert.True(config.GetBoolean("use-initial-contacts-discovery"));
+        Assert.Empty(settings.InitialContacts);
+        Assert.Equal("testService", settings.DiscoverySettings.ServiceName);
+        Assert.Equal("testPort", settings.DiscoverySettings.PortName);
+        Assert.Equal(1.Seconds(), settings.DiscoverySettings.ResolveTimeout);
+        Assert.Equal(2.Seconds(), settings.DiscoverySettings.Interval);
+        Assert.Equal(10, settings.DiscoverySettings.NumberOfContacts);
 
-        systemConfig.GetString("akka.discovery.method").Should().Be("<method>");
+        Assert.Equal("<method>", systemConfig.GetString("akka.discovery.method"));
         
         var discoveryConfig = systemConfig.GetConfig("akka.discovery.custom");
-        discoveryConfig.Should().NotBeNull();
-        discoveryConfig.GetString("services-path").Should().Be("akka.discovery.custom.services");
-        discoveryConfig.GetConfig("services").Should().NotBeNull();
+        Assert.NotNull(discoveryConfig);
+        Assert.Equal("akka.discovery.custom.services", discoveryConfig.GetString("services-path"));
+        Assert.NotNull(discoveryConfig.GetConfig("services"));
     }
 
     [Fact(DisplayName = "ClusterClientDiscoverySettings with invalid values should throw")]
     public void ClusterClientDiscoveryInvalidSettingsSpec()
     {
-        Invoking(() => new ClusterClientDiscoveryOptions
-            {
-                DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
-                ServiceName = null!
-            }.ToString())
-            .Should().ThrowExactly<ArgumentException>()
-            .WithMessage("Service name must be provided*");
+        var ex = Assert.Throws<ArgumentException>(() => new ClusterClientDiscoveryOptions
+        {
+            DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
+            ServiceName = null!
+        }.ToString());
+        Assert.StartsWith("Service name must be provided", ex.Message);
+
+
+        ex = Assert.Throws<ArgumentException>(() => new ClusterClientDiscoveryOptions
+        {
+            DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
+            ServiceName = string.Empty
+        }.ToString());
+        Assert.StartsWith("Service name must be provided", ex.Message);
+
+        ex = Assert.Throws<ArgumentException>(() => new ClusterClientDiscoveryOptions
+        {
+            DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
+            ServiceName = "whatever",
+            Timeout = Timeout.InfiniteTimeSpan
+        }.ToString());
+        Assert.StartsWith("Timeout must be greater than zero", ex.Message);
+
+        ex = Assert.Throws<ArgumentException>(() => new ClusterClientDiscoveryOptions
+        {
+            DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
+            ServiceName = "whatever",
+            NumberOfContacts = 0
+        }.ToString());
+        Assert.StartsWith("Number of contacts must be greater than zero", ex.Message);
         
-        Invoking(() => new ClusterClientDiscoveryOptions
-            {
-                DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
-                ServiceName = string.Empty
-            }.ToString())
-            .Should().ThrowExactly<ArgumentException>()
-            .WithMessage("Service name must be provided*");
-        
-        Invoking(() => new ClusterClientDiscoveryOptions
-            {
-                DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
-                ServiceName = "whatever",
-                Timeout = Timeout.InfiniteTimeSpan
-            }.ToString())
-            .Should().ThrowExactly<ArgumentException>()
-            .WithMessage("Timeout must be greater than zero*");
-        
-        Invoking(() => new ClusterClientDiscoveryOptions
-            {
-                DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
-                ServiceName = "whatever",
-                NumberOfContacts = 0
-            }.ToString())
-            .Should().ThrowExactly<ArgumentException>()
-            .WithMessage("Number of contacts must be greater than zero*");
-        
-        Invoking(() => new ClusterClientDiscoveryOptions
-            {
-                DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
-                ServiceName = "whatever",
-                ClientActorName = string.Empty
-            }.ToString())
-            .Should().ThrowExactly<ArgumentException>()
-            .WithMessage("Cluster client actor name must not be empty or whitespace*");
-        
-        Invoking(() => new ClusterClientDiscoveryOptions
-            {
-                DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
-                ServiceName = "whatever",
-                ClientActorName = " "
-            }.ToString())
-            .Should().ThrowExactly<ArgumentException>()
-            .WithMessage("Cluster client actor name must not be empty or whitespace*");
-        
+        ex = Assert.Throws<ArgumentException>(() => new ClusterClientDiscoveryOptions
+        {
+            DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
+            ServiceName = "whatever",
+            ClientActorName = string.Empty
+        }.ToString());
+        Assert.StartsWith("Cluster client actor name must not be empty or whitespace", ex.Message);
+
+        ex = Assert.Throws<ArgumentException>(() => new ClusterClientDiscoveryOptions
+        {
+            DiscoveryOptions = new ConfigServiceDiscoveryOptions(),
+            ServiceName = "whatever",
+            ClientActorName = " "
+        }.ToString());
+        Assert.StartsWith("Cluster client actor name must not be empty or whitespace", ex.Message);
     }
     
     private class ConfigServiceDiscoveryOptions: IDiscoveryOptions

--- a/src/Akka.Cluster.Hosting.Tests/ClusterClientSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterClientSpecs.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Cluster.Tools.Client;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Cluster.Hosting.Tests;
@@ -16,8 +14,8 @@ public class ClusterClientSpecs
             .GetConfig("akka.cluster.client.receptionist");
         var settings = ClusterReceptionistSettings.Create(config);
 
-        config.GetString("name").Should().Be("customName");
-        settings.Role.Should().Be("customRole");
+        Assert.Equal("customName", config.GetString("name"));
+        Assert.Equal("customRole", settings.Role);
     }
 
     [Fact(DisplayName = "ClusterClientSettings should be set correctly")]
@@ -34,6 +32,6 @@ public class ClusterClientSpecs
             ClusterClientReceptionist.DefaultConfig(),
             contacts);
 
-        settings.InitialContacts.Should().BeEquivalentTo(contacts);
+        Assert.Equal(contacts, settings.InitialContacts);
     }
 }

--- a/src/Akka.Cluster.Hosting.Tests/ClusterClientSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterClientSpecs.cs
@@ -32,6 +32,6 @@ public class ClusterClientSpecs
             ClusterClientReceptionist.DefaultConfig(),
             contacts);
 
-        Assert.Equal(contacts, settings.InitialContacts);
+        contacts.CollectionEquals(settings.InitialContacts);
     }
 }

--- a/src/Akka.Cluster.Hosting.Tests/ClusterOptionsSpec.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterOptionsSpec.cs
@@ -83,7 +83,7 @@ public class ClusterOptionsSpec
         Assert.True(builder.Configuration.HasValue);
         var settings = new ClusterSettings(builder.Configuration.Value, "");
 
-        Assert.Equal(new[] { "front-end", "back-end" }, settings.Roles);
+        new[] { "front-end", "back-end" }.CollectionEquals(settings.Roles);
         
         Assert.Single(settings.MinNrOfMembersOfRole);
         Assert.True(settings.MinNrOfMembersOfRole.ContainsKey("back-end"));
@@ -154,7 +154,7 @@ public class ClusterOptionsSpec
         Assert.True(builder.Configuration.HasValue);
         var settings = new ClusterSettings(builder.Configuration.Value, "");
 
-        Assert.Equal(new[] { "front-end", "back-end" }, settings.Roles);
+        new[] { "front-end", "back-end" }.CollectionEquals(settings.Roles);
         
         Assert.Single(settings.MinNrOfMembersOfRole);
         Assert.True(settings.MinNrOfMembersOfRole.ContainsKey("back-end"));

--- a/src/Akka.Cluster.Hosting.Tests/ClusterOptionsSpec.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterOptionsSpec.cs
@@ -14,8 +14,6 @@ using Akka.Cluster.SBR;
 using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,19 +31,20 @@ public class ClusterOptionsSpec
             .WithActorRefProvider(ProviderSelection.Cluster.Instance)
             .BuildClusterHocon(new ClusterOptions());
         
-        builder.Configuration.HasValue.Should().BeTrue();
+        Assert.True(builder.Configuration.HasValue);
+
         var settings = new ClusterSettings(builder.Configuration.Value, "");
 
-        settings.Roles.Count.Should().Be(0);
-        settings.AppVersion.CompareTo(Util.AppVersion.Create("assembly-version")).Should().Be(0);
-        settings.MinNrOfMembersOfRole.Count.Should().Be(0);
-        settings.SeedNodes.Count.Should().Be(0);
-        settings.MinNrOfMembers.Should().Be(1);
-        settings.LogInfo.Should().BeTrue();
-        settings.LogInfoVerbose.Should().BeFalse();
-        settings.DowningProviderType.Should().Be(typeof(SplitBrainResolverProvider));
-        settings.HeartbeatInterval.Should().Be(1.Seconds());
-        settings.HeartbeatExpectedResponseAfter.Should().Be(1.Seconds());
+        Assert.Empty(settings.Roles);
+        Assert.Equal(0, settings.AppVersion.CompareTo(Util.AppVersion.Create("assembly-version")));
+        Assert.Empty(settings.MinNrOfMembersOfRole);
+        Assert.Empty(settings.SeedNodes);
+        Assert.Equal(1, settings.MinNrOfMembers);
+        Assert.True(settings.LogInfo);
+        Assert.False(settings.LogInfoVerbose);
+        Assert.Equal(typeof(SplitBrainResolverProvider), settings.DowningProviderType);
+        Assert.Equal(1.Seconds(), settings.HeartbeatInterval);
+        Assert.Equal(1.Seconds(), settings.HeartbeatExpectedResponseAfter);
     }
     
     [Fact(DisplayName = "ClusterOptions should generate proper HOCON values")]
@@ -81,34 +80,34 @@ public class ClusterOptionsSpec
                 }
             });
         
-        builder.Configuration.HasValue.Should().BeTrue();
+        Assert.True(builder.Configuration.HasValue);
         var settings = new ClusterSettings(builder.Configuration.Value, "");
 
-        settings.Roles.Should().BeEquivalentTo("front-end", "back-end");
+        Assert.Equal(new[] { "front-end", "back-end" }, settings.Roles);
         
-        settings.MinNrOfMembersOfRole.Count.Should().Be(1);
-        settings.MinNrOfMembersOfRole.ContainsKey("back-end").Should().BeTrue();
-        settings.MinNrOfMembersOfRole["back-end"].Should().Be(5);
+        Assert.Single(settings.MinNrOfMembersOfRole);
+        Assert.True(settings.MinNrOfMembersOfRole.ContainsKey("back-end"));
+        Assert.Equal(5, settings.MinNrOfMembersOfRole["back-end"]);
         
-        settings.AppVersion.CompareTo(Util.AppVersion.Create("1.0.0")).Should().Be(0);
-        settings.SeedNodes.Should().BeEquivalentTo(new [] { Address.Parse("akka.tcp://system@somewhere.com:9999" )});
-        settings.MinNrOfMembers.Should().Be(99);
-        settings.LogInfo.Should().BeTrue(); // This is not intuitive, but LogInfo is defined as LogInfoVerbose || LogInfo in ClusterSettings
-        settings.LogInfoVerbose.Should().BeTrue();
-        settings.DowningProviderType.Should().Be(typeof(SplitBrainResolverProvider));
+        Assert.Equal(0, settings.AppVersion.CompareTo(Util.AppVersion.Create("1.0.0")));
+        Assert.Equal(new[] { Address.Parse("akka.tcp://system@somewhere.com:9999") }, settings.SeedNodes);
+        Assert.Equal(99, settings.MinNrOfMembers);
+        Assert.True(settings.LogInfo); // This is not intuitive, but LogInfo is defined as LogInfoVerbose || LogInfo in ClusterSettings
+        Assert.True(settings.LogInfoVerbose);
+        Assert.Equal(typeof(SplitBrainResolverProvider), settings.DowningProviderType);
 
         var sbrConfig = builder.Configuration.Value.GetConfig("akka.cluster.split-brain-resolver");
-        sbrConfig.GetString("active-strategy").Should().Be(SplitBrainResolverSettings.KeepMajorityName);
-        sbrConfig.GetString($"{SplitBrainResolverSettings.KeepMajorityName}.role").Should().Be("back-end");
+        Assert.Equal(SplitBrainResolverSettings.KeepMajorityName, sbrConfig.GetString("active-strategy"));
+        Assert.Equal("back-end", sbrConfig.GetString($"{SplitBrainResolverSettings.KeepMajorityName}.role"));
 
         var detectorConfig = builder.Configuration.Value.GetConfig("akka.cluster.failure-detector");
-        detectorConfig.GetTimeSpan("heartbeat-interval").Should().Be(1.1.Seconds());
-        detectorConfig.GetTimeSpan("acceptable-heartbeat-pause").Should().Be(1.1.Seconds());
-        detectorConfig.GetDouble("threshold").Should().Be(1.1);
-        detectorConfig.GetInt("max-sample-size").Should().Be(1);
-        detectorConfig.GetTimeSpan("min-std-deviation").Should().Be(1.1.Seconds());
-        detectorConfig.GetTimeSpan("unreachable-nodes-reaper-interval").Should().Be(1.1.Seconds());
-        detectorConfig.GetTimeSpan("expected-response-after").Should().Be(1.1.Seconds());
+        Assert.Equal(1.1.Seconds(), detectorConfig.GetTimeSpan("heartbeat-interval"));
+        Assert.Equal(1.1.Seconds(), detectorConfig.GetTimeSpan("acceptable-heartbeat-pause"));
+        Assert.Equal(1.1, detectorConfig.GetDouble("threshold"));
+        Assert.Equal(1, detectorConfig.GetInt("max-sample-size"));
+        Assert.Equal(1.1.Seconds(), detectorConfig.GetTimeSpan("min-std-deviation"));
+        Assert.Equal(1.1.Seconds(), detectorConfig.GetTimeSpan("unreachable-nodes-reaper-interval"));
+        Assert.Equal(1.1.Seconds(), detectorConfig.GetTimeSpan("expected-response-after"));
     }
 
     [Fact(DisplayName = "ClusterOptions should be bindable using Microsoft.Extensions.Configuration")]
@@ -152,24 +151,24 @@ public class ClusterOptionsSpec
             .AddHocon(ConfigurationFactory.FromResource("Akka.Cluster.Configuration.Cluster.conf", typeof(Cluster).Assembly), HoconAddMode.Append)
             .BuildClusterHocon(clusterOptions);
         
-        builder.Configuration.HasValue.Should().BeTrue();
+        Assert.True(builder.Configuration.HasValue);
         var settings = new ClusterSettings(builder.Configuration.Value, "");
 
-        settings.Roles.Should().BeEquivalentTo("front-end", "back-end");
+        Assert.Equal(new[] { "front-end", "back-end" }, settings.Roles);
         
-        settings.MinNrOfMembersOfRole.Count.Should().Be(1);
-        settings.MinNrOfMembersOfRole.ContainsKey("back-end").Should().BeTrue();
-        settings.MinNrOfMembersOfRole["back-end"].Should().Be(5);
+        Assert.Single(settings.MinNrOfMembersOfRole);
+        Assert.True(settings.MinNrOfMembersOfRole.ContainsKey("back-end"));
+        Assert.Equal(5, settings.MinNrOfMembersOfRole["back-end"]);
         
-        settings.AppVersion.CompareTo(Util.AppVersion.Create("1.0.0")).Should().Be(0);
-        settings.SeedNodes.Should().BeEquivalentTo(new [] { Address.Parse("akka.tcp://system@somewhere.com:9999" )});
-        settings.MinNrOfMembers.Should().Be(99);
-        settings.LogInfo.Should().BeTrue(); // This is not intuitive, but LogInfo is defined as LogInfoVerbose || LogInfo in ClusterSettings
-        settings.LogInfoVerbose.Should().BeTrue();
-        settings.DowningProviderType.Should().Be(typeof(SplitBrainResolverProvider));
+        Assert.Equal(0, settings.AppVersion.CompareTo(Util.AppVersion.Create("1.0.0")));
+        Assert.Equal(new[] { Address.Parse("akka.tcp://system@somewhere.com:9999") }, settings.SeedNodes);
+        Assert.Equal(99, settings.MinNrOfMembers);
+        Assert.True(settings.LogInfo); // This is not intuitive, but LogInfo is defined as LogInfoVerbose || LogInfo in ClusterSettings
+        Assert.True(settings.LogInfoVerbose);
+        Assert.Equal(typeof(SplitBrainResolverProvider), settings.DowningProviderType);
 
         var sbrConfig = builder.Configuration.Value.GetConfig("akka.cluster.split-brain-resolver");
-        sbrConfig.GetString("active-strategy").Should().Be(SplitBrainResolverSettings.KeepMajorityName);
-        sbrConfig.GetString($"{SplitBrainResolverSettings.KeepMajorityName}.role").Should().Be("back-end");
+        Assert.Equal(SplitBrainResolverSettings.KeepMajorityName, sbrConfig.GetString("active-strategy"));
+        Assert.Equal("back-end", sbrConfig.GetString($"{SplitBrainResolverSettings.KeepMajorityName}.role"));
     }
 }

--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -5,7 +5,6 @@ using Akka.Actor;
 using Akka.DistributedData;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,7 +35,7 @@ public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
         var cluster = Cluster.Get(Sys);
         await cluster.JoinAsync(cluster.SelfAddress);
         await AwaitAssertAsync(() => 
-                cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1),
+                Assert.Equal(1, cluster.State.Members.Count(m => m.Status == MemberStatus.Up)),
             interval: TimeSpan.FromMilliseconds(200),
             duration: TimeSpan.FromSeconds(10));
         
@@ -54,7 +53,7 @@ public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
             // * This actor is created inside DistributedData extension .ctor
             // * Marks that the extension is running
             // * We can't use DistributedData.Get() because that defeats the purpose.
-            identity.Subject.Should().NotBeNull();
+            Assert.NotNull(identity.Subject);
         });
     }
 }

--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Cluster.Hosting.SBR;
 using Akka.Cluster.Hosting.Tests.Lease;
 using Akka.Cluster.Sharding;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -112,8 +108,8 @@ public class ClusterShardingSpecs
             await shardRegion.Ask<IActorRef>(new MyEntityActor.GetSourceRef("foo"), TimeSpan.FromSeconds(3));
 
         // assert
-        id.Should().Be("foo");
-        sourceRef.Should().Be(actorRegistry.Get<MyTopLevelActor>());
+        Assert.Equal("foo", id);
+        Assert.Equal(actorRegistry.Get<MyTopLevelActor>(), sourceRef);
     }
 
     [Fact(DisplayName = "ShardOptions with different values should generate valid ClusterShardSettings")]
@@ -132,16 +128,18 @@ public class ClusterShardingSpecs
             LeaseRetryInterval = 2.Seconds(),
             ShardRegionQueryTimeout = 3.Seconds(),
         });
-        settings1.RememberEntities.Should().BeTrue();
-        settings1.StateStoreMode.Should().Be(StateStoreMode.Persistence);
-        settings1.RememberEntitiesStore.Should().Be(RememberEntitiesStore.Eventsourced);
-        settings1.Role.Should().Be("first");
-        settings1.PassivateIdleEntityAfter.Should().Be(1.Seconds());
-        settings1.SnapshotPluginId.Should().Be("firstSnapshot");
-        settings1.JournalPluginId.Should().Be("firstJournal");
-        settings1.LeaseSettings.LeaseImplementation.Should().Be("test-lease");
-        settings1.LeaseSettings.LeaseRetryInterval.Should().Be(2.Seconds());
-        settings1.ShardRegionQueryTimeout.Should().Be(3.Seconds());
+
+        Assert.True(settings1.RememberEntities);
+        Assert.Equal(StateStoreMode.Persistence, settings1.StateStoreMode);
+        Assert.Equal(RememberEntitiesStore.Eventsourced, settings1.RememberEntitiesStore);
+        Assert.Equal("first", settings1.Role);
+        Assert.Equal(1.Seconds(), settings1.PassivateIdleEntityAfter);
+        Assert.Equal("firstSnapshot", settings1.SnapshotPluginId);
+        Assert.Equal("firstJournal", settings1.JournalPluginId);
+        Assert.NotNull(settings1.LeaseSettings);
+        Assert.Equal("test-lease", settings1.LeaseSettings!.LeaseImplementation);
+        Assert.Equal(2.Seconds(), settings1.LeaseSettings.LeaseRetryInterval);
+        Assert.Equal(3.Seconds(), settings1.ShardRegionQueryTimeout);
         
         var settings2 = ToSettings(new ShardOptions
         {
@@ -154,15 +152,16 @@ public class ClusterShardingSpecs
             JournalPluginId = "secondJournal", 
             ShardRegionQueryTimeout = 5.Seconds(),
         });
-        settings2.RememberEntities.Should().BeFalse();
-        settings2.StateStoreMode.Should().Be(StateStoreMode.DData);
-        settings2.RememberEntitiesStore.Should().Be(RememberEntitiesStore.DData);
-        settings2.Role.Should().Be("second");
-        settings2.PassivateIdleEntityAfter.Should().Be(4.Seconds());
-        settings2.JournalPluginId.Should().Be("secondJournal");
-        settings2.SnapshotPluginId.Should().Be("secondSnapshot");
-        settings2.LeaseSettings.Should().BeNull();
-        settings2.ShardRegionQueryTimeout.Should().Be(5.Seconds());
+
+        Assert.False(settings2.RememberEntities);
+        Assert.Equal(StateStoreMode.DData, settings2.StateStoreMode);
+        Assert.Equal(RememberEntitiesStore.DData, settings2.RememberEntitiesStore);
+        Assert.Equal("second", settings2.Role);
+        Assert.Equal(4.Seconds(), settings2.PassivateIdleEntityAfter);
+        Assert.Equal("secondJournal", settings2.JournalPluginId);
+        Assert.Equal("secondSnapshot", settings2.SnapshotPluginId);
+        Assert.Null(settings2.LeaseSettings);
+        Assert.Equal(5.Seconds(), settings2.ShardRegionQueryTimeout);
     }
 
     private static ClusterShardingSettings ToSettings(ShardOptions shardOptions)

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
@@ -2,12 +2,9 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Cluster.Hosting.Tests;
 
@@ -47,7 +44,7 @@ public class ClusterSingletonSpecs
         var respond = await singletonProxy.Ask<string>("hit", TimeSpan.FromSeconds(3));
 
         // assert
-        respond.Should().Be("hit");
+        Assert.Equal("hit", respond);
 
         await host.StopAsync();
     }
@@ -77,7 +74,7 @@ public class ClusterSingletonSpecs
 
         await AssertSingletonSelectionAsync(singletonSelector);
 
-        singletonProxy.Path.ToString().Should().Be("akka://TestSys/user/my-singleton-proxy");
+        Assert.Equal("akka://TestSys/user/my-singleton-proxy", singletonProxy.Path.ToString());
 
         await host.StopAsync();
     }
@@ -86,7 +83,10 @@ public class ClusterSingletonSpecs
     {
         var startTime = DateTime.UtcNow;
         var timeout = TimeSpan.FromSeconds(3);
-        await Awaiting(async () =>
+        await Test();
+        return;
+
+        async Task Test()
         {
             // might take multiple tries to resolve the singleton if it hasn't been created yet
             while (DateTime.UtcNow - startTime < timeout)
@@ -94,7 +94,7 @@ public class ClusterSingletonSpecs
                 try
                 {
                     var identify = await singletonSelector.ResolveOne(100.Milliseconds());
-                    identify.Should().NotBe(ActorRefs.Nobody);
+                    Assert.NotEqual(ActorRefs.Nobody, identify);
                     return;
                 }
                 catch (Exception)
@@ -104,7 +104,7 @@ public class ClusterSingletonSpecs
             }
             
             throw new AskTimeoutException("Failed to resolve singleton within timeout");
-        }).Should().NotThrowAsync();
+        }
     }
 
     [Fact(DisplayName = "Should launch singleton manager and proxy at the appropriate path (no manager name, actor factory)")]
@@ -132,7 +132,7 @@ public class ClusterSingletonSpecs
 
         await AssertSingletonSelectionAsync(singletonSelector);
 
-        singletonProxy.Path.ToString().Should().Be("akka://TestSys/user/my-singleton-proxy");
+        Assert.Equal("akka://TestSys/user/my-singleton-proxy", singletonProxy.Path.ToString());
 
         await host.StopAsync();
     }
@@ -163,7 +163,7 @@ public class ClusterSingletonSpecs
 
         await AssertSingletonSelectionAsync(singletonSelector);
 
-        singletonProxy.Path.ToString().Should().Be("akka://TestSys/user/singleton-proxy");
+        Assert.Equal("akka://TestSys/user/singleton-proxy", singletonProxy.Path.ToString());
 
         await host.StopAsync();
     }
@@ -194,7 +194,7 @@ public class ClusterSingletonSpecs
 
         await AssertSingletonSelectionAsync(singletonSelector);
 
-        singletonProxy.Path.ToString().Should().Be("akka://TestSys/user/singleton-proxy");
+        Assert.Equal("akka://TestSys/user/singleton-proxy", singletonProxy.Path.ToString());
 
         await host.StopAsync();
     }
@@ -225,7 +225,7 @@ public class ClusterSingletonSpecs
         var respond = await singletonProxy.Ask<string>("hit", TimeSpan.FromSeconds(3));
 
         // assert
-        respond.Should().Be("hit");
+        Assert.Equal("hit", respond);
 
         await Task.WhenAll(singletonHost.StopAsync(), singletonProxyHost.StopAsync());
     }
@@ -277,7 +277,7 @@ public class ClusterSingletonSpecs
         var respond = await singletonProxy.Ask<string>("hit", 3.Seconds());
 
         // assert
-        respond.Should().Be("hit");
+        Assert.Equal("hit", respond);
 
         await Task.WhenAll(singletonHost.StopAsync(), singletonProxyHost.StopAsync());
     }

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonWithDiSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonWithDiSpecs.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -80,6 +79,6 @@ public class ClusterSingletonWithDiSpecs : Akka.Hosting.TestKit.TestKit
         var respond = await singletonProxy.Ask<string>("hit", TimeSpan.FromSeconds(3));
 
         // assert
-        respond.Should().Be(thing.ThingId);
+        Assert.Equal(thing.ThingId, respond);
     }
 }

--- a/src/Akka.Cluster.Hosting.Tests/ConfigAssertionHelper.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ConfigAssertionHelper.cs
@@ -1,16 +1,16 @@
 ﻿using Akka.Configuration;
-using FluentAssertions;
+using Xunit;
 
 namespace Akka.Cluster.Hosting.Tests;
 
 public static class ConfigAssertionHelper
 {
     public static void AssertSameString(this Config first, Config second, string key)
-        => first.GetString(key).Should().Be(second.GetString(key));
+        => Assert.Equal(second.GetString(key), first.GetString(key));
 
     public static void AssertSameInt(this Config first, Config second, string key)
-        => first.GetInt(key).Should().Be(second.GetInt(key));
+        => Assert.Equal(second.GetInt(key), first.GetInt(key));
     
     public static void AssertSameTimeSpan(this Config first, Config second, string key)
-        => first.GetTimeSpan(key).Should().Be(second.GetTimeSpan(key));
+        => Assert.Equal(second.GetTimeSpan(key), first.GetTimeSpan(key));
 }

--- a/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
@@ -6,7 +6,6 @@ using Akka.Cluster.Tools.PublishSubscribe;
 using Akka.Event;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -33,25 +32,23 @@ public class DistributedPubSubSpecs : IAsyncLifetime
     {
         _helper = helper;
         _specBuilder = _ => { };
-        _clusterOptions = new ClusterOptions { Roles = new[] { "my-host" } };
+        _clusterOptions = new ClusterOptions { Roles = ["my-host"] };
     }
     
     // Issue #55 https://github.com/akkadotnet/Akka.Hosting/issues/55
     [Fact]
-    public Task Should_launch_distributed_pub_sub_with_roles()
+    public async Task Should_launch_distributed_pub_sub_with_roles()
     {
         var testProbe = _testKit!.CreateTestProbe(_system);
 
         // act
         testProbe.Send(_mediator, new Subscribe("testSub", testProbe));
-        var response = testProbe.ExpectMsg<SubscribeAck>();
+        var response = await testProbe.ExpectMsgAsync<SubscribeAck>();
 
         // assert
-        _system!.Settings.Config.GetString("akka.cluster.pub-sub.role").Should().Be("my-host");
-        response.Subscribe.Topic.Should().Be("testSub");
-        response.Subscribe.Ref.Should().Be(testProbe);
-
-        return Task.CompletedTask;
+        Assert.Equal("my-host", _system!.Settings.Config.GetString("akka.cluster.pub-sub.role"));
+        Assert.Equal("testSub", response.Subscribe.Topic);
+        Assert.Equal(testProbe, response.Subscribe.Ref);
     }
     
     [Fact]
@@ -107,8 +104,8 @@ public class DistributedPubSubSpecs : IAsyncLifetime
 
         // Lifetime should be healthy
         var lifetime = _host.Services.GetRequiredService<IHostApplicationLifetime>();
-        lifetime.ApplicationStopped.IsCancellationRequested.Should().BeFalse();
-        lifetime.ApplicationStopping.IsCancellationRequested.Should().BeFalse();
+        Assert.False(lifetime.ApplicationStopped.IsCancellationRequested);
+        Assert.False(lifetime.ApplicationStopping.IsCancellationRequested);
         
         // Join cluster
         var myAddress = _cluster!.SelfAddress;

--- a/src/Akka.Cluster.Hosting.Tests/ShardOptionsSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ShardOptionsSpecs.cs
@@ -11,8 +11,6 @@ using Akka.DistributedData;
 using Akka.Hosting;
 using Akka.Persistence.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -92,50 +90,64 @@ public class ShardOptionsSpecs
 
         #region ClusterShardingSettings validation
 
-        shardingSettings.Role.Should().BeNull();
-        shardingSettings.RememberEntities.Should().Be(shardingConfig.GetBoolean("remember-entities"));
-        shardingSettings.JournalPluginId.Should().Be(shardingConfig.GetString("journal-plugin-id"));
-        shardingSettings.SnapshotPluginId.Should().Be(shardingConfig.GetString("snapshot-plugin-id"));
-        shardingSettings.StateStoreMode.Should().Be(Enum.Parse<StateStoreMode>(shardingConfig.GetString("state-store-mode"), true));
-        shardingSettings.RememberEntitiesStore.Should().Be(Enum.Parse<RememberEntitiesStore>(shardingConfig.GetString("remember-entities-store"), true));
-        shardingSettings.ShardRegionQueryTimeout.Should().Be(shardingConfig.GetTimeSpan("shard-region-query-timeout"));
-        shardingSettings.PassivateIdleEntityAfter.Should().Be(shardingConfig.GetTimeSpan("passivate-idle-entity-after"));
-        appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition").Should().Be(shardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"));
+        Assert.Null(shardingSettings.Role);
+        Assert.Equal(shardingConfig.GetBoolean("remember-entities"), shardingSettings.RememberEntities);
+        Assert.Equal(shardingConfig.GetString("journal-plugin-id"), shardingSettings.JournalPluginId);
+        Assert.Equal(shardingConfig.GetString("snapshot-plugin-id"), shardingSettings.SnapshotPluginId);
+        Assert.Equal(Enum.Parse<StateStoreMode>(shardingConfig.GetString("state-store-mode"), true), shardingSettings.StateStoreMode);
+        Assert.Equal(Enum.Parse<RememberEntitiesStore>(shardingConfig.GetString("remember-entities-store"), true), shardingSettings.RememberEntitiesStore);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-region-query-timeout"), shardingSettings.ShardRegionQueryTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("passivate-idle-entity-after"), shardingSettings.PassivateIdleEntityAfter);
+        Assert.Equal(shardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"),
+            appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"));
         
-        shardingSettings.TuningParameters.CoordinatorFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("coordinator-failure-backoff"));
-        shardingSettings.TuningParameters.RetryInterval.Should().Be(shardingConfig.GetTimeSpan("retry-interval"));
-        shardingSettings.TuningParameters.BufferSize.Should().Be(shardingConfig.GetInt("buffer-size"));
-        shardingSettings.TuningParameters.HandOffTimeout.Should().Be(shardingConfig.GetTimeSpan("handoff-timeout"));
-        shardingSettings.TuningParameters.ShardStartTimeout.Should().Be(shardingConfig.GetTimeSpan("shard-start-timeout"));
-        shardingSettings.TuningParameters.ShardFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("shard-failure-backoff"));
-        shardingSettings.TuningParameters.EntityRestartBackoff.Should().Be(shardingConfig.GetTimeSpan("entity-restart-backoff"));
-        shardingSettings.TuningParameters.RebalanceInterval.Should().Be(shardingConfig.GetTimeSpan("rebalance-interval"));
-        shardingSettings.TuningParameters.SnapshotAfter.Should().Be(shardingConfig.GetInt("snapshot-after"));
-        shardingSettings.TuningParameters.KeepNrOfBatches.Should().Be(shardingConfig.GetInt("keep-nr-of-batches"));
-        shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"));
-        shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"));
-        shardingSettings.TuningParameters.WaitingForStateTimeout.Should().Be(shardingConfig.GetTimeSpan("waiting-for-state-timeout"));
-        shardingSettings.TuningParameters.UpdatingStateTimeout.Should().Be(shardingConfig.GetTimeSpan("updating-state-timeout"));
-        shardingSettings.TuningParameters.EntityRecoveryStrategy.Should().Be(shardingConfig.GetString("entity-recovery-strategy"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency.Should().Be(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities.Should().Be(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"));
-        shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"));
-        shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"));
-        shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"));
-        shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit.Should().Be(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"));
+        Assert.Equal(shardingConfig.GetTimeSpan("coordinator-failure-backoff"), shardingSettings.TuningParameters.CoordinatorFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("retry-interval"), shardingSettings.TuningParameters.RetryInterval);
+        Assert.Equal(shardingConfig.GetInt("buffer-size"), shardingSettings.TuningParameters.BufferSize);
+        Assert.Equal(shardingConfig.GetTimeSpan("handoff-timeout"), shardingSettings.TuningParameters.HandOffTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-start-timeout"), shardingSettings.TuningParameters.ShardStartTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-failure-backoff"), shardingSettings.TuningParameters.ShardFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-restart-backoff"), shardingSettings.TuningParameters.EntityRestartBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("rebalance-interval"), shardingSettings.TuningParameters.RebalanceInterval);
+        Assert.Equal(shardingConfig.GetInt("snapshot-after"), shardingSettings.TuningParameters.SnapshotAfter);
+        Assert.Equal(shardingConfig.GetInt("keep-nr-of-batches"), shardingSettings.TuningParameters.KeepNrOfBatches);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"), shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"), shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance);
+        Assert.Equal(shardingConfig.GetTimeSpan("waiting-for-state-timeout"), shardingSettings.TuningParameters.WaitingForStateTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("updating-state-timeout"), shardingSettings.TuningParameters.UpdatingStateTimeout);
+        Assert.Equal(shardingConfig.GetString("entity-recovery-strategy"), shardingSettings.TuningParameters.EntityRecoveryStrategy);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency);
+        Assert.Equal(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"), shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit);
+        Assert.Equal(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"), shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit);
 
         var singletonConfig = ClusterSingleton.DefaultConfig().GetConfig("akka.cluster.singleton");
-        shardingSettings.CoordinatorSingletonSettings.SingletonName.Should().Be(singletonConfig.GetString("singleton-name"));
-        shardingSettings.CoordinatorSingletonSettings.Role.Should().BeNull();
+        Assert.Equal(singletonConfig.GetString("singleton-name"), shardingSettings.CoordinatorSingletonSettings.SingletonName);
+        Assert.Null(shardingSettings.CoordinatorSingletonSettings.Role);
         // https://github.com/akkadotnet/akka.net/blob/4ae47927da9f2539742c336acfa8ae0037fabbb7/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManagerSettings.cs#L58
-        shardingSettings.CoordinatorSingletonSettings.RemovalMargin.Should().Be(TimeSpan.Zero);
-        shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval.Should().Be(singletonConfig.GetTimeSpan("hand-over-retry-interval"));
-        shardingSettings.CoordinatorSingletonSettings.LeaseSettings.Should().Be(GetLeaseUsageSettings(shardingConfig));
+        Assert.Equal(TimeSpan.Zero, shardingSettings.CoordinatorSingletonSettings.RemovalMargin);
+        Assert.Equal(singletonConfig.GetTimeSpan("hand-over-retry-interval"), shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval);
+        {
+            var expectedLease = GetLeaseUsageSettings(shardingConfig);
+            var actualLease = shardingSettings.CoordinatorSingletonSettings.LeaseSettings;
+            if (expectedLease is null)
+            {
+                Assert.Null(actualLease);
+            }
+            else
+            {
+                Assert.NotNull(actualLease);
+                Assert.Equal(expectedLease.LeaseImplementation, actualLease.LeaseImplementation);
+                Assert.Equal(expectedLease.LeaseRetryInterval, actualLease.LeaseRetryInterval);
+            }
+        }
 #pragma warning disable CS0618 // Type or member is obsolete
-        shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion.Should().Be(singletonConfig.GetBoolean("consider-app-version"));
+        Assert.Equal(singletonConfig.GetBoolean("consider-app-version"), shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        shardingSettings.LeaseSettings.Should().BeNull();
+        Assert.Null(shardingSettings.LeaseSettings);
 
         #endregion
 
@@ -143,20 +155,20 @@ public class ShardOptionsSpecs
         var repConfig = shardingConfig.GetConfig("distributed-data")
             .WithFallback(DistributedData.DistributedData.DefaultConfig().GetConfig("akka.cluster.distributed-data"));
 
-        replicatorSettings.Role.Should().Be(repConfig.GetString("role"));
-        replicatorSettings.GossipInterval.Should().Be(repConfig.GetTimeSpan("gossip-interval"));
-        replicatorSettings.NotifySubscribersInterval.Should().Be(repConfig.GetTimeSpan("notify-subscribers-interval"));
-        replicatorSettings.MaxDeltaElements.Should().Be(repConfig.GetInt("max-delta-elements"));
-        replicatorSettings.Dispatcher.Should().Be("akka.actor.internal-dispatcher");
-        replicatorSettings.PruningInterval.Should().Be(repConfig.GetTimeSpan("pruning-interval"));
-        replicatorSettings.MaxPruningDissemination.Should().Be(repConfig.GetTimeSpan("max-pruning-dissemination"));
-        replicatorSettings.DurableKeys.Should().BeEmpty();
-        replicatorSettings.PruningMarkerTimeToLive.Should().Be(repConfig.GetTimeSpan("pruning-marker-time-to-live"));
-        replicatorSettings.DurableStoreProps.Should().NotBeNull();
-        replicatorSettings.MaxDeltaSize.Should().Be(repConfig.GetInt("delta-crdt.max-delta-size"));
-        replicatorSettings.RestartReplicatorOnFailure.Should().Be(repConfig.GetBoolean("recreate-on-failure"));
-        replicatorSettings.PreferOldest.Should().Be(repConfig.GetBoolean("prefer-oldest"));
-        replicatorSettings.VerboseDebugLogging.Should().Be(repConfig.GetBoolean("verbose-debug-logging"));
+        Assert.Equal(repConfig.GetString("role"), replicatorSettings.Role);
+        Assert.Equal(repConfig.GetTimeSpan("gossip-interval"), replicatorSettings.GossipInterval);
+        Assert.Equal(repConfig.GetTimeSpan("notify-subscribers-interval"), replicatorSettings.NotifySubscribersInterval);
+        Assert.Equal(repConfig.GetInt("max-delta-elements"), replicatorSettings.MaxDeltaElements);
+        Assert.Equal("akka.actor.internal-dispatcher", replicatorSettings.Dispatcher);
+        Assert.Equal(repConfig.GetTimeSpan("pruning-interval"), replicatorSettings.PruningInterval);
+        Assert.Equal(repConfig.GetTimeSpan("max-pruning-dissemination"), replicatorSettings.MaxPruningDissemination);
+        Assert.Empty(replicatorSettings.DurableKeys);
+        Assert.Equal(repConfig.GetTimeSpan("pruning-marker-time-to-live"), replicatorSettings.PruningMarkerTimeToLive);
+        Assert.NotNull(replicatorSettings.DurableStoreProps);
+        Assert.Equal(repConfig.GetInt("delta-crdt.max-delta-size"), replicatorSettings.MaxDeltaSize);
+        Assert.Equal(repConfig.GetBoolean("recreate-on-failure"), replicatorSettings.RestartReplicatorOnFailure);
+        Assert.Equal(repConfig.GetBoolean("prefer-oldest"), replicatorSettings.PreferOldest);
+        Assert.Equal(repConfig.GetBoolean("verbose-debug-logging"), replicatorSettings.VerboseDebugLogging);
 
         #endregion
     }
@@ -209,50 +221,64 @@ public class ShardOptionsSpecs
 
         #region ClusterShardingSettings validation
 
-        shardingSettings.Role.Should().BeNull();
-        shardingSettings.RememberEntities.Should().BeTrue();
-        shardingSettings.RememberEntitiesStore.Should().Be(RememberEntitiesStore.DData);
-        shardingSettings.JournalPluginId.Should().Be(shardingConfig.GetString("journal-plugin-id"));
-        shardingSettings.SnapshotPluginId.Should().Be(shardingConfig.GetString("snapshot-plugin-id"));
-        shardingSettings.StateStoreMode.Should().Be(Enum.Parse<StateStoreMode>(shardingConfig.GetString("state-store-mode"), true));
-        shardingSettings.ShardRegionQueryTimeout.Should().Be(shardingConfig.GetTimeSpan("shard-region-query-timeout"));
-        shardingSettings.PassivateIdleEntityAfter.Should().Be(shardingConfig.GetTimeSpan("passivate-idle-entity-after"));
-        appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition").Should().Be(shardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"));
+        Assert.Null(shardingSettings.Role);
+        Assert.True(shardingSettings.RememberEntities);
+        Assert.Equal(RememberEntitiesStore.DData, shardingSettings.RememberEntitiesStore);
+        Assert.Equal(shardingConfig.GetString("journal-plugin-id"), shardingSettings.JournalPluginId);
+        Assert.Equal(shardingConfig.GetString("snapshot-plugin-id"), shardingSettings.SnapshotPluginId);
+        Assert.Equal(Enum.Parse<StateStoreMode>(shardingConfig.GetString("state-store-mode"), true), shardingSettings.StateStoreMode);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-region-query-timeout"), shardingSettings.ShardRegionQueryTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("passivate-idle-entity-after"), shardingSettings.PassivateIdleEntityAfter);
+        Assert.Equal(shardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"),
+            appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"));
         
-        shardingSettings.TuningParameters.CoordinatorFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("coordinator-failure-backoff"));
-        shardingSettings.TuningParameters.RetryInterval.Should().Be(shardingConfig.GetTimeSpan("retry-interval"));
-        shardingSettings.TuningParameters.BufferSize.Should().Be(shardingConfig.GetInt("buffer-size"));
-        shardingSettings.TuningParameters.HandOffTimeout.Should().Be(shardingConfig.GetTimeSpan("handoff-timeout"));
-        shardingSettings.TuningParameters.ShardStartTimeout.Should().Be(shardingConfig.GetTimeSpan("shard-start-timeout"));
-        shardingSettings.TuningParameters.ShardFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("shard-failure-backoff"));
-        shardingSettings.TuningParameters.EntityRestartBackoff.Should().Be(shardingConfig.GetTimeSpan("entity-restart-backoff"));
-        shardingSettings.TuningParameters.RebalanceInterval.Should().Be(shardingConfig.GetTimeSpan("rebalance-interval"));
-        shardingSettings.TuningParameters.SnapshotAfter.Should().Be(shardingConfig.GetInt("snapshot-after"));
-        shardingSettings.TuningParameters.KeepNrOfBatches.Should().Be(shardingConfig.GetInt("keep-nr-of-batches"));
-        shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"));
-        shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"));
-        shardingSettings.TuningParameters.WaitingForStateTimeout.Should().Be(shardingConfig.GetTimeSpan("waiting-for-state-timeout"));
-        shardingSettings.TuningParameters.UpdatingStateTimeout.Should().Be(shardingConfig.GetTimeSpan("updating-state-timeout"));
-        shardingSettings.TuningParameters.EntityRecoveryStrategy.Should().Be(shardingConfig.GetString("entity-recovery-strategy"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency.Should().Be(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities.Should().Be(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"));
-        shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"));
-        shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"));
-        shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"));
-        shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit.Should().Be(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"));
+        Assert.Equal(shardingConfig.GetTimeSpan("coordinator-failure-backoff"), shardingSettings.TuningParameters.CoordinatorFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("retry-interval"), shardingSettings.TuningParameters.RetryInterval);
+        Assert.Equal(shardingConfig.GetInt("buffer-size"), shardingSettings.TuningParameters.BufferSize);
+        Assert.Equal(shardingConfig.GetTimeSpan("handoff-timeout"), shardingSettings.TuningParameters.HandOffTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-start-timeout"), shardingSettings.TuningParameters.ShardStartTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-failure-backoff"), shardingSettings.TuningParameters.ShardFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-restart-backoff"), shardingSettings.TuningParameters.EntityRestartBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("rebalance-interval"), shardingSettings.TuningParameters.RebalanceInterval);
+        Assert.Equal(shardingConfig.GetInt("snapshot-after"), shardingSettings.TuningParameters.SnapshotAfter);
+        Assert.Equal(shardingConfig.GetInt("keep-nr-of-batches"), shardingSettings.TuningParameters.KeepNrOfBatches);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"), shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"), shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance);
+        Assert.Equal(shardingConfig.GetTimeSpan("waiting-for-state-timeout"), shardingSettings.TuningParameters.WaitingForStateTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("updating-state-timeout"), shardingSettings.TuningParameters.UpdatingStateTimeout);
+        Assert.Equal(shardingConfig.GetString("entity-recovery-strategy"), shardingSettings.TuningParameters.EntityRecoveryStrategy);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency);
+        Assert.Equal(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"), shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit);
+        Assert.Equal(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"), shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit);
 
         var singletonConfig = ClusterSingleton.DefaultConfig().GetConfig("akka.cluster.singleton");
-        shardingSettings.CoordinatorSingletonSettings.SingletonName.Should().Be(singletonConfig.GetString("singleton-name"));
-        shardingSettings.CoordinatorSingletonSettings.Role.Should().BeNull();
+        Assert.Equal(singletonConfig.GetString("singleton-name"), shardingSettings.CoordinatorSingletonSettings.SingletonName);
+        Assert.Null(shardingSettings.CoordinatorSingletonSettings.Role);
         // https://github.com/akkadotnet/akka.net/blob/4ae47927da9f2539742c336acfa8ae0037fabbb7/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManagerSettings.cs#L58
-        shardingSettings.CoordinatorSingletonSettings.RemovalMargin.Should().Be(TimeSpan.Zero);
-        shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval.Should().Be(singletonConfig.GetTimeSpan("hand-over-retry-interval"));
-        shardingSettings.CoordinatorSingletonSettings.LeaseSettings.Should().Be(GetLeaseUsageSettings(shardingConfig));
+        Assert.Equal(TimeSpan.Zero, shardingSettings.CoordinatorSingletonSettings.RemovalMargin);
+        Assert.Equal(singletonConfig.GetTimeSpan("hand-over-retry-interval"), shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval);
+        {
+            var expectedLease = GetLeaseUsageSettings(shardingConfig);
+            var actualLease = shardingSettings.CoordinatorSingletonSettings.LeaseSettings;
+            if (expectedLease is null)
+            {
+                Assert.Null(actualLease);
+            }
+            else
+            {
+                Assert.NotNull(actualLease);
+                Assert.Equal(expectedLease.LeaseImplementation, actualLease.LeaseImplementation);
+                Assert.Equal(expectedLease.LeaseRetryInterval, actualLease.LeaseRetryInterval);
+            }
+        }
 #pragma warning disable CS0618 // Type or member is obsolete
-        shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion.Should().Be(singletonConfig.GetBoolean("consider-app-version"));
+        Assert.Equal(singletonConfig.GetBoolean("consider-app-version"), shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        shardingSettings.LeaseSettings.Should().BeNull();
+        Assert.Null(shardingSettings.LeaseSettings);
 
         #endregion
 
@@ -260,20 +286,20 @@ public class ShardOptionsSpecs
         var repConfig = shardingConfig.GetConfig("distributed-data")
             .WithFallback(DistributedData.DistributedData.DefaultConfig().GetConfig("akka.cluster.distributed-data"));
 
-        replicatorSettings.Role.Should().Be(repConfig.GetString("role"));
-        replicatorSettings.GossipInterval.Should().Be(repConfig.GetTimeSpan("gossip-interval"));
-        replicatorSettings.NotifySubscribersInterval.Should().Be(repConfig.GetTimeSpan("notify-subscribers-interval"));
-        replicatorSettings.MaxDeltaElements.Should().Be(repConfig.GetInt("max-delta-elements"));
-        replicatorSettings.Dispatcher.Should().Be("akka.actor.internal-dispatcher");
-        replicatorSettings.PruningInterval.Should().Be(repConfig.GetTimeSpan("pruning-interval"));
-        replicatorSettings.MaxPruningDissemination.Should().Be(repConfig.GetTimeSpan("max-pruning-dissemination"));
-        replicatorSettings.DurableKeys.Should().BeEquivalentTo("shard-*");
-        replicatorSettings.PruningMarkerTimeToLive.Should().Be(repConfig.GetTimeSpan("pruning-marker-time-to-live"));
-        replicatorSettings.DurableStoreProps.Should().NotBeNull();
-        replicatorSettings.MaxDeltaSize.Should().Be(repConfig.GetInt("delta-crdt.max-delta-size"));
-        replicatorSettings.RestartReplicatorOnFailure.Should().Be(repConfig.GetBoolean("recreate-on-failure"));
-        replicatorSettings.PreferOldest.Should().Be(repConfig.GetBoolean("prefer-oldest"));
-        replicatorSettings.VerboseDebugLogging.Should().Be(repConfig.GetBoolean("verbose-debug-logging"));
+        Assert.Equal(repConfig.GetString("role"), replicatorSettings.Role);
+        Assert.Equal(repConfig.GetTimeSpan("gossip-interval"), replicatorSettings.GossipInterval);
+        Assert.Equal(repConfig.GetTimeSpan("notify-subscribers-interval"), replicatorSettings.NotifySubscribersInterval);
+        Assert.Equal(repConfig.GetInt("max-delta-elements"), replicatorSettings.MaxDeltaElements);
+        Assert.Equal("akka.actor.internal-dispatcher", replicatorSettings.Dispatcher);
+        Assert.Equal(repConfig.GetTimeSpan("pruning-interval"), replicatorSettings.PruningInterval);
+        Assert.Equal(repConfig.GetTimeSpan("max-pruning-dissemination"), replicatorSettings.MaxPruningDissemination);
+        Assert.Single(replicatorSettings.DurableKeys, "shard-*");
+        Assert.Equal(repConfig.GetTimeSpan("pruning-marker-time-to-live"), replicatorSettings.PruningMarkerTimeToLive);
+        Assert.NotNull(replicatorSettings.DurableStoreProps);
+        Assert.Equal(repConfig.GetInt("delta-crdt.max-delta-size"), replicatorSettings.MaxDeltaSize);
+        Assert.Equal(repConfig.GetBoolean("recreate-on-failure"), replicatorSettings.RestartReplicatorOnFailure);
+        Assert.Equal(repConfig.GetBoolean("prefer-oldest"), replicatorSettings.PreferOldest);
+        Assert.Equal(repConfig.GetBoolean("verbose-debug-logging"), replicatorSettings.VerboseDebugLogging);
 
         #endregion
     }
@@ -290,7 +316,7 @@ public class ShardOptionsSpecs
             JournalPluginId = "custom-journal", 
             SnapshotPluginId = "custom-snapshot-store", 
             LeaseImplementation = new TestLeaseOption(), 
-            LeaseRetryInterval = 1.Seconds(), 
+            LeaseRetryInterval = TimeSpan.FromSeconds(1), 
             HandOffStopMessage = StopMessage.Instance, // can't be tested, assigned directly
             FailOnInvalidEntityStateTransition = true, 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -302,8 +328,8 @@ public class ShardOptionsSpecs
             },
 #pragma warning restore CS0618 // Type or member is obsolete
             ShouldPassivateIdleEntities = false, 
-            ShardRegionQueryTimeout = 2.Seconds(), 
-            PassivateIdleEntityAfter = 3.Seconds(), 
+            ShardRegionQueryTimeout = TimeSpan.FromSeconds(2), 
+            PassivateIdleEntityAfter = TimeSpan.FromSeconds(3), 
         };
         
         using var host = Host.CreateDefaultBuilder()
@@ -315,7 +341,7 @@ public class ShardOptionsSpecs
                         .WithRemoting()
                         .WithClustering(new ClusterOptions
                         {
-                            Roles = new[] {"test"}
+                            Roles = ["test"]
                         })
                         .WithShardRegion<MyEntityActor>(
                             typeName: "entities", 
@@ -336,7 +362,7 @@ public class ShardOptionsSpecs
                             VerboseDebugLogging = true, 
                             Durable = new DurableOptions
                             {
-                                Keys = new[] {"custom-*"},
+                                Keys = ["custom-*"],
                                 Lmdb = new LmdbOptions
                                 {
                                     Directory = "lmdb",
@@ -368,52 +394,67 @@ public class ShardOptionsSpecs
 
         #region ClusterShardingSettings validation
 
-        shardingSettings.Role.Should().Be("test");
-        shardingSettings.RememberEntities.Should().BeTrue();
-        shardingSettings.JournalPluginId.Should().Be("custom-journal");
-        shardingSettings.SnapshotPluginId.Should().Be("custom-snapshot-store");
-        shardingSettings.StateStoreMode.Should().Be(StateStoreMode.DData);
-        shardingSettings.RememberEntitiesStore.Should().Be(RememberEntitiesStore.Eventsourced);
-        shardingSettings.ShardRegionQueryTimeout.Should().Be(2.Seconds());
-        shardingSettings.PassivateIdleEntityAfter.Should().Be(default);
+        Assert.Equal("test", shardingSettings.Role);
+        Assert.True(shardingSettings.RememberEntities);
+        Assert.Equal("custom-journal", shardingSettings.JournalPluginId);
+        Assert.Equal("custom-snapshot-store", shardingSettings.SnapshotPluginId);
+        Assert.Equal(StateStoreMode.DData, shardingSettings.StateStoreMode);
+        Assert.Equal(RememberEntitiesStore.Eventsourced, shardingSettings.RememberEntitiesStore);
+        Assert.Equal(TimeSpan.FromSeconds(2), shardingSettings.ShardRegionQueryTimeout);
+        Assert.Equal(TimeSpan.Zero, shardingSettings.PassivateIdleEntityAfter);
         
-        appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition").Should().BeTrue();
-        appliedShardingConfig.GetInt("distributed-data.majority-min-cap").Should().Be(1);
+        Assert.True(appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"));
+        Assert.Equal(1, appliedShardingConfig.GetInt("distributed-data.majority-min-cap"));
         
-        shardingSettings.TuningParameters.CoordinatorFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("coordinator-failure-backoff"));
-        shardingSettings.TuningParameters.RetryInterval.Should().Be(shardingConfig.GetTimeSpan("retry-interval"));
-        shardingSettings.TuningParameters.BufferSize.Should().Be(shardingConfig.GetInt("buffer-size"));
-        shardingSettings.TuningParameters.HandOffTimeout.Should().Be(shardingConfig.GetTimeSpan("handoff-timeout"));
-        shardingSettings.TuningParameters.ShardStartTimeout.Should().Be(shardingConfig.GetTimeSpan("shard-start-timeout"));
-        shardingSettings.TuningParameters.ShardFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("shard-failure-backoff"));
-        shardingSettings.TuningParameters.EntityRestartBackoff.Should().Be(shardingConfig.GetTimeSpan("entity-restart-backoff"));
-        shardingSettings.TuningParameters.RebalanceInterval.Should().Be(shardingConfig.GetTimeSpan("rebalance-interval"));
-        shardingSettings.TuningParameters.SnapshotAfter.Should().Be(shardingConfig.GetInt("snapshot-after"));
-        shardingSettings.TuningParameters.KeepNrOfBatches.Should().Be(shardingConfig.GetInt("keep-nr-of-batches"));
-        shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"));
-        shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"));
-        shardingSettings.TuningParameters.WaitingForStateTimeout.Should().Be(shardingConfig.GetTimeSpan("waiting-for-state-timeout"));
-        shardingSettings.TuningParameters.UpdatingStateTimeout.Should().Be(shardingConfig.GetTimeSpan("updating-state-timeout"));
-        shardingSettings.TuningParameters.EntityRecoveryStrategy.Should().Be(shardingConfig.GetString("entity-recovery-strategy"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency.Should().Be(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities.Should().Be(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"));
-        shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"));
-        shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"));
-        shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"));
-        shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit.Should().Be(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"));
+        Assert.Equal(shardingConfig.GetTimeSpan("coordinator-failure-backoff"), shardingSettings.TuningParameters.CoordinatorFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("retry-interval"), shardingSettings.TuningParameters.RetryInterval);
+        Assert.Equal(shardingConfig.GetInt("buffer-size"), shardingSettings.TuningParameters.BufferSize);
+        Assert.Equal(shardingConfig.GetTimeSpan("handoff-timeout"), shardingSettings.TuningParameters.HandOffTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-start-timeout"), shardingSettings.TuningParameters.ShardStartTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-failure-backoff"), shardingSettings.TuningParameters.ShardFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-restart-backoff"), shardingSettings.TuningParameters.EntityRestartBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("rebalance-interval"), shardingSettings.TuningParameters.RebalanceInterval);
+        Assert.Equal(shardingConfig.GetInt("snapshot-after"), shardingSettings.TuningParameters.SnapshotAfter);
+        Assert.Equal(shardingConfig.GetInt("keep-nr-of-batches"), shardingSettings.TuningParameters.KeepNrOfBatches);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"), shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"), shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance);
+        Assert.Equal(shardingConfig.GetTimeSpan("waiting-for-state-timeout"), shardingSettings.TuningParameters.WaitingForStateTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("updating-state-timeout"), shardingSettings.TuningParameters.UpdatingStateTimeout);
+        Assert.Equal(shardingConfig.GetString("entity-recovery-strategy"), shardingSettings.TuningParameters.EntityRecoveryStrategy);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency);
+        Assert.Equal(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"), shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit);
+        Assert.Equal(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"), shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit);
 
         var singletonConfig = ClusterSingleton.DefaultConfig().GetConfig("akka.cluster.singleton");
-        shardingSettings.CoordinatorSingletonSettings.SingletonName.Should().Be(singletonConfig.GetString("singleton-name"));
-        shardingSettings.CoordinatorSingletonSettings.Role.Should().BeNull();
+        Assert.Equal(singletonConfig.GetString("singleton-name"), shardingSettings.CoordinatorSingletonSettings.SingletonName);
+        Assert.Null(shardingSettings.CoordinatorSingletonSettings.Role);
         // https://github.com/akkadotnet/akka.net/blob/4ae47927da9f2539742c336acfa8ae0037fabbb7/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManagerSettings.cs#L58
-        shardingSettings.CoordinatorSingletonSettings.RemovalMargin.Should().Be(TimeSpan.Zero);
-        shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval.Should().Be(singletonConfig.GetTimeSpan("hand-over-retry-interval"));
-        shardingSettings.CoordinatorSingletonSettings.LeaseSettings.Should().Be(GetLeaseUsageSettings(shardingConfig));
+        Assert.Equal(TimeSpan.Zero, shardingSettings.CoordinatorSingletonSettings.RemovalMargin);
+        Assert.Equal(singletonConfig.GetTimeSpan("hand-over-retry-interval"), shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval);
+        {
+            var expectedLease = GetLeaseUsageSettings(shardingConfig);
+            var actualLease = shardingSettings.CoordinatorSingletonSettings.LeaseSettings;
+            if (expectedLease is null)
+            {
+                Assert.Null(actualLease);
+            }
+            else
+            {
+                Assert.NotNull(actualLease);
+                Assert.Equal(expectedLease.LeaseImplementation, actualLease.LeaseImplementation);
+                Assert.Equal(expectedLease.LeaseRetryInterval, actualLease.LeaseRetryInterval);
+            }
+        }
 #pragma warning disable CS0618 // Type or member is obsolete
-        shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion.Should().Be(singletonConfig.GetBoolean("consider-app-version"));
+        Assert.Equal(singletonConfig.GetBoolean("consider-app-version"), shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        shardingSettings.LeaseSettings.Should().BeEquivalentTo(new LeaseUsageSettings("test-lease", 1.Seconds()));
+        Assert.NotNull(shardingSettings.LeaseSettings);
+        Assert.Equal("test-lease", shardingSettings.LeaseSettings!.LeaseImplementation);
+        Assert.Equal(1.Seconds(), shardingSettings.LeaseSettings.LeaseRetryInterval);
 
         #endregion
 
@@ -421,24 +462,28 @@ public class ShardOptionsSpecs
         var repConfig = shardingConfig.GetConfig("distributed-data")
             .WithFallback(DistributedData.DistributedData.DefaultConfig().GetConfig("akka.cluster.distributed-data"));
 
-        appliedShardingConfig.GetString("distributed-data.name").Should().NotBe("wrong-name").And.Be("customReplicator");
-        replicatorSettings.Role.Should().NotBe("wrong-role").And.Be("test");
-        replicatorSettings.GossipInterval.Should().Be(repConfig.GetTimeSpan("gossip-interval"));
-        replicatorSettings.NotifySubscribersInterval.Should().Be(repConfig.GetTimeSpan("notify-subscribers-interval"));
-        replicatorSettings.MaxDeltaElements.Should().Be(2);
-        replicatorSettings.Dispatcher.Should().Be("akka.actor.internal-dispatcher");
-        replicatorSettings.PruningInterval.Should().Be(repConfig.GetTimeSpan("pruning-interval"));
-        replicatorSettings.MaxPruningDissemination.Should().Be(repConfig.GetTimeSpan("max-pruning-dissemination"));
-        replicatorSettings.DurableKeys.Should().BeEmpty();
-        replicatorSettings.PruningMarkerTimeToLive.Should().Be(repConfig.GetTimeSpan("pruning-marker-time-to-live"));
-        replicatorSettings.DurableStoreProps.Should().NotBeNull();
-        replicatorSettings.MaxDeltaSize.Should().Be(repConfig.GetInt("delta-crdt.max-delta-size"));
-        replicatorSettings.RestartReplicatorOnFailure.Should().BeTrue();
-        replicatorSettings.PreferOldest.Should().BeFalse();
-        replicatorSettings.VerboseDebugLogging.Should().BeTrue();
+        Assert.NotEqual("wrong-name", appliedShardingConfig.GetString("distributed-data.name"));
+        Assert.Equal("customReplicator", appliedShardingConfig.GetString("distributed-data.name"));
 
-        appliedShardingConfig.GetString("distributed-data.durable.lmdb.dir").Should().Be("lmdb");
-        appliedShardingConfig.GetLong("distributed-data.durable.lmdb.map-size").Should().Be(1024 * 1024);
+        Assert.NotEqual("wrong-role", replicatorSettings.Role);
+        Assert.Equal("test", replicatorSettings.Role);
+
+        Assert.Equal(repConfig.GetTimeSpan("gossip-interval"), replicatorSettings.GossipInterval);
+        Assert.Equal(repConfig.GetTimeSpan("notify-subscribers-interval"), replicatorSettings.NotifySubscribersInterval);
+        Assert.Equal(2, replicatorSettings.MaxDeltaElements);
+        Assert.Equal("akka.actor.internal-dispatcher", replicatorSettings.Dispatcher);
+        Assert.Equal(repConfig.GetTimeSpan("pruning-interval"), replicatorSettings.PruningInterval);
+        Assert.Equal(repConfig.GetTimeSpan("max-pruning-dissemination"), replicatorSettings.MaxPruningDissemination);
+        Assert.Empty(replicatorSettings.DurableKeys);
+        Assert.Equal(repConfig.GetTimeSpan("pruning-marker-time-to-live"), replicatorSettings.PruningMarkerTimeToLive);
+        Assert.NotNull(replicatorSettings.DurableStoreProps);
+        Assert.Equal(repConfig.GetInt("delta-crdt.max-delta-size"), replicatorSettings.MaxDeltaSize);
+        Assert.True(replicatorSettings.RestartReplicatorOnFailure);
+        Assert.False(replicatorSettings.PreferOldest);
+        Assert.True(replicatorSettings.VerboseDebugLogging);
+
+        Assert.Equal("lmdb", appliedShardingConfig.GetString("distributed-data.durable.lmdb.dir"));
+        Assert.Equal(1024 * 1024, appliedShardingConfig.GetLong("distributed-data.durable.lmdb.map-size"));
         
         #endregion
     }
@@ -455,7 +500,7 @@ public class ShardOptionsSpecs
             JournalPluginId = "custom-journal", 
             SnapshotPluginId = "custom-snapshot-store", 
             LeaseImplementation = new TestLeaseOption(), 
-            LeaseRetryInterval = 1.Seconds(), 
+            LeaseRetryInterval = TimeSpan.FromSeconds(1), 
             HandOffStopMessage = StopMessage.Instance, // can't be tested, assigned directly
             FailOnInvalidEntityStateTransition = true, 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -467,8 +512,8 @@ public class ShardOptionsSpecs
             },
 #pragma warning restore CS0618 // Type or member is obsolete
             ShouldPassivateIdleEntities = false, 
-            ShardRegionQueryTimeout = 2.Seconds(), 
-            PassivateIdleEntityAfter = 3.Seconds(), 
+            ShardRegionQueryTimeout = TimeSpan.FromSeconds(2), 
+            PassivateIdleEntityAfter = TimeSpan.FromSeconds(3), 
         };
         
         using var host = Host.CreateDefaultBuilder()
@@ -480,7 +525,7 @@ public class ShardOptionsSpecs
                         .WithRemoting()
                         .WithClustering(new ClusterOptions
                         {
-                            Roles = new[] {"test"}
+                            Roles = ["test"]
                         })
                         .WithShardRegion<MyEntityActor>(
                             typeName: "entities", 
@@ -501,7 +546,7 @@ public class ShardOptionsSpecs
                             VerboseDebugLogging = true, 
                             Durable = new DurableOptions
                             {
-                                Keys = new[] {"custom-*"},
+                                Keys = ["custom-*"],
                                 Lmdb = new LmdbOptions
                                 {
                                     Directory = "lmdb",
@@ -533,52 +578,67 @@ public class ShardOptionsSpecs
 
         #region ClusterShardingSettings validation
 
-        shardingSettings.Role.Should().Be("test");
-        shardingSettings.RememberEntities.Should().BeTrue();
-        shardingSettings.JournalPluginId.Should().Be("custom-journal");
-        shardingSettings.SnapshotPluginId.Should().Be("custom-snapshot-store");
-        shardingSettings.StateStoreMode.Should().Be(StateStoreMode.DData);
-        shardingSettings.RememberEntitiesStore.Should().Be(RememberEntitiesStore.DData);
-        shardingSettings.ShardRegionQueryTimeout.Should().Be(2.Seconds());
-        shardingSettings.PassivateIdleEntityAfter.Should().Be(default);
+        Assert.Equal("test", shardingSettings.Role);
+        Assert.True(shardingSettings.RememberEntities);
+        Assert.Equal("custom-journal", shardingSettings.JournalPluginId);
+        Assert.Equal("custom-snapshot-store", shardingSettings.SnapshotPluginId);
+        Assert.Equal(StateStoreMode.DData, shardingSettings.StateStoreMode);
+        Assert.Equal(RememberEntitiesStore.DData, shardingSettings.RememberEntitiesStore);
+        Assert.Equal(2.Seconds(), shardingSettings.ShardRegionQueryTimeout);
+        Assert.Equal(TimeSpan.Zero, shardingSettings.PassivateIdleEntityAfter);
         
-        appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition").Should().BeTrue();
-        appliedShardingConfig.GetInt("distributed-data.majority-min-cap").Should().Be(1);
+        Assert.True(appliedShardingConfig.GetBoolean("fail-on-invalid-entity-state-transition"));
+        Assert.Equal(1, appliedShardingConfig.GetInt("distributed-data.majority-min-cap"));
         
-        shardingSettings.TuningParameters.CoordinatorFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("coordinator-failure-backoff"));
-        shardingSettings.TuningParameters.RetryInterval.Should().Be(shardingConfig.GetTimeSpan("retry-interval"));
-        shardingSettings.TuningParameters.BufferSize.Should().Be(shardingConfig.GetInt("buffer-size"));
-        shardingSettings.TuningParameters.HandOffTimeout.Should().Be(shardingConfig.GetTimeSpan("handoff-timeout"));
-        shardingSettings.TuningParameters.ShardStartTimeout.Should().Be(shardingConfig.GetTimeSpan("shard-start-timeout"));
-        shardingSettings.TuningParameters.ShardFailureBackoff.Should().Be(shardingConfig.GetTimeSpan("shard-failure-backoff"));
-        shardingSettings.TuningParameters.EntityRestartBackoff.Should().Be(shardingConfig.GetTimeSpan("entity-restart-backoff"));
-        shardingSettings.TuningParameters.RebalanceInterval.Should().Be(shardingConfig.GetTimeSpan("rebalance-interval"));
-        shardingSettings.TuningParameters.SnapshotAfter.Should().Be(shardingConfig.GetInt("snapshot-after"));
-        shardingSettings.TuningParameters.KeepNrOfBatches.Should().Be(shardingConfig.GetInt("keep-nr-of-batches"));
-        shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"));
-        shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"));
-        shardingSettings.TuningParameters.WaitingForStateTimeout.Should().Be(shardingConfig.GetTimeSpan("waiting-for-state-timeout"));
-        shardingSettings.TuningParameters.UpdatingStateTimeout.Should().Be(shardingConfig.GetTimeSpan("updating-state-timeout"));
-        shardingSettings.TuningParameters.EntityRecoveryStrategy.Should().Be(shardingConfig.GetString("entity-recovery-strategy"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency.Should().Be(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"));
-        shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities.Should().Be(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"));
-        shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"));
-        shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"));
-        shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit.Should().Be(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"));
-        shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit.Should().Be(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"));
+        Assert.Equal(shardingConfig.GetTimeSpan("coordinator-failure-backoff"), shardingSettings.TuningParameters.CoordinatorFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("retry-interval"), shardingSettings.TuningParameters.RetryInterval);
+        Assert.Equal(shardingConfig.GetInt("buffer-size"), shardingSettings.TuningParameters.BufferSize);
+        Assert.Equal(shardingConfig.GetTimeSpan("handoff-timeout"), shardingSettings.TuningParameters.HandOffTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-start-timeout"), shardingSettings.TuningParameters.ShardStartTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("shard-failure-backoff"), shardingSettings.TuningParameters.ShardFailureBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-restart-backoff"), shardingSettings.TuningParameters.EntityRestartBackoff);
+        Assert.Equal(shardingConfig.GetTimeSpan("rebalance-interval"), shardingSettings.TuningParameters.RebalanceInterval);
+        Assert.Equal(shardingConfig.GetInt("snapshot-after"), shardingSettings.TuningParameters.SnapshotAfter);
+        Assert.Equal(shardingConfig.GetInt("keep-nr-of-batches"), shardingSettings.TuningParameters.KeepNrOfBatches);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-threshold"), shardingSettings.TuningParameters.LeastShardAllocationRebalanceThreshold);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.max-simultaneous-rebalance"), shardingSettings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance);
+        Assert.Equal(shardingConfig.GetTimeSpan("waiting-for-state-timeout"), shardingSettings.TuningParameters.WaitingForStateTimeout);
+        Assert.Equal(shardingConfig.GetTimeSpan("updating-state-timeout"), shardingSettings.TuningParameters.UpdatingStateTimeout);
+        Assert.Equal(shardingConfig.GetString("entity-recovery-strategy"), shardingSettings.TuningParameters.EntityRecoveryStrategy);
+        Assert.Equal(shardingConfig.GetTimeSpan("entity-recovery-constant-rate-strategy.frequency"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyFrequency);
+        Assert.Equal(shardingConfig.GetInt("entity-recovery-constant-rate-strategy.number-of-entities"), shardingSettings.TuningParameters.EntityRecoveryConstantRateStrategyNumberOfEntities);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.write-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus);
+        Assert.Equal(ConfigMajorityPlus(shardingConfig, "coordinator-state.read-majority-plus"), shardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus);
+        Assert.Equal(shardingConfig.GetInt("least-shard-allocation-strategy.rebalance-absolute-limit"), shardingSettings.TuningParameters.LeastShardAllocationAbsoluteLimit);
+        Assert.Equal(shardingConfig.GetDouble("least-shard-allocation-strategy.rebalance-relative-limit"), shardingSettings.TuningParameters.LeastShardAllocationRelativeLimit);
 
         var singletonConfig = ClusterSingleton.DefaultConfig().GetConfig("akka.cluster.singleton");
-        shardingSettings.CoordinatorSingletonSettings.SingletonName.Should().Be(singletonConfig.GetString("singleton-name"));
-        shardingSettings.CoordinatorSingletonSettings.Role.Should().BeNull();
+        Assert.Equal(singletonConfig.GetString("singleton-name"), shardingSettings.CoordinatorSingletonSettings.SingletonName);
+        Assert.Null(shardingSettings.CoordinatorSingletonSettings.Role);
         // https://github.com/akkadotnet/akka.net/blob/4ae47927da9f2539742c336acfa8ae0037fabbb7/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManagerSettings.cs#L58
-        shardingSettings.CoordinatorSingletonSettings.RemovalMargin.Should().Be(TimeSpan.Zero);
-        shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval.Should().Be(singletonConfig.GetTimeSpan("hand-over-retry-interval"));
-        shardingSettings.CoordinatorSingletonSettings.LeaseSettings.Should().Be(GetLeaseUsageSettings(shardingConfig));
+        Assert.Equal(TimeSpan.Zero, shardingSettings.CoordinatorSingletonSettings.RemovalMargin);
+        Assert.Equal(singletonConfig.GetTimeSpan("hand-over-retry-interval"), shardingSettings.CoordinatorSingletonSettings.HandOverRetryInterval);
+        {
+            var expectedLease = GetLeaseUsageSettings(shardingConfig);
+            var actualLease = shardingSettings.CoordinatorSingletonSettings.LeaseSettings;
+            if (expectedLease is null)
+            {
+                Assert.Null(actualLease);
+            }
+            else
+            {
+                Assert.NotNull(actualLease);
+                Assert.Equal(expectedLease.LeaseImplementation, actualLease.LeaseImplementation);
+                Assert.Equal(expectedLease.LeaseRetryInterval, actualLease.LeaseRetryInterval);
+            }
+        }
 #pragma warning disable CS0618 // Type or member is obsolete
-        shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion.Should().Be(singletonConfig.GetBoolean("consider-app-version"));
+        Assert.Equal(singletonConfig.GetBoolean("consider-app-version"), shardingSettings.CoordinatorSingletonSettings.ConsiderAppVersion);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        shardingSettings.LeaseSettings.Should().BeEquivalentTo(new LeaseUsageSettings("test-lease", 1.Seconds()));
+        Assert.NotNull(shardingSettings.LeaseSettings);
+        Assert.Equal("test-lease", shardingSettings.LeaseSettings!.LeaseImplementation);
+        Assert.Equal(TimeSpan.FromSeconds(1), shardingSettings.LeaseSettings.LeaseRetryInterval);
 
         #endregion
 
@@ -586,24 +646,28 @@ public class ShardOptionsSpecs
         var repConfig = shardingConfig.GetConfig("distributed-data")
             .WithFallback(DistributedData.DistributedData.DefaultConfig().GetConfig("akka.cluster.distributed-data"));
 
-        appliedShardingConfig.GetString("distributed-data.name").Should().NotBe("wrong-name").And.Be("customReplicator");
-        replicatorSettings.Role.Should().NotBe("wrong-role").And.Be("test");
-        replicatorSettings.GossipInterval.Should().Be(repConfig.GetTimeSpan("gossip-interval"));
-        replicatorSettings.NotifySubscribersInterval.Should().Be(repConfig.GetTimeSpan("notify-subscribers-interval"));
-        replicatorSettings.MaxDeltaElements.Should().Be(2);
-        replicatorSettings.Dispatcher.Should().Be("akka.actor.internal-dispatcher");
-        replicatorSettings.PruningInterval.Should().Be(repConfig.GetTimeSpan("pruning-interval"));
-        replicatorSettings.MaxPruningDissemination.Should().Be(repConfig.GetTimeSpan("max-pruning-dissemination"));
-        replicatorSettings.DurableKeys.Should().BeEquivalentTo("custom-*");
-        replicatorSettings.PruningMarkerTimeToLive.Should().Be(repConfig.GetTimeSpan("pruning-marker-time-to-live"));
-        replicatorSettings.DurableStoreProps.Should().NotBeNull();
-        replicatorSettings.MaxDeltaSize.Should().Be(repConfig.GetInt("delta-crdt.max-delta-size"));
-        replicatorSettings.RestartReplicatorOnFailure.Should().BeTrue();
-        replicatorSettings.PreferOldest.Should().BeFalse();
-        replicatorSettings.VerboseDebugLogging.Should().BeTrue();
+        Assert.NotEqual("wrong-name", appliedShardingConfig.GetString("distributed-data.name"));
+        Assert.Equal("customReplicator", appliedShardingConfig.GetString("distributed-data.name"));
 
-        appliedShardingConfig.GetString("distributed-data.durable.lmdb.dir").Should().Be("lmdb");
-        appliedShardingConfig.GetLong("distributed-data.durable.lmdb.map-size").Should().Be(1024 * 1024);
+        Assert.NotEqual("wrong-role", replicatorSettings.Role);
+        Assert.Equal("test", replicatorSettings.Role);
+
+        Assert.Equal(repConfig.GetTimeSpan("gossip-interval"), replicatorSettings.GossipInterval);
+        Assert.Equal(repConfig.GetTimeSpan("notify-subscribers-interval"), replicatorSettings.NotifySubscribersInterval);
+        Assert.Equal(2, replicatorSettings.MaxDeltaElements);
+        Assert.Equal("akka.actor.internal-dispatcher", replicatorSettings.Dispatcher);
+        Assert.Equal(repConfig.GetTimeSpan("pruning-interval"), replicatorSettings.PruningInterval);
+        Assert.Equal(repConfig.GetTimeSpan("max-pruning-dissemination"), replicatorSettings.MaxPruningDissemination);
+        Assert.Single(replicatorSettings.DurableKeys, "custom-*");
+        Assert.Equal(repConfig.GetTimeSpan("pruning-marker-time-to-live"), replicatorSettings.PruningMarkerTimeToLive);
+        Assert.NotNull(replicatorSettings.DurableStoreProps);
+        Assert.Equal(repConfig.GetInt("delta-crdt.max-delta-size"), replicatorSettings.MaxDeltaSize);
+        Assert.True(replicatorSettings.RestartReplicatorOnFailure);
+        Assert.False(replicatorSettings.PreferOldest);
+        Assert.True(replicatorSettings.VerboseDebugLogging);
+
+        Assert.Equal("lmdb", appliedShardingConfig.GetString("distributed-data.durable.lmdb.dir"));
+        Assert.Equal(1024 * 1024, appliedShardingConfig.GetLong("distributed-data.durable.lmdb.map-size"));
         
         #endregion
     }
@@ -652,7 +716,7 @@ public class ShardOptionsSpecs
             .WithFallback(system.Settings.Config.GetConfig("akka.cluster.distributed-data"));
         var configuredSettings = ReplicatorSettings.Create(config);
         var settingsWithRoles = configuredSettings.WithRole(shardingSettings.Role);
-        if (shardingSettings.RememberEntities && shardingSettings.RememberEntitiesStore == RememberEntitiesStore.DData)
+        if (shardingSettings is { RememberEntities: true, RememberEntitiesStore: RememberEntitiesStore.DData })
             return settingsWithRoles; // only enable durable keys when using DData for remember-entities
         else
             return settingsWithRoles.WithDurableKeys(ImmutableHashSet<string>.Empty);

--- a/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessProxySpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessProxySpecs.cs
@@ -5,8 +5,6 @@ using Akka.Actor;
 using Akka.Cluster.Sharding;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,7 +38,7 @@ public class ShardedDaemonProcessProxySpecs: Akka.Hosting.TestKit.TestKit
             })
             .WithClustering(new ClusterOptions
             {
-                Roles = new[]{ Role }
+                Roles = [Role]
             })
             .WithShardedDaemonProcess<ShardedDaemonRouter>(
                 name: Name, 
@@ -68,7 +66,7 @@ public class ShardedDaemonProcessProxySpecs: Akka.Hosting.TestKit.TestKit
         // validate that we have a cluster
         await AwaitAssertAsync(() =>
         {
-            Cluster.Get(Sys).State.Members.Count(x => x.Status == MemberStatus.Up).Should().Be(1);
+            Assert.Equal(1, Cluster.Get(Sys).State.Members.Count(x => x.Status == MemberStatus.Up));
         });
         
         // <PushDaemon>
@@ -78,7 +76,7 @@ public class ShardedDaemonProcessProxySpecs: Akka.Hosting.TestKit.TestKit
         for(var i = 0; i < NumWorkers; i++)
         {
             var result = await host.Ask<int>(i);
-            result.Should().Be(i);
+            Assert.Equal(i, result);
         }
         // </PushDaemon>
         
@@ -93,8 +91,8 @@ public class ShardedDaemonProcessProxySpecs: Akka.Hosting.TestKit.TestKit
             // validate that we have a 2 node cluster with both members marked as up
             await AwaitAssertAsync(() =>
             {
-                Cluster.Get(Sys).State.Members.Count(x => x.Status == MemberStatus.Up).Should().Be(2);
-                Cluster.Get(proxySystem.Sys).State.Members.Count(x => x.Status == MemberStatus.Up).Should().Be(2);
+                Assert.Equal(2, Cluster.Get(Sys).State.Members.Count(x => x.Status == MemberStatus.Up));
+                Assert.Equal(2, Cluster.Get(proxySystem.Sys).State.Members.Count(x => x.Status == MemberStatus.Up));
             });
             
             var proxyRouter = await proxySystem.Host.Services
@@ -104,7 +102,7 @@ public class ShardedDaemonProcessProxySpecs: Akka.Hosting.TestKit.TestKit
             for(var i = 0; i < NumWorkers; i++)
             {
                 var result = await proxyRouter.Ask<int>(i);
-                result.Should().Be(i);
+                Assert.Equal(i, result);
             }
         }
         finally

--- a/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessSpecs.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Cluster.Sharding;
 using Akka.Event;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
 using Akka.TestKit;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -113,8 +108,7 @@ public class ShardedDaemonProcessSpecs: Akka.Hosting.TestKit.TestKit
     {
         _cluster = Cluster.Get(Sys);
         
-        await AwaitAssertAsync(() => _cluster.SelfMember.Status.Should().Be(MemberStatus.Up),
-            TimeSpan.FromSeconds(3));
+        await AwaitAssertAsync(() => Assert.Equal(MemberStatus.Up, _cluster.SelfMember.Status), 3.Seconds());
     }
 
     [Fact]
@@ -126,8 +120,8 @@ public class ShardedDaemonProcessSpecs: Akka.Hosting.TestKit.TestKit
             started.Add(await ExpectMsgAsync<Started>());
         }
         
-        started.Count.Should().Be(5);
-        started.Select(s => s.Id).ToList().Should().BeEquivalentTo(new []{0, 1, 2, 3, 4});
+        Assert.Equal(5, started.Count);
+        Assert.Equal([0, 1, 2, 3, 4], started.Select(s => s.Id).OrderBy(s => s));
         await ExpectNoMsgAsync(1.Seconds());
     }
 
@@ -140,8 +134,8 @@ public class ShardedDaemonProcessSpecs: Akka.Hosting.TestKit.TestKit
             startMessages.Add(await ExpectMsgAsync<Started>());
         }
         
-        startMessages.Count.Should().Be(5);
-        startMessages.Select(s => s.Id).ToList().Should().BeEquivalentTo(new []{0, 1, 2, 3, 4});
+        Assert.Equal(5, startMessages.Count);
+        Assert.Equal([0, 1, 2, 3, 4], startMessages.Select(s => s.Id).OrderBy(s => s));
 
         // Stop all entities
         foreach (var start in startMessages)
@@ -156,8 +150,8 @@ public class ShardedDaemonProcessSpecs: Akka.Hosting.TestKit.TestKit
             startMessages.Add(await ExpectMsgAsync<Started>());
         }
         
-        startMessages.Count.Should().Be(5);
-        startMessages.Select(s => s.Id).ToList().Should().BeEquivalentTo(new []{0, 1, 2, 3, 4});
+        Assert.Equal(5, startMessages.Count);
+        Assert.Equal([0, 1, 2, 3, 4], startMessages.Select(s => s.Id).OrderBy(s => s));
     }
 }
 
@@ -188,7 +182,7 @@ public class ShardedDaemonProcessFailureSpecs : Akka.Hosting.TestKit.TestKit
     public async Task ShardedDaemonProcess_must_not_run_if_the_role_does_not_match_node_role()
     {
         var registry = Host.Services.GetRequiredService<ActorRegistry>();
-        registry.TryGet<ShardedDaemonProcessSpecs.ShardedDaemonRouter>(out _).Should().BeFalse();
+        Assert.False(registry.TryGet<ShardedDaemonProcessSpecs.ShardedDaemonRouter>(out _));
 
         await ExpectNoMsgAsync(1.Seconds());
     }

--- a/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
@@ -14,7 +14,6 @@ using Akka.Cluster.Hosting.Tests.Lease;
 using Akka.Cluster.SBR;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -84,10 +83,11 @@ public class SplitBrainResolverSpecs
 
         var system = host.Services.GetRequiredService<ActorSystem>();
         
-        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        Assert.IsType<SplitBrainResolverProvider>(Cluster.Get(system).DowningProvider);
+        
         var settings = new SplitBrainResolverSettings(system.Settings.Config);
-        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.KeepMajorityName);
-        settings.KeepMajorityRole.Should().BeNull();
+        Assert.Equal(SplitBrainResolverSettings.KeepMajorityName, settings.DowningStrategy);
+        Assert.Null(settings.KeepMajorityRole);
     }
     
     [Fact(DisplayName = "Static quorum SBR set from Akka.Hosting should load")]
@@ -106,12 +106,12 @@ public class SplitBrainResolverSpecs
         });
 
         var system = host.Services.GetRequiredService<ActorSystem>();
-        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        Assert.IsType<SplitBrainResolverProvider>(Cluster.Get(system).DowningProvider);
         
         var settings = new SplitBrainResolverSettings(system.Settings.Config);
-        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.StaticQuorumName);
-        settings.StaticQuorumSettings.Size.Should().Be(1);
-        settings.StaticQuorumSettings.Role.Should().Be("myRole");
+        Assert.Equal(SplitBrainResolverSettings.StaticQuorumName, settings.DowningStrategy);
+        Assert.Equal(1, settings.StaticQuorumSettings.Size);
+        Assert.Equal("myRole", settings.StaticQuorumSettings.Role);
     }
     
     [Fact(DisplayName = "Keep majority SBR set from Akka.Hosting should load")]
@@ -129,11 +129,11 @@ public class SplitBrainResolverSpecs
         });
 
         var system = host.Services.GetRequiredService<ActorSystem>();
-        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        Assert.IsType<SplitBrainResolverProvider>(Cluster.Get(system).DowningProvider);
         
         var settings = new SplitBrainResolverSettings(system.Settings.Config);
-        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.KeepMajorityName);
-        settings.KeepMajorityRole.Should().Be("myRole");
+        Assert.Equal(SplitBrainResolverSettings.KeepMajorityName, settings.DowningStrategy);
+        Assert.Equal("myRole", settings.KeepMajorityRole);
     }
     
     [Fact(DisplayName = "Keep oldest SBR set from Akka.Hosting should load")]
@@ -152,12 +152,12 @@ public class SplitBrainResolverSpecs
         });
 
         var system = host.Services.GetRequiredService<ActorSystem>();
-        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        Assert.IsType<SplitBrainResolverProvider>(Cluster.Get(system).DowningProvider);
         
         var settings = new SplitBrainResolverSettings(system.Settings.Config);
-        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.KeepOldestName);
-        settings.KeepOldestSettings.DownIfAlone.Should().BeFalse();
-        settings.KeepOldestSettings.Role.Should().Be("myRole");
+        Assert.Equal(SplitBrainResolverSettings.KeepOldestName, settings.DowningStrategy);
+        Assert.False(settings.KeepOldestSettings.DownIfAlone);
+        Assert.Equal("myRole", settings.KeepOldestSettings.Role);
     }
     
     [Fact(DisplayName = "Lease Majority SBR set from Akka.Hosting should load")]
@@ -178,13 +178,13 @@ public class SplitBrainResolverSpecs
         });
 
         var system = host.Services.GetRequiredService<ActorSystem>();
-        Cluster.Get(system).DowningProvider.Should().BeOfType<SplitBrainResolverProvider>();
+        Assert.IsType<SplitBrainResolverProvider>(Cluster.Get(system).DowningProvider);
         
         var settings = new SplitBrainResolverSettings(system.Settings.Config);
-        settings.DowningStrategy.Should().Be(SplitBrainResolverSettings.LeaseMajorityName);
-        settings.LeaseMajoritySettings.LeaseImplementation.Should().Be("test-lease");
-        settings.LeaseMajoritySettings.LeaseName.Should().Be("myService-akka-sbr");
-        settings.LeaseMajoritySettings.Role.Should().Be("myRole");
+        Assert.Equal(SplitBrainResolverSettings.LeaseMajorityName, settings.DowningStrategy);
+        Assert.Equal("test-lease", settings.LeaseMajoritySettings.LeaseImplementation);
+        Assert.Equal("myService-akka-sbr", settings.LeaseMajoritySettings.LeaseName);
+        Assert.Equal("myRole", settings.LeaseMajoritySettings.Role);
     }
     
 }

--- a/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
+++ b/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
@@ -59,4 +59,16 @@ public static class TestHelper
 
         return host;
     }
+    
+    public static TimeSpan Seconds(this double value)
+        => TimeSpan.FromSeconds(value);
+    
+    public static TimeSpan Seconds(this int value)
+        => TimeSpan.FromSeconds(value);
+    
+    public static TimeSpan Milliseconds(this double value)
+        => TimeSpan.FromMilliseconds(value);
+    
+    public static TimeSpan Milliseconds(this int value)
+        => TimeSpan.FromMilliseconds(value);
 }

--- a/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
+++ b/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -7,6 +9,7 @@ using Akka.Hosting;
 using Akka.Remote.Hosting;
 using Akka.TestKit.Xunit2.Internals;
 using Microsoft.Extensions.Hosting;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.Cluster.Hosting.Tests;
@@ -71,4 +74,9 @@ public static class TestHelper
     
     public static TimeSpan Milliseconds(this int value)
         => TimeSpan.FromMilliseconds(value);
+
+    public static void CollectionEquals<T>(this IEnumerable<T> list1, IEnumerable<T> list2)
+    {
+        Assert.Equal(list1.OrderBy(a => a), list2.OrderBy(a => a));
+    }
 }


### PR DESCRIPTION
Convert all asserts in Akka.Cluster.Hosting.Tests to use pure Xunit Assert calls