### PR TITLE
Fix journal health check registration without event adapters

### DIFF
--- a/src/Akka.Persistence.Hosting.Tests/UnifiedApiSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/UnifiedApiSpecs.cs
@@ -286,6 +286,56 @@ public sealed class JournalAndSnapshotWithBuildersSpec : Akka.Hosting.TestKit.Te
 }
 
 /// <summary>
+/// Regression test for https://github.com/akkadotnet/Akka.Hosting/issues/666
+/// Ensures journal health checks are registered even without event adapters
+/// </summary>
+public sealed class JournalHealthCheckWithoutAdaptersSpec : Akka.Hosting.TestKit.TestKit
+{
+    public JournalHealthCheckWithoutAdaptersSpec(ITestOutputHelper output) : base(output: output)
+    {
+    }
+
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        base.ConfigureServices(context, services);
+        services.AddHealthChecks();
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        var journalOptions = new UnifiedApiTestResources.TestJournalOptions { IsDefaultPlugin = true };
+
+        // Configure journal with health check but WITHOUT any event adapters
+        // This is the regression case from issue #666
+        builder.WithJournal(
+            journalOptions,
+            journal => journal.WithHealthCheck());
+    }
+
+    [Fact]
+    public async Task Journal_health_check_should_be_registered_without_event_adapters()
+    {
+        // assert - journal plugin configured
+        var config = Sys.Settings.Config;
+        config.HasPath("akka.persistence.journal.test-journal")
+            .Should().BeTrue();
+
+        // assert - health check is registered even without event adapters
+        var healthCheckService = Host.Services.GetRequiredService<HealthCheckService>();
+        var result = await healthCheckService.CheckHealthAsync();
+
+        result.Status.Should().Be(HealthStatus.Healthy,
+            "journal health check should be healthy");
+
+        // Verify journal health check is present
+        var journalCheck = result.Entries.FirstOrDefault(e => e.Key.Contains("test-journal"));
+        journalCheck.Should().NotBeNull("journal health check should be registered even without event adapters");
+        journalCheck.Value.Status.Should().Be(HealthStatus.Healthy,
+            "journal health check should return healthy status");
+    }
+}
+
+/// <summary>
 /// Test null builder actions work correctly
 /// </summary>
 public sealed class NullBuilderActionsSpec : Akka.Hosting.TestKit.TestKit

--- a/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
+++ b/src/Akka.Persistence.Hosting/AkkaPersistenceHostingExtensions.cs
@@ -112,6 +112,10 @@ namespace Akka.Persistence.Hosting
         /// </summary>
         internal void Build()
         {
+            // add the health checks if specified - do this FIRST before any early returns
+            if(HealthCheckRegistration != null)
+                Builder.WithHealthCheck(HealthCheckRegistration);
+
             // useless configuration - don't bother.
             if (Adapters.Count == 0 || Bindings.Count == 0)
                 return;
@@ -126,10 +130,6 @@ namespace Akka.Persistence.Hosting
             var finalHocon = ConfigurationFactory.ParseString(adapters.ToString())
                 .WithFallback(Persistence.DefaultConfig()); // add the default config as a fallback
             Builder.AddHocon(finalHocon, HoconAddMode.Prepend);
-            
-            // add the health checks if specified
-            if(HealthCheckRegistration != null)
-                Builder.WithHealthCheck(HealthCheckRegistration);
         }
 
         internal void AppendAdapters(StringBuilder sb)


### PR DESCRIPTION
Fixes #666

## Summary
Journal health checks were not being registered when using `.WithHealthCheck()` without adding event adapters. This was caused by an early return in `AkkaPersistenceJournalBuilder.Build()` that exited before health check registration occurred.

## Changes
- Moved health check registration before the early return in `AkkaPersistenceHostingExtensions.cs:113-133` to ensure health checks are registered regardless of event adapter configuration
- Added regression test `JournalHealthCheckWithoutAdaptersSpec` that verifies health checks work without event adapters

## Testing
All 16 persistence hosting tests pass, including the new regression test that specifically tests the bug scenario.