### PR TITLE
Update RELEASE_NOTES.md for 1.5.48 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
-#### 1.5.46 July 17th 2025 ####
+#### 1.5.48 August 22nd 2025 ####
 
-* [Bump AkkaVersion from 1.5.45 to 1.5.46](https://github.com/akkadotnet/akka.net/releases/tag/1.5.46)
+This release does not include the new healthcheck feature introduced in Akka.Hosting 1.5.47-beta1.
+
+* [Bump AkkaVersion from 1.5.46 to 1.5.48](https://github.com/akkadotnet/akka.net/releases/tag/1.5.48)
+* [Fix IndexOutOfRangeException bug in ConfigurationHoconAdapter](https://github.com/akkadotnet/Akka.Hosting/pull/632)
+* [Fix Akka.Hosting.TestKit deadlock on parallel unit test execution](https://github.com/akkadotnet/Akka.Hosting/pull/643)


### PR DESCRIPTION
## 1.5.48 August 22nd 2025

This release does not include the new healthcheck feature introduced in Akka.Hosting 1.5.47-beta1.

* [Bump AkkaVersion from 1.5.46 to 1.5.48](https://github.com/akkadotnet/akka.net/releases/tag/1.5.48)
* [Fix IndexOutOfRangeException bug in ConfigurationHoconAdapter](https://github.com/akkadotnet/Akka.Hosting/pull/632)
* [Fix Akka.Hosting.TestKit deadlock on parallel unit test execution](https://github.com/akkadotnet/Akka.Hosting/pull/643)
