### PR TITLE
Update RELEASE_NOTES.md for 1.5.52 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2025 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.51.1</VersionPrefix>
-    <PackageReleaseNotes>**Bug Fixes**
-* [Fix journal health check registration without event adapters](https://github.com/akkadotnet/Akka.Hosting/pull/667) - resolved [issue #666](https://github.com/akkadotnet/Akka.Hosting/issues/666) where journal health checks were not being registered when using `.WithHealthCheck()` without adding event adapters</PackageReleaseNotes>
+    <VersionPrefix>1.5.52</VersionPrefix>
+    <PackageReleaseNotes>**API Changes**
+* [Deprecate JournalOptions.Adapters property in favor of callback API](https://github.com/akkadotnet/Akka.Hosting/pull/669) - resolved [issue #665](https://github.com/akkadotnet/Akka.Hosting/issues/665) by deprecating the `JournalOptions.Adapters` property. Users should migrate to the unified callback pattern: `builder.WithJournal(options, journal =&gt; journal.AddWriteEventAdapter&lt;T&gt;(...))`. The deprecated property will be removed in v1.6.0.
+
+**Updates**
+* [Bump Akka version from 1.5.51 to 1.5.52](https://github.com/akkadotnet/akka.net/releases/tag/1.5.52)</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 1.5.52 October 9th 2025 ####
+
+**API Changes**
+* [Deprecate JournalOptions.Adapters property in favor of callback API](https://github.com/akkadotnet/Akka.Hosting/pull/669) - resolved [issue #665](https://github.com/akkadotnet/Akka.Hosting/issues/665) by deprecating the `JournalOptions.Adapters` property. Users should migrate to the unified callback pattern: `builder.WithJournal(options, journal => journal.AddWriteEventAdapter<T>(...))`. The deprecated property will be removed in v1.6.0.
+
+**Updates**
+* [Bump Akka version from 1.5.51 to 1.5.52](https://github.com/akkadotnet/akka.net/releases/tag/1.5.52)
+
 #### 1.5.51.1 October 2nd 2025 ####
 
 **Bug Fixes**


### PR DESCRIPTION
## Summary
Prepare for the 1.5.52 release by updating RELEASE_NOTES.md and Directory.Build.props with the latest version and release notes.

## Changes
- Updated version to 1.5.52 (dated October 9th, 2025)
- Added release notes for API deprecation and Akka.NET version bump
- Updated Directory.Build.props metadata

## Release Notes
**API Changes**
* Deprecate JournalOptions.Adapters property in favor of callback API (#669) - resolves #665

**Updates**
* Bump Akka version from 1.5.51 to 1.5.52

## Test plan
- [ ] Build completes successfully
- [ ] All tests pass
- [ ] Version metadata is correct in Directory.Build.props