### PR TITLE
Release 1.5.53

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,15 +3,11 @@
     <Copyright>Copyright © 2013-2025 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>1.5.53</VersionPrefix>
-    <PackageReleaseNotes>**New Features**
-* [Add SSL/TLS configuration options from Akka.NET v1.5.52 and v1.5.53](https://github.com/akkadotnet/Akka.Hosting/pull/XXX) - Added support for new SSL/TLS configuration options:
-  * `RequireMutualAuthentication` - Enables mutual TLS (mTLS) authentication (default: true)
-  * `ValidateCertificateHostname` - Controls certificate hostname validation (default: false)
-
-**API Changes**
-* [Deprecate JournalOptions.Adapters property in favor of callback API](https://github.com/akkadotnet/Akka.Hosting/pull/669) - resolved [issue #665](https://github.com/akkadotnet/Akka.Hosting/issues/665) by deprecating the `JournalOptions.Adapters` property. Users should migrate to the unified callback pattern: `builder.WithJournal(options, journal =&gt; journal.AddWriteEventAdapter&lt;T&gt;(...))`. The deprecated property will be removed in v1.6.0.
+    <PackageReleaseNotes>**Bug Fixes**
+* [Fix event adapter callback API not invoking adapters at runtime](https://github.com/akkadotnet/Akka.Hosting/pull/674) - resolved critical bug where event adapters configured via the callback API were not being invoked at runtime. This fix is especially important for users who have migrated to the callback pattern following the deprecation of `JournalOptions.Adapters` property. The issue was caused by unnecessary fallback configuration that interfered with adapter registration during HOCON merging.
 
 **Updates**
+* [Add SSL/TLS configuration settings from Akka.NET 1.5.52 and 1.5.53](https://github.com/akkadotnet/Akka.Hosting/pull/675) - updated SSL/TLS configuration options to support new features and settings introduced in Akka.NET versions 1.5.52 and 1.5.53
 * [Bump Akka version from 1.5.52 to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 1.5.53 October 14th 2025 ####
+
+**Bug Fixes**
+* [Fix event adapter callback API not invoking adapters at runtime](https://github.com/akkadotnet/Akka.Hosting/pull/674) - resolved critical bug where event adapters configured via the callback API were not being invoked at runtime. This fix is especially important for users who have migrated to the callback pattern following the deprecation of `JournalOptions.Adapters` property. The issue was caused by unnecessary fallback configuration that interfered with adapter registration during HOCON merging.
+
+**Updates**
+* [Add SSL/TLS configuration settings from Akka.NET 1.5.52 and 1.5.53](https://github.com/akkadotnet/Akka.Hosting/pull/675) - updated SSL/TLS configuration options to support new features and settings introduced in Akka.NET versions 1.5.52 and 1.5.53
+* [Bump Akka version from 1.5.52 to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
+
 #### 1.5.52 October 9th 2025 ####
 
 **API Changes**


### PR DESCRIPTION
## Summary
Prepare for version 1.5.53 release with the following changes:

- Critical bug fix for event adapter callback API runtime invocation
- Updated SSL/TLS configuration settings from Akka.NET 1.5.52 and 1.5.53
- Bump Akka.NET dependency to version 1.5.53

## Changes
- Updated RELEASE_NOTES.md with version 1.5.53 release notes
- Updated Directory.Build.props with new version metadata

## Post-Merge Actions
After this PR is merged:
1. Create git tag `1.5.53` on dev branch
2. Push tag to trigger automated release workflow