### PR TITLE
Feature/Add dependency injection support for health checks

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "8.0.404"
+    "version": "8.0.302"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "8.0.302"
+    "version": "8.0.404"
   }
 }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -46,8 +46,6 @@ namespace Akka.Hosting
             where T : Akka.Actor.IExtensionId { }
         public Akka.Hosting.AkkaConfigurationBuilder WithExtensions(params System.Type[] extensions) { }
         public Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck(Akka.Hosting.AkkaHealthCheckRegistration registration) { }
-        public Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck<T>(Akka.Hosting.AkkaHealthCheckRegistration registrationTemplate)
-            where T :  class, Akka.Hosting.IAkkaHealthCheck { }
         public Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck<T>(string name, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default)
             where T :  class, Akka.Hosting.IAkkaHealthCheck { }
     }
@@ -60,11 +58,10 @@ namespace Akka.Hosting
     }
     public sealed class AkkaHealthCheckRegistration
     {
-        public AkkaHealthCheckRegistration(string name, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus, System.Collections.Generic.IEnumerable<string>? tags) { }
         public AkkaHealthCheckRegistration(string name, Akka.Hosting.IAkkaHealthCheck instance, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus, System.Collections.Generic.IEnumerable<string>? tags) { }
         public AkkaHealthCheckRegistration(string name, Akka.Hosting.IAkkaHealthCheck instance, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus, System.Collections.Generic.IEnumerable<string>? tags, System.TimeSpan? timeout) { }
+        public System.Func<System.IServiceProvider, Akka.Hosting.IAkkaHealthCheck> Factory { get; set; }
         public Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus FailureStatus { get; set; }
-        public Akka.Hosting.IAkkaHealthCheck HealthCheck { get; set; }
         public string Name { get; set; }
         public System.Collections.Generic.ISet<string> Tags { get; }
         public System.TimeSpan Timeout { get; set; }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -46,6 +46,10 @@ namespace Akka.Hosting
             where T : Akka.Actor.IExtensionId { }
         public Akka.Hosting.AkkaConfigurationBuilder WithExtensions(params System.Type[] extensions) { }
         public Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck(Akka.Hosting.AkkaHealthCheckRegistration registration) { }
+        public Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck<T>(Akka.Hosting.AkkaHealthCheckRegistration registrationTemplate)
+            where T :  class, Akka.Hosting.IAkkaHealthCheck { }
+        public Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck<T>(string name, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default)
+            where T :  class, Akka.Hosting.IAkkaHealthCheck { }
     }
     public sealed class AkkaHealthCheckContext
     {
@@ -56,6 +60,7 @@ namespace Akka.Hosting
     }
     public sealed class AkkaHealthCheckRegistration
     {
+        public AkkaHealthCheckRegistration(string name, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus, System.Collections.Generic.IEnumerable<string>? tags) { }
         public AkkaHealthCheckRegistration(string name, Akka.Hosting.IAkkaHealthCheck instance, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus, System.Collections.Generic.IEnumerable<string>? tags) { }
         public AkkaHealthCheckRegistration(string name, Akka.Hosting.IAkkaHealthCheck instance, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus, System.Collections.Generic.IEnumerable<string>? tags, System.TimeSpan? timeout) { }
         public Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus FailureStatus { get; set; }

--- a/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
+++ b/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
@@ -14,9 +14,11 @@ namespace Akka.Hosting.Tests.HealthChecks;
 
 public class HealthChecksSpec : TestKit.TestKit
 {
-    public HealthChecksSpec(ITestOutputHelper output) 
-        : base(output: output){ }
-    
+    public HealthChecksSpec(ITestOutputHelper output)
+        : base(output: output)
+    {
+    }
+
     private class FooActor : UntypedActor
     {
         protected override void OnReceive(object message)
@@ -29,44 +31,37 @@ public class HealthChecksSpec : TestKit.TestKit
         builder
             .WithActorSystemLivenessCheck() // have to opt-in to the built-in health check
             .WithHealthCheck("FooActor alive", async (system, registry, cancellationToken) =>
-        {
-            /*
-             * N.B. CancellationToken is set by the call to MSFT.EXT.DIAGNOSTICS.HEALTHCHECK,
-             * so that value could be "infinite" by default.
-             *
-             * Therefore, it might be a really, really good idea to guard this with a non-infinite
-             * timeout via a LinkedCancellationToken here.
-             */
-            try
             {
-                var fooActor = await registry.GetAsync<FooActor>(cancellationToken);
-
+                /*
+                 * N.B. CancellationToken is set by the call to MSFT.EXT.DIAGNOSTICS.HEALTHCHECK,
+                 * so that value could be "infinite" by default.
+                 *
+                 * Therefore, it might be a really, really good idea to guard this with a non-infinite
+                 * timeout via a LinkedCancellationToken here.
+                 */
                 try
                 {
-                    var r = await fooActor.Ask<ActorIdentity>(new Identify("foo"), cancellationToken: cancellationToken);
-                    if (r.Subject.IsNobody())
-                        return HealthCheckResult.Unhealthy("FooActor was alive but is now dead");
+                    var fooActor = await registry.GetAsync<FooActor>(cancellationToken);
+
+                    try
+                    {
+                        var r = await fooActor.Ask<ActorIdentity>(new Identify("foo"),
+                            cancellationToken: cancellationToken);
+                        if (r.Subject.IsNobody())
+                            return HealthCheckResult.Unhealthy("FooActor was alive but is now dead");
+                    }
+                    catch (Exception e)
+                    {
+                        return HealthCheckResult.Degraded("FooActor found but non-responsive", e);
+                    }
                 }
-                catch (Exception e)
+                catch (Exception e2)
                 {
-                    return HealthCheckResult.Degraded("FooActor found but non-responsive", e);
+                    return HealthCheckResult.Unhealthy("FooActor not found in registry", e2);
                 }
-            }
-            catch (Exception e2)
-            {
-                return HealthCheckResult.Unhealthy("FooActor not found in registry", e2);
-            }
 
-            return HealthCheckResult.Healthy("fooActor found and responsive");
-        });
-    }
-
-    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
-    {
-        // Register the test health check for DI resolution
-        services.AddTransient<TestDiHealthCheck>();
-
-        base.ConfigureServices(context, services);
+                return HealthCheckResult.Healthy("fooActor found and responsive");
+            });
     }
 
     [Fact]
@@ -74,24 +69,26 @@ public class HealthChecksSpec : TestKit.TestKit
     {
         // arrange
         var configurationBuilder = Host.Services.GetRequiredService<AkkaConfigurationBuilder>();
-        
+
         // act
-        
+
         // assert
         Assert.Equal(2, configurationBuilder.HealthChecks.Count); // 1 built-in, 1 custom
-        
+
         // find the built-in implementation
-        var actorSystemHealthCheckRegistration = configurationBuilder.HealthChecks.Values.Single(c => c.HealthCheck is ActorSystemLivenessCheck);
+        var actorSystemHealthCheckRegistration =
+            configurationBuilder.HealthChecks.Values.Single(c => c.Factory(Host.Services) is ActorSystemLivenessCheck);
         var akkaHealthCheckContext = new AkkaHealthCheckContext(Sys)
             { Registration = actorSystemHealthCheckRegistration.ToHealthCheckRegistration() };
-        
+
         // invoke the actorSystem liveness check
-        var healthCheckResult = await actorSystemHealthCheckRegistration.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
-        
+        var healthCheck = actorSystemHealthCheckRegistration.Factory(Host.Services);
+        var healthCheckResult = await healthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
+
         // assert - system is alive, health check should be healthy
         Assert.Equal(HealthStatus.Healthy, healthCheckResult.Status);
     }
-    
+
     [Fact]
     public async Task ShouldReturnAppropriateResults()
     {
@@ -100,11 +97,11 @@ public class HealthChecksSpec : TestKit.TestKit
 
         // act
         var customActorHealthCheck =
-            configurationBuilder.HealthChecks.Values.Single(c => c.HealthCheck is DelegateHealthCheck);
-        
+            configurationBuilder.HealthChecks.Values.Single(c => c.Factory(Host.Services) is DelegateHealthCheck);
+
         var akkaHealthCheckContext = new AkkaHealthCheckContext(Sys)
             { Registration = customActorHealthCheck.ToHealthCheckRegistration() };
-        
+
         // should fail - target actor is not alive
         await InvokeHealthCheck(HealthStatus.Unhealthy);
 
@@ -114,7 +111,7 @@ public class HealthChecksSpec : TestKit.TestKit
 
         // should succeed - target actor is around
         await InvokeHealthCheck(HealthStatus.Healthy, 3000);
-        
+
         // kill the target actor
         await WatchAsync(fooActor);
         fooActor.Tell(PoisonPill.Instance);
@@ -127,100 +124,99 @@ public class HealthChecksSpec : TestKit.TestKit
         async Task InvokeHealthCheck(HealthStatus expectedStatus, int waitMilliseconds = 1)
         {
             using var fastCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(waitMilliseconds));
-            var healthCheckResult = await customActorHealthCheck.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, fastCts.Token);
-            if(healthCheckResult.Description != null)
+            var healthCheck = customActorHealthCheck.Factory(Host.Services);
+            var healthCheckResult = await healthCheck.CheckHealthAsync(akkaHealthCheckContext, fastCts.Token);
+            if (healthCheckResult.Description != null)
                 Output?.WriteLine(healthCheckResult.Description);
             Assert.Equal(expectedStatus, healthCheckResult.Status);
         }
     }
-    
+
     [Fact]
     public async Task ShouldResolveDiHealthCheckFromContainer()
     {
         // arrange
         var configurationBuilder = Host.Services.GetRequiredService<AkkaConfigurationBuilder>();
-        
+
         // act - add a DI-resolved health check to the existing configuration
         configurationBuilder.WithHealthCheck<TestDiHealthCheck>("test-di-health");
-        
+
         // assert
         Assert.Equal(3, configurationBuilder.HealthChecks.Count); // 2 from base configuration + 1 DI-resolved
-        
+
         // find the DI-resolved health check
-        var diHealthCheckRegistration = configurationBuilder.HealthChecks.Values.Single(c => c.Name == "test-di-health");
+        var diHealthCheckRegistration =
+            configurationBuilder.HealthChecks.Values.Single(c => c.Name == "test-di-health");
         var akkaHealthCheckContext = new AkkaHealthCheckContext(Sys)
         {
             Registration = diHealthCheckRegistration.ToHealthCheckRegistration()
         };
-        
+
         // invoke the DI-resolved health check - TestDiHealthCheck is registered in ConfigureServices
-        var healthCheckResult = await diHealthCheckRegistration.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
-        
+        var healthCheck = diHealthCheckRegistration.Factory(Host.Services);
+        var healthCheckResult = await healthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
+
         // assert - health check should be healthy
         Assert.Equal(HealthStatus.Healthy, healthCheckResult.Status);
         Assert.Equal("Test DI health check is working with DI", healthCheckResult.Description);
     }
-    
+
     [Fact]
     public async Task ShouldResolveDiHealthCheckWithRegistrationTemplate()
     {
         // arrange
         var configurationBuilder = Host.Services.GetRequiredService<AkkaConfigurationBuilder>();
-        
+
         // act - add a DI-resolved health check using the registration template pattern
-        configurationBuilder.WithHealthCheck<TestDiHealthCheck>(new AkkaHealthCheckRegistration(
-            "template-test", 
+        configurationBuilder.WithHealthCheck<TestDiHealthCheck>(
+            "template-test",
             HealthStatus.Degraded,
-            new[]
-            {
+            [
                 "custom", "test"
-            }));
-        
+            ]);
+
         // assert
         Assert.Equal(3, configurationBuilder.HealthChecks.Count); // 2 from base configuration + 1 DI-resolved
-        
+
         // find the DI-resolved health check
         var diHealthCheckRegistration = configurationBuilder.HealthChecks.Values.Single(c => c.Name == "template-test");
         Assert.Equal(HealthStatus.Degraded, diHealthCheckRegistration.FailureStatus);
         Assert.Contains("custom", diHealthCheckRegistration.Tags);
         Assert.Contains("test", diHealthCheckRegistration.Tags);
-        
+
         var akkaHealthCheckContext = new AkkaHealthCheckContext(Sys)
             { Registration = diHealthCheckRegistration.ToHealthCheckRegistration() };
-        
+
         // invoke the health check
-        var healthCheckResult = await diHealthCheckRegistration.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
-        
+        var healthCheck = diHealthCheckRegistration.Factory(Host.Services);
+        var healthCheckResult = await healthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
+
         // assert
         Assert.Equal(HealthStatus.Healthy, healthCheckResult.Status);
         Assert.Equal("Test DI health check is working with DI", healthCheckResult.Description);
     }
-    
+
     /// <summary>
     /// Test health check class that requires DI (simulates ILogger dependency)
     /// </summary>
     private class TestDiHealthCheck : IAkkaHealthCheck
     {
         private readonly IServiceProvider? _serviceProvider;
-        
-        public TestDiHealthCheck()
-        {
-            // Parameterless constructor for manual creation
-        }
-        
+
         public TestDiHealthCheck(IServiceProvider serviceProvider)
         {
             // Constructor with DI dependency
             _serviceProvider = serviceProvider;
         }
-        
-        public Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
+
+        public Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context,
+            CancellationToken cancellationToken = default)
         {
             // Verify that dependencies can be resolved (simulates ILogger usage)
             var hasServiceProvider = _serviceProvider != null;
-            
-            return Task.FromResult(HealthCheckResult.Healthy("Test DI health check is working" + 
-                (hasServiceProvider ? " with DI" : "")));
+
+            return Task.FromResult(HealthCheckResult.Healthy("Test DI health check is working" +
+                                                             (hasServiceProvider ? " with DI" : "")));
         }
     }
 }

--- a/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
+++ b/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
@@ -124,4 +124,94 @@ public class HealthChecksSpec : TestKit.TestKit
             Assert.Equal(expectedStatus, healthCheckResult.Status);
         }
     }
+    
+    [Fact]
+    public async Task ShouldResolveDiHealthCheckWithoutRegistration()
+    {
+        // arrange
+        var configurationBuilder = Host.Services.GetRequiredService<AkkaConfigurationBuilder>();
+        
+        // act - add a DI-resolved health check to the existing configuration
+        configurationBuilder.WithHealthCheck<TestDiHealthCheck>("test-di-health");
+        
+        // assert
+        Assert.Equal(3, configurationBuilder.HealthChecks.Count); // 2 from base configuration + 1 DI-resolved
+        
+        // find the DI-resolved health check
+        var diHealthCheckRegistration = configurationBuilder.HealthChecks.Values.Single(c => c.Name == "test-di-health");
+        var akkaHealthCheckContext = new AkkaHealthCheckContext(Sys)
+        {
+            Registration = diHealthCheckRegistration.ToHealthCheckRegistration()
+        };
+        
+        // invoke the DI-resolved health check - should work even though TestDiHealthCheck wasn't registered in DI
+        var healthCheckResult = await diHealthCheckRegistration.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
+        
+        // assert - health check should be healthy
+        Assert.Equal(HealthStatus.Healthy, healthCheckResult.Status);
+        Assert.Equal("Test DI health check is working with DI", healthCheckResult.Description);
+    }
+    
+    [Fact]
+    public async Task ShouldResolveDiHealthCheckWithRegistrationTemplate()
+    {
+        // arrange
+        var configurationBuilder = Host.Services.GetRequiredService<AkkaConfigurationBuilder>();
+        
+        // act - add a DI-resolved health check using the registration template pattern
+        configurationBuilder.WithHealthCheck<TestDiHealthCheck>(new AkkaHealthCheckRegistration(
+            "template-test", 
+            HealthStatus.Degraded,
+            new[]
+            {
+                "custom", "test"
+            }));
+        
+        // assert
+        Assert.Equal(3, configurationBuilder.HealthChecks.Count); // 2 from base configuration + 1 DI-resolved
+        
+        // find the DI-resolved health check
+        var diHealthCheckRegistration = configurationBuilder.HealthChecks.Values.Single(c => c.Name == "template-test");
+        Assert.Equal(HealthStatus.Degraded, diHealthCheckRegistration.FailureStatus);
+        Assert.Contains("custom", diHealthCheckRegistration.Tags);
+        Assert.Contains("test", diHealthCheckRegistration.Tags);
+        
+        var akkaHealthCheckContext = new AkkaHealthCheckContext(Sys)
+            { Registration = diHealthCheckRegistration.ToHealthCheckRegistration() };
+        
+        // invoke the health check
+        var healthCheckResult = await diHealthCheckRegistration.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
+        
+        // assert
+        Assert.Equal(HealthStatus.Healthy, healthCheckResult.Status);
+        Assert.Equal("Test DI health check is working with DI", healthCheckResult.Description);
+    }
+    
+    /// <summary>
+    /// Test health check class that requires DI (simulates ILogger dependency)
+    /// </summary>
+    private class TestDiHealthCheck : IAkkaHealthCheck
+    {
+        private readonly IServiceProvider? _serviceProvider;
+        
+        public TestDiHealthCheck()
+        {
+            // Parameterless constructor for manual creation
+        }
+        
+        public TestDiHealthCheck(IServiceProvider serviceProvider)
+        {
+            // Constructor with DI dependency
+            _serviceProvider = serviceProvider;
+        }
+        
+        public Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            // Verify that dependencies can be resolved (simulates ILogger usage)
+            var hasServiceProvider = _serviceProvider != null;
+            
+            return Task.FromResult(HealthCheckResult.Healthy("Test DI health check is working" + 
+                (hasServiceProvider ? " with DI" : "")));
+        }
+    }
 }

--- a/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
+++ b/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
@@ -6,6 +6,7 @@ using Akka.Actor;
 using Akka.Hosting.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -58,6 +59,14 @@ public class HealthChecksSpec : TestKit.TestKit
 
             return HealthCheckResult.Healthy("fooActor found and responsive");
         });
+    }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        // Register the test health check for DI resolution
+        services.AddTransient<TestDiHealthCheck>();
+
+        base.ConfigureServices(context, services);
     }
 
     [Fact]
@@ -126,7 +135,7 @@ public class HealthChecksSpec : TestKit.TestKit
     }
     
     [Fact]
-    public async Task ShouldResolveDiHealthCheckWithoutRegistration()
+    public async Task ShouldResolveDiHealthCheckFromContainer()
     {
         // arrange
         var configurationBuilder = Host.Services.GetRequiredService<AkkaConfigurationBuilder>();
@@ -144,7 +153,7 @@ public class HealthChecksSpec : TestKit.TestKit
             Registration = diHealthCheckRegistration.ToHealthCheckRegistration()
         };
         
-        // invoke the DI-resolved health check - should work even though TestDiHealthCheck wasn't registered in DI
+        // invoke the DI-resolved health check - TestDiHealthCheck is registered in ConfigureServices
         var healthCheckResult = await diHealthCheckRegistration.HealthCheck.CheckHealthAsync(akkaHealthCheckContext, CancellationToken.None);
         
         // assert - health check should be healthy

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
@@ -79,6 +80,64 @@ namespace Akka.Hosting
         public Func<ExtendedActorSystem, Serializer> SerializerFactory { get; }
 
         public ImmutableHashSet<Type> TypeBindings { get; }
+    }
+
+    /// <summary>
+    /// A wrapper health check that resolves the actual health check from the DI container when needed.
+    /// </summary>
+    /// <typeparam name="T">The type of health check to resolve.</typeparam>
+    internal sealed class DiResolvedHealthCheck<T> : IAkkaHealthCheck where T : class, IAkkaHealthCheck
+    {
+        public async Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            // Get the DI resolver from the actor system
+            var diResolver = DependencyResolver.For(context.ActorSystem);
+            
+            // Try to resolve the actual health check from DI first
+            var healthCheck = diResolver.Resolver.GetService<T>();
+            
+            // If not available in DI, create manually by resolving dependencies
+            if (healthCheck == null)
+            {
+                healthCheck = CreateHealthCheckInstance<T>(diResolver.Resolver);
+            }
+            
+            // Delegate to the resolved health check
+            return await healthCheck.CheckHealthAsync(context, cancellationToken);
+        }
+        
+        private static T CreateHealthCheckInstance<THealthCheck>(IDependencyResolver serviceProvider) where THealthCheck : class, IAkkaHealthCheck
+        {
+            var constructors = typeof(THealthCheck).GetConstructors()
+                .OrderByDescending(c => c.GetParameters().Length)
+                .ToArray();
+            
+            foreach (var constructor in constructors)
+            {
+                var parameters = constructor.GetParameters();
+                var args = new object[parameters.Length];
+                var canResolveAllParams = true;
+                
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    var param = parameters[i];
+                    var service = serviceProvider.GetService(param.ParameterType);
+                    if (service == null)
+                    {
+                        canResolveAllParams = false;
+                        break;
+                    }
+                    args[i] = service;
+                }
+                
+                if (canResolveAllParams)
+                {
+                    return (T)Activator.CreateInstance(typeof(THealthCheck), args)!;
+                }
+            }
+            
+            throw new InvalidOperationException($"Unable to create instance of {typeof(THealthCheck).Name}. Could not resolve all constructor dependencies from the service provider.");
+        }
     }
 
     public sealed class AkkaConfigurationBuilder
@@ -344,6 +403,50 @@ namespace Akka.Hosting
         /// <param name="registration">The health check registration.</param>
         public AkkaConfigurationBuilder WithHealthCheck(AkkaHealthCheckRegistration registration)
         {
+            HealthChecks[registration.Name] = registration;
+            return this;
+        }
+        
+        /// <summary>
+        /// Registers a DI-resolved health check with the <see cref="AkkaConfigurationBuilder"/>.
+        /// The health check type will be registered as a transient service and resolved from the DI container.
+        /// </summary>
+        /// <param name="name">The healthcheck name.</param>
+        /// <param name="failureStatus">
+        /// The <see cref="HealthStatus"/> that should be reported upon failure of the health check. If the provided value
+        /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
+        /// </param>
+        /// <param name="tags">A list of tags that can be used for filtering health checks.</param>
+        /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+        /// <typeparam name="T">The type of the health check that implements <see cref="IAkkaHealthCheck"/>.</typeparam>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public AkkaConfigurationBuilder WithHealthCheck<T>(string name, HealthStatus? failureStatus = null, 
+            IEnumerable<string>? tags = null, TimeSpan? timeout = null) where T : class, IAkkaHealthCheck
+        {
+            // Create a health check instance that will be resolved from DI when needed
+            var healthCheckInstance = new DiResolvedHealthCheck<T>();
+            var registration = new AkkaHealthCheckRegistration(name, healthCheckInstance, failureStatus, tags, timeout);
+            
+            HealthChecks[registration.Name] = registration;
+            return this;
+        }
+        
+        /// <summary>
+        /// Registers a DI-resolved health check with the <see cref="AkkaConfigurationBuilder"/> using the specified registration template.
+        /// The health check type will be registered as a transient service and resolved from the DI container.
+        /// </summary>
+        /// <param name="registrationTemplate">The health check registration template (name, failure status, tags, timeout).</param>
+        /// <typeparam name="T">The type of the health check that implements <see cref="IAkkaHealthCheck"/>.</typeparam>
+        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
+        public AkkaConfigurationBuilder WithHealthCheck<T>(AkkaHealthCheckRegistration registrationTemplate) where T : class, IAkkaHealthCheck
+        {
+            // Create a health check instance that will be resolved from DI when needed
+            var healthCheckInstance = new DiResolvedHealthCheck<T>();
+            
+            // Create the actual registration with the resolved health check
+            var registration = new AkkaHealthCheckRegistration(registrationTemplate.Name, healthCheckInstance,
+                registrationTemplate.FailureStatus, registrationTemplate.Tags, registrationTemplate.Timeout);
+            
             HealthChecks[registration.Name] = registration;
             return this;
         }

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -93,50 +93,16 @@ namespace Akka.Hosting
             // Get the DI resolver from the actor system
             var diResolver = DependencyResolver.For(context.ActorSystem);
             
-            // Try to resolve the actual health check from DI first
+            // Resolve the health check from DI - will throw if not registered
             var healthCheck = diResolver.Resolver.GetService<T>();
-            
-            // If not available in DI, create manually by resolving dependencies
             if (healthCheck == null)
             {
-                healthCheck = CreateHealthCheckInstance<T>(diResolver.Resolver);
+                throw new InvalidOperationException($"Health check type '{typeof(T).Name}' is not registered in the dependency injection container. " +
+                    $"Register the health check type using services.AddTransient<{typeof(T).Name}>() or similar in your DI configuration.");
             }
             
             // Delegate to the resolved health check
             return await healthCheck.CheckHealthAsync(context, cancellationToken);
-        }
-        
-        private static T CreateHealthCheckInstance<THealthCheck>(IDependencyResolver serviceProvider) where THealthCheck : class, IAkkaHealthCheck
-        {
-            var constructors = typeof(THealthCheck).GetConstructors()
-                .OrderByDescending(c => c.GetParameters().Length)
-                .ToArray();
-            
-            foreach (var constructor in constructors)
-            {
-                var parameters = constructor.GetParameters();
-                var args = new object[parameters.Length];
-                var canResolveAllParams = true;
-                
-                for (int i = 0; i < parameters.Length; i++)
-                {
-                    var param = parameters[i];
-                    var service = serviceProvider.GetService(param.ParameterType);
-                    if (service == null)
-                    {
-                        canResolveAllParams = false;
-                        break;
-                    }
-                    args[i] = service;
-                }
-                
-                if (canResolveAllParams)
-                {
-                    return (T)Activator.CreateInstance(typeof(THealthCheck), args)!;
-                }
-            }
-            
-            throw new InvalidOperationException($"Unable to create instance of {typeof(THealthCheck).Name}. Could not resolve all constructor dependencies from the service provider.");
         }
     }
 
@@ -409,7 +375,7 @@ namespace Akka.Hosting
         
         /// <summary>
         /// Registers a DI-resolved health check with the <see cref="AkkaConfigurationBuilder"/>.
-        /// The health check type will be registered as a transient service and resolved from the DI container.
+        /// The health check type must be registered in the DI container.
         /// </summary>
         /// <param name="name">The healthcheck name.</param>
         /// <param name="failureStatus">
@@ -433,7 +399,7 @@ namespace Akka.Hosting
         
         /// <summary>
         /// Registers a DI-resolved health check with the <see cref="AkkaConfigurationBuilder"/> using the specified registration template.
-        /// The health check type will be registered as a transient service and resolved from the DI container.
+        /// The health check type must be registered in the DI container.
         /// </summary>
         /// <param name="registrationTemplate">The health check registration template (name, failure status, tags, timeout).</param>
         /// <typeparam name="T">The type of the health check that implements <see cref="IAkkaHealthCheck"/>.</typeparam>

--- a/src/Akka.Hosting/AkkaConfigurationBuilder.cs
+++ b/src/Akka.Hosting/AkkaConfigurationBuilder.cs
@@ -82,30 +82,6 @@ namespace Akka.Hosting
         public ImmutableHashSet<Type> TypeBindings { get; }
     }
 
-    /// <summary>
-    /// A wrapper health check that resolves the actual health check from the DI container when needed.
-    /// </summary>
-    /// <typeparam name="T">The type of health check to resolve.</typeparam>
-    internal sealed class DiResolvedHealthCheck<T> : IAkkaHealthCheck where T : class, IAkkaHealthCheck
-    {
-        public async Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
-        {
-            // Get the DI resolver from the actor system
-            var diResolver = DependencyResolver.For(context.ActorSystem);
-            
-            // Resolve the health check from DI - will throw if not registered
-            var healthCheck = diResolver.Resolver.GetService<T>();
-            if (healthCheck == null)
-            {
-                throw new InvalidOperationException($"Health check type '{typeof(T).Name}' is not registered in the dependency injection container. " +
-                    $"Register the health check type using services.AddTransient<{typeof(T).Name}>() or similar in your DI configuration.");
-            }
-            
-            // Delegate to the resolved health check
-            return await healthCheck.CheckHealthAsync(context, cancellationToken);
-        }
-    }
-
     public sealed class AkkaConfigurationBuilder
     {
         internal readonly string ActorSystemName;
@@ -390,31 +366,12 @@ namespace Akka.Hosting
             IEnumerable<string>? tags = null, TimeSpan? timeout = null) where T : class, IAkkaHealthCheck
         {
             // Create a health check instance that will be resolved from DI when needed
-            var healthCheckInstance = new DiResolvedHealthCheck<T>();
-            var registration = new AkkaHealthCheckRegistration(name, healthCheckInstance, failureStatus, tags, timeout);
+            var registration = new AkkaHealthCheckRegistration(name, GetServiceOrCreateInstance, failureStatus, tags, timeout);
             
             HealthChecks[registration.Name] = registration;
             return this;
-        }
-        
-        /// <summary>
-        /// Registers a DI-resolved health check with the <see cref="AkkaConfigurationBuilder"/> using the specified registration template.
-        /// The health check type must be registered in the DI container.
-        /// </summary>
-        /// <param name="registrationTemplate">The health check registration template (name, failure status, tags, timeout).</param>
-        /// <typeparam name="T">The type of the health check that implements <see cref="IAkkaHealthCheck"/>.</typeparam>
-        /// <returns>The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.</returns>
-        public AkkaConfigurationBuilder WithHealthCheck<T>(AkkaHealthCheckRegistration registrationTemplate) where T : class, IAkkaHealthCheck
-        {
-            // Create a health check instance that will be resolved from DI when needed
-            var healthCheckInstance = new DiResolvedHealthCheck<T>();
             
-            // Create the actual registration with the resolved health check
-            var registration = new AkkaHealthCheckRegistration(registrationTemplate.Name, healthCheckInstance,
-                registrationTemplate.FailureStatus, registrationTemplate.Tags, registrationTemplate.Timeout);
-            
-            HealthChecks[registration.Name] = registration;
-            return this;
+            static T GetServiceOrCreateInstance(IServiceProvider sp) => ActivatorUtilities.GetServiceOrCreateInstance<T>(sp);
         }
         
         internal void Bind()

--- a/src/Akka.Hosting/HealthChecks/AkkaHealthCheckExtensions.cs
+++ b/src/Akka.Hosting/HealthChecks/AkkaHealthCheckExtensions.cs
@@ -17,7 +17,7 @@ internal static class AkkaHealthCheckExtensions
     {
         // func for lazily instantiating the health check registration
         Func<IServiceProvider, IHealthCheck> adapter = provider =>
-            new HealthCheckAdapter(registration.HealthCheck, provider.GetRequiredService<ActorSystem>());
+            new HealthCheckAdapter(registration.Factory(provider), provider.GetRequiredService<ActorSystem>());
 
         var tags = registration.Tags;
         tags.Add(AkkaTag);

--- a/src/Akka.Hosting/IAkkaHealthCheck.cs
+++ b/src/Akka.Hosting/IAkkaHealthCheck.cs
@@ -16,7 +16,7 @@ namespace Akka.Hosting;
 /// </remarks>
 public sealed class AkkaHealthCheckRegistration
 {
-    private IAkkaHealthCheck _healthCheck;
+    private Func<IServiceProvider, IAkkaHealthCheck> _healthCheck;
     private string _name;
     private TimeSpan _timeout;
     
@@ -65,15 +65,16 @@ public sealed class AkkaHealthCheckRegistration
         _name = name;
         FailureStatus = failureStatus ?? HealthStatus.Unhealthy;
         Tags = new HashSet<string>(tags ?? [], StringComparer.OrdinalIgnoreCase);
-        _healthCheck  = instance;
+        _healthCheck  = _ => instance;
         Timeout = timeout ?? System.Threading.Timeout.InfiniteTimeSpan;
     }
-    
+
     /// <summary>
     /// Creates a new <see cref="AkkaHealthCheckRegistration"/> template for use with DI-resolved health checks.
     /// This constructor is intended for use with generic health check registration methods.
     /// </summary>
     /// <param name="name">The healthcheck name.</param>
+    /// <param name="factory">The DI-enabled factory.</param>
     /// <param name="failureStatus">
     /// The <see cref="HealthStatus"/> that should be reported upon failure of the health check. If the provided value
     /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
@@ -82,13 +83,14 @@ public sealed class AkkaHealthCheckRegistration
     /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
     /// <exception cref="ArgumentNullException">Thrown if <see cref="name"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if a negative timeout other than <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> is used.</exception>
-    internal AkkaHealthCheckRegistration(string name, HealthStatus? failureStatus,
+    internal AkkaHealthCheckRegistration(string name, Func<IServiceProvider, IAkkaHealthCheck> factory, HealthStatus? failureStatus,
         IEnumerable<string>? tags, TimeSpan? timeout)
     {
         if (name == null)
         {
             throw new ArgumentNullException(nameof(name));
         }
+        if(factory == null) throw new ArgumentNullException(nameof(factory));
 
         if (timeout <= TimeSpan.Zero && timeout != System.Threading.Timeout.InfiniteTimeSpan)
         {
@@ -98,24 +100,8 @@ public sealed class AkkaHealthCheckRegistration
         _name = name;
         FailureStatus = failureStatus ?? HealthStatus.Unhealthy;
         Tags = new HashSet<string>(tags ?? [], StringComparer.OrdinalIgnoreCase);
-        _healthCheck = null!; // Will be set by the generic method
+        _healthCheck = factory;
         Timeout = timeout ?? System.Threading.Timeout.InfiniteTimeSpan;
-    }
-    
-    /// <summary>
-    /// Creates a new <see cref="AkkaHealthCheckRegistration"/> for use with DI-resolved health checks.
-    /// This constructor is intended for use with the generic <c>WithHealthCheck&lt;T&gt;</c> method.
-    /// </summary>
-    /// <param name="name">The healthcheck name.</param>
-    /// <param name="failureStatus">
-    /// The <see cref="HealthStatus"/> that should be reported upon failure of the health check. If the provided value
-    /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
-    /// </param>
-    /// <param name="tags">A list of tags that can be used for filtering health checks.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <see cref="name"/> is null.</exception>
-    public AkkaHealthCheckRegistration(string name, HealthStatus? failureStatus, IEnumerable<string>? tags) 
-        : this(name, failureStatus, tags, null)
-    {
     }
     
     /// <summary>
@@ -131,7 +117,7 @@ public sealed class AkkaHealthCheckRegistration
     /// Gets or sets the <see cref="IAkkaHealthCheck"/>
     /// </summary>
     /// <exception cref="ArgumentNullException"></exception>
-    public IAkkaHealthCheck HealthCheck
+    public Func<IServiceProvider,IAkkaHealthCheck> Factory
     {
         get => _healthCheck;
         set => _healthCheck = value ?? throw new ArgumentNullException(nameof(value));

--- a/src/Akka.Hosting/IAkkaHealthCheck.cs
+++ b/src/Akka.Hosting/IAkkaHealthCheck.cs
@@ -70,6 +70,55 @@ public sealed class AkkaHealthCheckRegistration
     }
     
     /// <summary>
+    /// Creates a new <see cref="AkkaHealthCheckRegistration"/> template for use with DI-resolved health checks.
+    /// This constructor is intended for use with generic health check registration methods.
+    /// </summary>
+    /// <param name="name">The healthcheck name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported upon failure of the health check. If the provided value
+    /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used for filtering health checks.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <see cref="name"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if a negative timeout other than <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> is used.</exception>
+    internal AkkaHealthCheckRegistration(string name, HealthStatus? failureStatus,
+        IEnumerable<string>? tags, TimeSpan? timeout)
+    {
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        if (timeout <= TimeSpan.Zero && timeout != System.Threading.Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+        _name = name;
+        FailureStatus = failureStatus ?? HealthStatus.Unhealthy;
+        Tags = new HashSet<string>(tags ?? [], StringComparer.OrdinalIgnoreCase);
+        _healthCheck = null!; // Will be set by the generic method
+        Timeout = timeout ?? System.Threading.Timeout.InfiniteTimeSpan;
+    }
+    
+    /// <summary>
+    /// Creates a new <see cref="AkkaHealthCheckRegistration"/> for use with DI-resolved health checks.
+    /// This constructor is intended for use with the generic <c>WithHealthCheck&lt;T&gt;</c> method.
+    /// </summary>
+    /// <param name="name">The healthcheck name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported upon failure of the health check. If the provided value
+    /// is <c>null</c>, then <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used for filtering health checks.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <see cref="name"/> is null.</exception>
+    public AkkaHealthCheckRegistration(string name, HealthStatus? failureStatus, IEnumerable<string>? tags) 
+        : this(name, failureStatus, tags, null)
+    {
+    }
+    
+    /// <summary>
     /// Gets or sets the healthcheck name.
     /// </summary>
     public string Name

--- a/src/Examples/Akka.Hosting.Asp.LoggingDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.Asp.LoggingDemo/Program.cs
@@ -13,6 +13,9 @@ using LogLevel = Akka.Event.LogLevel;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHealthChecks();
 
+// This is required for WithHealthCheck<T> call
+builder.Services.AddTransient<TestHealth>();
+
 builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider) =>
 {
     configurationBuilder

--- a/src/Examples/Akka.Hosting.Asp.LoggingDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.Asp.LoggingDemo/Program.cs
@@ -7,6 +7,7 @@ using Akka.Event;
 using Akka.Hosting.Asp.LoggingDemo;
 using Akka.Remote.Hosting;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using LogLevel = Akka.Event.LogLevel;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,8 +35,9 @@ builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider
             Roles = ["myRole"], 
             SeedNodes = ["akka.tcp://MyActorSystem@localhost:8110"]
         })
-        .WithActorSystemLivenessCheck()
         .WithAkkaClusterReadinessCheck()
+        .WithActorSystemLivenessCheck()
+        .WithHealthCheck<TestHealth>("test", HealthStatus.Unhealthy, new[] { "test", "custom" })
         .WithActors((system, registry) =>
         {
             var echo = system.ActorOf(act =>

--- a/src/Examples/Akka.Hosting.Asp.LoggingDemo/Program.cs
+++ b/src/Examples/Akka.Hosting.Asp.LoggingDemo/Program.cs
@@ -13,9 +13,6 @@ using LogLevel = Akka.Event.LogLevel;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHealthChecks();
 
-// This is required for WithHealthCheck<T> call
-builder.Services.AddTransient<TestHealth>();
-
 builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider) =>
 {
     configurationBuilder
@@ -40,7 +37,7 @@ builder.Services.AddAkka("MyActorSystem", (configurationBuilder, serviceProvider
         })
         .WithAkkaClusterReadinessCheck()
         .WithActorSystemLivenessCheck()
-        .WithHealthCheck<TestHealth>("test", HealthStatus.Unhealthy, new[] { "test", "custom" })
+        .WithHealthCheck<TestHealth>("di-test", HealthStatus.Unhealthy, new[] { "test", "custom" })
         .WithActors((system, registry) =>
         {
             var echo = system.ActorOf(act =>

--- a/src/Examples/Akka.Hosting.Asp.LoggingDemo/TestHealthCheck.cs
+++ b/src/Examples/Akka.Hosting.Asp.LoggingDemo/TestHealthCheck.cs
@@ -15,6 +15,7 @@ namespace Akka.Hosting.Asp.LoggingDemo
         {
             try
             {
+                _logger.LogInformation("DI healthcheck is running");
                 return Task.FromResult(HealthCheckResult.Healthy("Test is healthy"));
             }
             catch (Exception ex)

--- a/src/Examples/Akka.Hosting.Asp.LoggingDemo/TestHealthCheck.cs
+++ b/src/Examples/Akka.Hosting.Asp.LoggingDemo/TestHealthCheck.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Akka.Hosting.Asp.LoggingDemo
+{
+    public class TestHealth : IAkkaHealthCheck
+    {
+        private readonly ILogger<TestHealth> _logger;
+
+        public TestHealth(ILogger<TestHealth> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(AkkaHealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Task.FromResult(HealthCheckResult.Healthy("Test is healthy"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Health check failed for test");
+                return Task.FromResult(HealthCheckResult.Unhealthy($"Test health check failed: {ex.Message}"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #N/A

## Changes

This PR adds dependency injection support for health checks, enabling seamless registration of health checks that require constructor dependencies like `ILogger<T>`, dbcontexts or any other services.

### New API Methods
- `WithHealthCheck<T>(string name, HealthStatus?, IEnumerable<string>?, TimeSpan?)` - Simple DI-resolved health check registration
- `WithHealthCheck<T>(AkkaHealthCheckRegistration)` - Template based registration with custom configuration

### Implementation Details
- **`DiResolvedHealthCheck<T>`**: Internal wrapper that resolves health checks from DI at runtime
- **New ctor**: Added `AkkaHealthCheckRegistration(string, HealthStatus?, IEnumerable<string>?)` for template usage

### Key Features
- Dependency injection support for health check ctors
- Automatic fallback to manual instance creation with reflection when needed

### Usage Example
```csharp
// Before: Manual injection
.WithHealthCheck(new AkkaHealthCheckRegistration("test", 
    new TestHealth(logger), // Manually supplied parameters
    HealthStatus.Unhealthy, new[] { "test" }))

// After: DI integration
.WithHealthCheck<TestHealth>("test", HealthStatus.Unhealthy, new[] { "test" })

// Or using the template
.WithHealthCheck<TestHealth>(new AkkaHealthCheckRegistration("test", 
    HealthStatus.Unhealthy, new[] { "test" }))
```

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
