### PR TITLE
Fix race condition in EventFilterTestBase logger initialization

### DIFF
--- a/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -49,7 +49,7 @@ namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
             SendRawLogEventMessage(initLoggerMessage);
             try
             {
-                ExpectMsg("OK");
+                await ExpectMsgAsync("OK", TimeSpan.FromSeconds(10));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary
Fixed intermittent test failures in CI environments caused by a race condition during logger initialization in `EventFilterTestBase`.

## Changes
- Increased timeout for `ForwardAllEventsTestEventListener` initialization from 3 seconds to 10 seconds
- Converted to async API (`ExpectMsgAsync`) for better async/await pattern consistency

## Root Cause
The test event listener initialization in `EventFilterTestBase.BeforeTestStart()` was waiting for an "OK" acknowledgment with only a 3-second timeout. In CI environments under load, the logger sometimes takes longer to initialize, causing intermittent failures with timeout errors.

## Test Plan
- [x] Build succeeds with no warnings or errors
- [x] Previously failing tests now pass:
  - `ExceptionEventFilterTests.ShouldReportCorrectMessageCount`
  - `CustomEventFilterErrorTests.Messages_can_be_muted_from_now_on`
- [x] All 279 tests in TestEventListenerTests suite pass

## Related Issues
Fixes intermittent test failures observed in:
- https://github.com/akkadotnet/Akka.Hosting/actions/runs/18390801324/job/52400382836
- https://github.com/akkadotnet/Akka.Hosting/actions/runs/18390271285/job/52398751876