### PR TITLE
Fix race condition in DiPropsFailTest when using DI-created actors

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -52,6 +52,7 @@ namespace Akka.Hosting.TestKit
         public Microsoft.Extensions.Logging.LogLevel LogLevel { get; }
         public Xunit.Abstractions.ITestOutputHelper? Output { get; }
         public System.TimeSpan StartupTimeout { get; }
+        public new Akka.Actor.ActorSystem Sys { get; }
         protected static Akka.TestKit.Xunit2.XunitAssertions Assertions { get; }
         protected virtual System.Threading.Tasks.Task AfterAllAsync() { }
         protected virtual System.Threading.Tasks.Task BeforeTestStart() { }

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -43,11 +43,26 @@ namespace Akka.Hosting.TestKit
             {
                 if(_host is null)
                     throw new XunitException("Test has not been initialized yet");
+                    
+                // Ensure implicit sender is set on current thread when accessing Host
+                EnsureImplicitSender();
                 return _host;
             }
         }
 
         public ActorRegistry ActorRegistry => Host.Services.GetRequiredService<ActorRegistry>();
+        
+        /// <summary>
+        /// Ensures the implicit sender is set on the current thread.
+        /// Called automatically when accessing Host or Sys.
+        /// </summary>
+        private void EnsureImplicitSender()
+        {
+            if (this is not INoImplicitSender && TestActor != null)
+            {
+                InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+            }
+        }
         
         public TimeSpan StartupTimeout { get; }
         public string ActorSystemName { get; }
@@ -193,8 +208,13 @@ namespace Akka.Hosting.TestKit
             
             registry.Register<TestProbe>(TestActor);
             
-            if (this is not INoImplicitSender && InternalCurrentActorCellKeeper.Current is null)
+            // ALWAYS set the implicit sender context on the current thread after initialization
+            // This ensures it's available on the thread where tests will run
+            // This is critical for tests using DI-created actors
+            if (this is not INoImplicitSender)
+            {
                 InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+            }
             
             await BeforeTestStart();
         }
@@ -203,9 +223,28 @@ namespace Akka.Hosting.TestKit
         {
             // no-op, deferring InitializeTest after Host have ran
         }
+        
+        /// <summary>
+        /// Override Sys property to ensure implicit sender is set when accessing the actor system
+        /// </summary>
+        public new ActorSystem Sys 
+        { 
+            get 
+            {
+                EnsureImplicitSender();
+                return base.Sys;
+            }
+        }
 
         protected virtual Task BeforeTestStart()
         {
+            // Ensure the implicit sender is set on the current thread before each test
+            // This is critical because tests may run on different threads than initialization
+            if (this is not INoImplicitSender)
+            {
+                InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+            }
+            
             return Task.CompletedTask;
         }
         


### PR DESCRIPTION
## Summary

This PR fixes a race condition in  that was introduced after PR #646. The test was intermittently failing in CI/CD with messages being sent to deadLetters instead of the TestActor.

## Root Cause

The issue was that  is thread-local, but xUnit may run test methods on different threads than where  runs. After PR #646's synchronization context changes, the implicit sender was being set during initialization but wasn't available on the test execution thread.

## The Fix

The solution ensures the implicit sender is always set on the current thread by:
- Adding an  method that sets the thread-local implicit sender
- Overriding the  property to call  before returning the actor system
- This ensures the implicit sender is properly set regardless of which thread the test runs on

## Test Results

Ran the previously failing test 20 times consecutively - all passed:
- Before fix: Test failed with timeout waiting for message (message went to deadLetters)
- After fix: All 20 runs passed successfully

## Related Issues

- Fixes the CI/CD failure that occurred after merging PR #646
- Related to issue #458 (which PR #646 was trying to fix)