### PR TITLE
Prepare for 1.5.55 stable release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.55-beta1</VersionPrefix>
+    <VersionPrefix>1.5.55</VersionPrefix>
     <PackageReleaseNotes>**New Features**
 * [Support custom health check registrations on Journal and Snapshot Builders](https://github.com/akkadotnet/Akka.Hosting/pull/683) - added API to support custom health check registrations for Akka.Persistence plugins, related to [issue #678](https://github.com/akkadotnet/Akka.Hosting/issues/678)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 **New Features**
 * [Support custom health check registrations on Journal and Snapshot Builders](https://github.com/akkadotnet/Akka.Hosting/pull/683) - added API to support custom health check registrations for Akka.Persistence plugins, related to [issue #678](https://github.com/akkadotnet/Akka.Hosting/issues/678)
+* [Add support for custom certificate validation callbacks](https://github.com/akkadotnet/Akka.Hosting/pull/686) - integrated the new `CertificateValidationCallback` feature from Akka.NET v1.5.55, allowing users to provide custom certificate validation logic for SSL/TLS connections. Enables advanced scenarios including certificate pinning, subject/issuer matching, custom business validation rules, and advanced mTLS scenarios
 
 **Enhancements**
 * [Add customizable tags parameter to health check methods](https://github.com/akkadotnet/Akka.Hosting/pull/681) - resolved [issue #679](https://github.com/akkadotnet/Akka.Hosting/issues/679) by adding new overload allowing custom tags for health checks while maintaining backward compatibility

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+#### 1.5.55 October 26th 2025 ####
+
+**New Features**
+* [Support custom health check registrations on Journal and Snapshot Builders](https://github.com/akkadotnet/Akka.Hosting/pull/683) - added API to support custom health check registrations for Akka.Persistence plugins, related to [issue #678](https://github.com/akkadotnet/Akka.Hosting/issues/678)
+
+**Enhancements**
+* [Add customizable tags parameter to health check methods](https://github.com/akkadotnet/Akka.Hosting/pull/681) - resolved [issue #679](https://github.com/akkadotnet/Akka.Hosting/issues/679) by adding new overload allowing custom tags for health checks while maintaining backward compatibility
+* [Made it easier to customize failureState and tags for all health checks](https://github.com/akkadotnet/Akka.Hosting/pull/682) - simplified health check configuration API for all health checks
+
+**Updates**
+* [Bump Akka version from 1.5.53 to 1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)
+
 #### 1.5.55-beta1 October 26th 2025 ####
 
 **New Features**


### PR DESCRIPTION
## Summary
Preparation for version 1.5.55 stable release.

## Changes
- Updated RELEASE_NOTES.md with stable release entry for version 1.5.55
- Updated version metadata from 1.5.55-beta1 to 1.5.55 in Directory.Build.props

## Release Notes
This stable release includes health check enhancements that were previously released in v1.5.55-beta1:

**New Features**
- Custom health check registrations for Journal and Snapshot Builders

**Enhancements**
- Customizable tags parameter for health check methods
- Simplified health check configuration API with customizable failureState and tags

**Updates**
- Akka.NET upgraded from 1.5.53 to 1.5.55

After merge, tag 1.5.55 will be created and pushed to trigger the release workflow.