### PR TITLE
Prepare for 1.5.55.1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,16 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.55</VersionPrefix>
-    <PackageReleaseNotes>**New Features**
-* [Support custom health check registrations on Journal and Snapshot Builders](https://github.com/akkadotnet/Akka.Hosting/pull/683) - added API to support custom health check registrations for Akka.Persistence plugins, related to [issue #678](https://github.com/akkadotnet/Akka.Hosting/issues/678)
-
-**Enhancements**
-* [Add customizable tags parameter to health check methods](https://github.com/akkadotnet/Akka.Hosting/pull/681) - resolved [issue #679](https://github.com/akkadotnet/Akka.Hosting/issues/679) by adding new overload allowing custom tags for health checks while maintaining backward compatibility
-* [Made it easier to customize failureState and tags for all health checks](https://github.com/akkadotnet/Akka.Hosting/pull/682) - simplified health check configuration API for all health checks
-
-**Updates**
-* [Bump Akka version from 1.5.53 to 1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55)</PackageReleaseNotes>
+    <VersionPrefix>1.5.55.1</VersionPrefix>
+    <PackageReleaseNotes>**Enhancements**
+* [Expose options in journal and snapshot builders](https://github.com/akkadotnet/Akka.Hosting/pull/691) - resolved [issue #690](https://github.com/akkadotnet/Akka.Hosting/issues/690) by adding `Options` property to `AkkaPersistenceJournalBuilder` and `AkkaPersistenceSnapshotBuilder`. Extension methods can now access configuration details without requiring options as explicit parameters, eliminating redundant option passing for connectivity health checks and other plugin-specific features</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.55.1 October 27th 2025 ####
+
+**Enhancements**
+* [Expose options in journal and snapshot builders](https://github.com/akkadotnet/Akka.Hosting/pull/691) - resolved [issue #690](https://github.com/akkadotnet/Akka.Hosting/issues/690) by adding `Options` property to `AkkaPersistenceJournalBuilder` and `AkkaPersistenceSnapshotBuilder`. Extension methods can now access configuration details without requiring options as explicit parameters, eliminating redundant option passing for connectivity health checks and other plugin-specific features
+
 #### 1.5.55 October 26th 2025 ####
 
 **New Features**


### PR DESCRIPTION
## Summary
Release preparation for version 1.5.55.1

## Changes
- Updated RELEASE_NOTES.md with version 1.5.55.1 entry
- Updated Directory.Build.props with new version and release notes
- Includes enhancement from PR #691: Expose options in journal and snapshot builders

## Release Notes
**Enhancements**
* [Expose options in journal and snapshot builders](https://github.com/akkadotnet/Akka.Hosting/pull/691) - resolved [issue #690](https://github.com/akkadotnet/Akka.Hosting/issues/690) by adding `Options` property to `AkkaPersistenceJournalBuilder` and `AkkaPersistenceSnapshotBuilder`. Extension methods can now access configuration details without requiring options as explicit parameters, eliminating redundant option passing for connectivity health checks and other plugin-specific features