### PR TITLE
Fix race condition in DistributedPubSubSpecs cluster join test

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
@@ -109,7 +109,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
         
         // Join cluster
         var myAddress = _cluster!.SelfAddress;
-        await _cluster.JoinAsync(myAddress, cancellationTokenSource.Token); // force system to wait until we're up
+        await _cluster.JoinAsync(myAddress); // force system to wait until we're up
 
         // Prepare test
         var registry = _host.Services.GetRequiredService<ActorRegistry>();


### PR DESCRIPTION
## Summary
Fixes a race condition in `DistributedPubSubSpecs.Should_launch_distributed_pub_sub_with_roles` that caused intermittent test failures in CI.

## Problem
The test was using a shared `CancellationTokenSource` (10-second timeout) for both:
1. `_host.StartAsync()` - Host initialization
2. `_cluster.JoinAsync()` - Cluster join operation

This created a race condition where the timeout could fire during cluster join even though the cluster successfully formed. The logs showed the node reaching `Up` state, but the test threw `ClusterJoinFailedException` because the cancellation token fired microseconds before the `JoinAsync` completion callback executed.

### Root Cause
- Shared timeout budget across sequential operations
- `JoinAsync` uses a `TaskCompletionSource` with competing completion paths:
  - Success: `RegisterOnMemberUp` callback
  - Failure: CancellationToken timeout callback
- In slow CI environments, timeout wins the race despite successful cluster formation

## Solution
Removed the `CancellationToken` parameter from the `JoinAsync` call, letting Akka.NET use its own internal timeout mechanisms. This approach:
- Eliminates the token registration race
- Matches the pattern used in `TestHelper.cs` and other working tests
- Aligns with how `ClusterShardingDistributedDataSpecs` handles cluster joins

## Test Plan
The test should no longer flake in CI environments. Cluster join still has timeout protection via Akka.NET's internal mechanisms.