### PR TITLE
Fix flaky TestProbe supervision test by preventing restart storm

### DIFF
--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
@@ -84,7 +84,7 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
         }
 
         [Fact]
-        public void TestProbe_restart_a_failing_child_if_the_given_supervisor_says_so()
+        public async Task TestProbe_restart_a_failing_child_if_the_given_supervisor_says_so()
         {
             var probe = CreateTestProbe();
             var restartWatcher = CreateTestProbe();
@@ -95,8 +95,8 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
             child.Tell("hello");
 
             // Wait for exactly 2 restart notifications
-            restartWatcher.ExpectMsg("restarted");
-            restartWatcher.ExpectMsg("restarted");
+            await restartWatcher.ExpectMsgAsync("restarted");
+            await restartWatcher.ExpectMsgAsync("restarted");
         }
 
         class FailingActor : ActorBase

--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
@@ -86,31 +86,28 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
         [Fact]
         public void TestProbe_restart_a_failing_child_if_the_given_supervisor_says_so()
         {
-            var restarts = new AtomicCounter(0);
             var probe = CreateTestProbe();
-            var child = probe.ChildActorOf(Props.Create(() => new FailingActor(restarts)), SupervisorStrategy.DefaultStrategy);
+            var restartWatcher = CreateTestProbe();
+            var child = probe.ChildActorOf(Props.Create(() => new FailingActor(restartWatcher)), SupervisorStrategy.DefaultStrategy);
 
-            // Send messages BEFORE AwaitAssert to avoid restart storm
-            // Each message will trigger one restart
+            // Send two messages that will cause failures and restarts
             child.Tell("hello");
             child.Tell("hello");
 
-            // Only check the counter, don't send more messages
-            AwaitAssert(() =>
-            {
-                restarts.Current.Should().BeGreaterThan(1);
-            });
+            // Wait for exactly 2 restart notifications
+            restartWatcher.ExpectMsg("restarted");
+            restartWatcher.ExpectMsg("restarted");
         }
-        
+
         class FailingActor : ActorBase
         {
-            private AtomicCounter Restarts { get; }
-            
-            public FailingActor(AtomicCounter restarts)
+            private readonly IActorRef _restartWatcher;
+
+            public FailingActor(IActorRef restartWatcher)
             {
-                Restarts = restarts;
+                _restartWatcher = restartWatcher;
             }
-            
+
             protected override bool Receive(object message)
             {
                 throw new Exception("Simulated failure");
@@ -118,7 +115,7 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
 
             protected override void PostRestart(Exception reason)
             {
-                Restarts.IncrementAndGet();
+                _restartWatcher.Tell("restarted");
                 base.PostRestart(reason);
             }
         }

--- a/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorRefTests/TestProbeSpec.cs
@@ -89,9 +89,15 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
             var restarts = new AtomicCounter(0);
             var probe = CreateTestProbe();
             var child = probe.ChildActorOf(Props.Create(() => new FailingActor(restarts)), SupervisorStrategy.DefaultStrategy);
+
+            // Send messages BEFORE AwaitAssert to avoid restart storm
+            // Each message will trigger one restart
+            child.Tell("hello");
+            child.Tell("hello");
+
+            // Only check the counter, don't send more messages
             AwaitAssert(() =>
             {
-                child.Tell("hello");
                 restarts.Current.Should().BeGreaterThan(1);
             });
         }
@@ -113,6 +119,7 @@ namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
             protected override void PostRestart(Exception reason)
             {
                 Restarts.IncrementAndGet();
+                base.PostRestart(reason);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes a flaky test in `TestProbeSpec` that was failing intermittently with `restarts.Current` being 0 when it should be greater than 1.

## Root Cause

The test was creating a **restart storm** by sending a new message on each `AwaitAssert` retry:
- `AwaitAssert` retries every 100ms for 3 seconds = ~30 message sends
- Each message triggers an actor crash and restart attempt  
- If the supervisor's restart limit is exceeded, it stops the child permanently
- Once stopped, `PostRestart` never runs again and the counter freezes (often at 0)

## Solution

Replaced counter-based polling with **idiomatic message-passing verification**:
- Actor sends a "restarted" message to a TestProbe on each `PostRestart`
- Test uses `ExpectMsg` to block until both restart notifications arrive
- No timing assumptions, no polling, no shared state
- Direct synchronization via Akka.NET message passing

## Changes

1. **Use TestProbe for restart verification** - Deterministic message-based synchronization
2. **Send exactly 2 messages upfront** - No restart storm from retries
3. **Call `base.PostRestart()`** - Maintains proper actor lifecycle

## Test Plan

- [x] Test is now fully deterministic with no timing assumptions
- [x] Uses idiomatic Akka.NET testing patterns
- [x] No restart storm or supervisor limit violations
- [x] Clear test intent: send 2 messages → expect 2 restart notifications