### PR TITLE
Fix semantic logging bug #701

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -102,7 +102,7 @@ namespace Akka.Hosting
     public class DeadLetterOptions
     {
         public DeadLetterOptions() { }
-        public int LogCount { get; set; }
+        public int? LogCount { get; set; }
         public bool? LogDuringShutdown { get; set; }
         public System.TimeSpan? LogSuspendDuration { get; set; }
         public Akka.Hosting.TriStateValue ShouldLog { get; set; }
@@ -182,9 +182,9 @@ namespace Akka.Hosting
     {
         public Akka.Hosting.DeadLetterOptions? DeadLetterOptions { get; set; }
         public Akka.Hosting.DebugOptions? DebugOptions { get; set; }
-        public bool LogConfigOnStart { get; set; }
+        public bool? LogConfigOnStart { get; set; }
         public Akka.Event.LogFilterBuilder? LogFilterBuilder { get; set; }
-        public Akka.Event.LogLevel LogLevel { get; set; }
+        public Akka.Event.LogLevel? LogLevel { get; set; }
         [System.Obsolete("Use the WithDefaultLogMessageFormatter<T> method instead")]
         public System.Type LogMessageFormatter { get; set; }
         public Akka.Hosting.LoggerConfigBuilder AddLogger<T>()

--- a/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
@@ -1,0 +1,265 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Issue701SemanticLoggingRegressionSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Event;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Akka.Hosting.Tests.Logging;
+
+/// <summary>
+/// Bug reproduction tests for semantic logging issue reported in Discord.
+///
+/// Issue: When using ILoggingAdapter with named placeholders like {UserId}, the formatted
+/// message output shows the raw template instead of substituted values.
+///
+/// Example:
+///   _logger.Info("User {UserId} logged in", 12345);
+///
+/// Expected output: "User 12345 logged in"
+/// Actual output:   "User {UserId} logged in"
+///
+/// Root cause: LoggerFactoryLogger.FormatMessage() uses string.Format() which only
+/// supports positional placeholders ({0}, {1}), not named placeholders ({UserId}).
+/// </summary>
+public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
+{
+    private readonly BugReproTestSink _sink;
+
+    public Issue701SemanticLoggingRegressionSpecs(ITestOutputHelper output) : base(output: output)
+    {
+        _sink = new BugReproTestSink(output);
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.ConfigureLoggers(setup =>
+        {
+            setup.LogLevel = Event.LogLevel.InfoLevel;
+            setup.ClearLoggers();
+            setup.AddLoggerFactory(new BugReproTestLoggerFactory(_sink));
+        });
+    }
+
+    /// <summary>
+    /// BUG REPRO: Named template placeholders should have values substituted in the formatted message.
+    /// This test demonstrates the bug where {UserId} is NOT replaced with the actual value.
+    /// </summary>
+    [Fact(DisplayName = "Named placeholders should be substituted in formatted message")]
+    public void NamedPlaceholdersShouldBeSubstitutedInFormattedMessage()
+    {
+        _sink.Clear();
+
+        // Log with named placeholder
+        Sys.Log.Info("User {UserId} logged in", 12345);
+
+        AwaitCondition(() => _sink.Entries.Any(e =>
+            e.Message.Contains("User") && (e.Message.Contains("12345") || e.Message.Contains("{UserId}"))));
+
+        var entry = _sink.Entries.First(e =>
+            e.Message.Contains("User") && (e.Message.Contains("12345") || e.Message.Contains("{UserId}")));
+
+        // BUG: The message should contain the substituted value "12345", not the raw placeholder "{UserId}"
+        entry.Message.Should().Contain("12345",
+            "the formatted message should contain the substituted value, not the raw template placeholder");
+        entry.Message.Should().NotContain("{UserId}",
+            "the formatted message should NOT contain the raw template placeholder");
+    }
+
+    /// <summary>
+    /// Control test: Positional placeholders ({0}) should work correctly.
+    /// </summary>
+    [Fact(DisplayName = "Positional placeholders should be substituted correctly")]
+    public void PositionalPlaceholdersShouldBeSubstitutedCorrectly()
+    {
+        _sink.Clear();
+
+        // Log with positional placeholder
+        Sys.Log.Info("User {0} logged in", 12345);
+
+        AwaitCondition(() => _sink.Entries.Any(e =>
+            e.Message.Contains("User") && e.Message.Contains("logged in")));
+
+        var entry = _sink.Entries.First(e =>
+            e.Message.Contains("User") && e.Message.Contains("logged in"));
+
+        // Positional placeholders should work
+        entry.Message.Should().Contain("12345",
+            "positional placeholders should be substituted correctly");
+        entry.Message.Should().NotContain("{0}",
+            "positional placeholders should be replaced");
+    }
+
+    /// <summary>
+    /// BUG REPRO: Multiple named placeholders should all be substituted.
+    /// This matches the Discord user's exact scenario.
+    /// </summary>
+    [Fact(DisplayName = "Multiple named placeholders")]
+    public void MultipleNamedPlaceholdersDiscordScenario()
+    {
+        _sink.Clear();
+
+        // Matches the bug log format:
+        // _logger.Info("Published callback event: {Event} | ActorId: {ActorId}", eventName, actorId)
+        Sys.Log.Info("Published callback event: {Event} | ActorId: {ActorId}", "UserLoggedIn", "actor-123");
+
+        AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("Published callback event")));
+
+        var entry = _sink.Entries.First(e => e.Message.Contains("Published callback event"));
+
+        // BUG: Values should be substituted
+        entry.Message.Should().Contain("UserLoggedIn",
+            "the Event value should be substituted");
+        entry.Message.Should().Contain("actor-123",
+            "the ActorId value should be substituted");
+        entry.Message.Should().NotContain("{Event}",
+            "should NOT contain raw {Event} placeholder");
+        entry.Message.Should().NotContain("{ActorId}",
+            "should NOT contain raw {ActorId} placeholder");
+    }
+
+    /// <summary>
+    /// Verify that structured properties ARE extracted correctly even when message formatting fails.
+    /// This shows that the semantic logging infrastructure works - only the message formatting is broken.
+    ///
+    /// This test demonstrates the contrast:
+    /// - State dictionary: Properties correctly extracted (UserId=12345, Email=user@example.com)
+    /// - Message string: Values NOT substituted (shows raw "{UserId}" instead of "12345")
+    /// </summary>
+    [Fact(DisplayName = "Properties extracted correctly but message formatting broken")]
+    public void PropertiesExtractedButMessageFormattingBroken()
+    {
+        _sink.Clear();
+
+        Sys.Log.Info("User {UserId} with email {Email} logged in", 12345, "user@example.com");
+
+        AwaitCondition(() => _sink.Entries.Any(e =>
+            e.State.ContainsKey("UserId") || e.State.ContainsKey("Email")));
+
+        var entry = _sink.Entries.First(e =>
+            e.State.ContainsKey("UserId") || e.State.ContainsKey("Email"));
+
+        // WORKS: Properties ARE extracted correctly into state dictionary
+        entry.State.Should().ContainKey("UserId");
+        entry.State.Should().ContainKey("Email");
+        entry.State["UserId"].Should().Be(12345);
+        entry.State["Email"].Should().Be("user@example.com");
+
+        // WORKS: Original format is preserved
+        entry.State.Should().ContainKey("{OriginalFormat}");
+        entry.State["{OriginalFormat}"].Should().Be("User {UserId} with email {Email} logged in");
+
+        // BUG: Message should have substituted values, but it doesn't
+        entry.Message.Should().Contain("12345",
+            "the formatted message should contain the substituted UserId value");
+        entry.Message.Should().Contain("user@example.com",
+            "the formatted message should contain the substituted Email value");
+    }
+
+    /// <summary>
+    /// BUG REPRO: Mixed positional and named placeholders (edge case).
+    /// </summary>
+    [Fact(DisplayName = "Mixed positional and named placeholders")]
+    public void MixedPositionalAndNamedPlaceholders()
+    {
+        _sink.Clear();
+
+        // Mix of positional and named
+        Sys.Log.Info("User {UserId} action {0}", 12345, "Login");
+
+        AwaitCondition(() => _sink.Entries.Any(e =>
+            e.Message.Contains("User") && e.Message.Contains("action")));
+
+        var entry = _sink.Entries.First(e =>
+            e.Message.Contains("User") && e.Message.Contains("action"));
+
+        // Both should be substituted
+        entry.Message.Should().Contain("12345", "UserId should be substituted");
+        entry.Message.Should().Contain("Login", "action should be substituted");
+    }
+}
+
+/// <summary>
+/// Test sink that captures both the formatted message AND the structured state
+/// </summary>
+public class BugReproTestSink : ILogger
+{
+    private readonly ITestOutputHelper _output;
+    public ConcurrentQueue<BugReproLogEntry> Entries { get; } = new();
+
+    public BugReproTestSink(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public void Clear()
+    {
+        Entries.Clear();
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+        Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        // Get the formatted message - this is where the bug manifests
+        var message = formatter(state, exception);
+        _output.WriteLine($"[{logLevel}] Message: \"{message}\"");
+
+        // Capture state as dictionary
+        var stateDict = new Dictionary<string, object>();
+        if (state is IEnumerable<KeyValuePair<string, object>> kvps)
+        {
+            foreach (var kvp in kvps)
+            {
+                stateDict[kvp.Key] = kvp.Value;
+                _output.WriteLine($"  State[{kvp.Key}] = {kvp.Value}");
+            }
+        }
+
+        Entries.Enqueue(new BugReproLogEntry
+        {
+            LogLevel = logLevel,
+            Message = message,
+            State = stateDict,
+            Exception = exception
+        });
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable BeginScope<TState>(TState state) => EmptyDisposable.Instance;
+}
+
+public class BugReproLogEntry
+{
+    public LogLevel LogLevel { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public Dictionary<string, object> State { get; init; } = new();
+    public Exception? Exception { get; init; }
+}
+
+public class BugReproTestLoggerFactory : ILoggerFactory
+{
+    private readonly BugReproTestSink _sink;
+
+    public BugReproTestLoggerFactory(BugReproTestSink sink)
+    {
+        _sink = sink;
+    }
+
+    public void Dispose() { }
+
+    public ILogger CreateLogger(string categoryName) => _sink;
+
+    public void AddProvider(ILoggerProvider provider) { }
+}

--- a/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
@@ -52,6 +52,24 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
         });
     }
 
+    private void AssertMetadata(BugReproLogEntry entry, string? format = null)
+    {
+        entry.State.Should().ContainKey("ActorPath");
+        entry.State.Should().ContainKey("Timestamp");
+        entry.State.Should().ContainKey("Thread");
+        entry.State.Should().ContainKey("LogSource");
+        entry.State.Should().ContainKey("{OriginalFormat}");
+        
+        entry.State["ActorPath"].Should().BeOfType<string>();
+        entry.State["Timestamp"].Should().BeOfType<DateTime>();
+        entry.State["Thread"].Should().BeOfType<int>();
+        entry.State["LogSource"].Should().BeOfType<string>();
+        entry.State["{OriginalFormat}"].Should().BeOfType<string>();
+
+        if (format is not null)
+            entry.State["{OriginalFormat}"].Should().Be(format);
+    }
+    
     /// <summary>
     /// BUG REPRO: Named template placeholders should have values substituted in the formatted message.
     /// This test demonstrates the bug where {UserId} is NOT replaced with the actual value.
@@ -75,6 +93,11 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
             "the formatted message should contain the substituted value, not the raw template placeholder");
         entry.Message.Should().NotContain("{UserId}",
             "the formatted message should NOT contain the raw template placeholder");
+        
+        entry.State.Should().ContainKey("UserId");
+        entry.State["UserId"].Should().Be(12345);
+        
+        AssertMetadata(entry, "User {UserId} logged in");
     }
 
     /// <summary>
@@ -99,6 +122,11 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
             "positional placeholders should be substituted correctly");
         entry.Message.Should().NotContain("{0}",
             "positional placeholders should be replaced");
+        
+        entry.State.Should().ContainKey("0");
+        entry.State["0"].Should().Be(12345);
+        
+        AssertMetadata(entry, "User {0} logged in");
     }
 
     /// <summary>
@@ -127,6 +155,13 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
             "should NOT contain raw {Event} placeholder");
         entry.Message.Should().NotContain("{ActorId}",
             "should NOT contain raw {ActorId} placeholder");
+        
+        entry.State.Should().ContainKey("Event");
+        entry.State.Should().ContainKey("ActorId");
+        entry.State["Event"].Should().Be("UserLoggedIn");
+        entry.State["ActorId"].Should().Be("actor-123");
+        
+        AssertMetadata(entry, "Published callback event: {Event} | ActorId: {ActorId}");
     }
 
     /// <summary>
@@ -156,15 +191,13 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
         entry.State["UserId"].Should().Be(12345);
         entry.State["Email"].Should().Be("user@example.com");
 
-        // WORKS: Original format is preserved
-        entry.State.Should().ContainKey("{OriginalFormat}");
-        entry.State["{OriginalFormat}"].Should().Be("User {UserId} with email {Email} logged in");
-
         // BUG: Message should have substituted values, but it doesn't
         entry.Message.Should().Contain("12345",
             "the formatted message should contain the substituted UserId value");
         entry.Message.Should().Contain("user@example.com",
             "the formatted message should contain the substituted Email value");
+        
+        AssertMetadata(entry, "User {UserId} with email {Email} logged in");
     }
 
     /// <summary>
@@ -187,6 +220,13 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
         // Both should be substituted
         entry.Message.Should().Contain("12345", "UserId should be substituted");
         entry.Message.Should().Contain("Login", "action should be substituted");
+        
+        entry.State.Should().ContainKey("UserId");
+        entry.State.Should().ContainKey("0");
+        entry.State["UserId"].Should().Be(12345);
+        entry.State["0"].Should().Be("Login");
+        
+        AssertMetadata(entry, "User {UserId} action {0}");
     }
 }
 

--- a/src/Akka.Hosting.Tests/Logging/LoggerConfigBuilderSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerConfigBuilderSpecs.cs
@@ -6,10 +6,13 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 using LogLevel = Akka.Event.LogLevel;
 
@@ -18,23 +21,55 @@ namespace Akka.Hosting.Tests.Logging;
 public class LoggerConfigBuilderSpecs
 {
     [Fact(DisplayName = "LoggerConfigBuilder should contain proper default configuration")]
-    public void LoggerSetupDefaultValues()
+    public async Task LoggerSetupDefaultValues()
     {
         var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "test")
             .ConfigureLoggers(_ => { });
 
-        builder.Configuration.HasValue.Should().BeTrue();
-        var config = builder.Configuration.Value;
-        config.GetString("akka.loglevel").Should().Be("Info");
-        config.GetString("akka.log-config-on-start").Should().Be("false");
-        var loggers = config.GetStringList("akka.loggers");
-        loggers.Count.Should().Be(1);
-        loggers[0].Should().Contain("Akka.Event.DefaultLogger");
+        builder.Configuration.HasValue.Should().BeFalse();
 
-        config.GetConfig("akka.actor.debug").Should().BeNull();
-        config.GetString("akka.log-dead-letters").Should().BeNull();
-        config.GetString("akka.log-dead-letters-during-shutdown").Should().BeNull();
-        config.GetString("akka.log-dead-letters-suspend-duration").Should().BeNull();
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddAkka(nameof(LoggerConfigBuilderSpecs), b =>
+                {
+                    b.ConfigureLoggers(_ => { });
+                });
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        try
+        {
+            var config = host.Services.GetRequiredService<ActorSystem>().Settings.Config;
+            config.GetString("akka.loglevel").Should().Be("INFO");
+            config.GetBoolean("akka.log-config-on-start").Should().BeFalse();
+            var loggers = config.GetStringList("akka.loggers");
+            loggers.Count.Should().Be(1);
+            loggers[0].Should().Contain("Akka.Event.DefaultLogger");
+            config.GetString("akka.logger-formatter").Should().Contain("SemanticLogMessageFormatter");
+
+            var debug = config.GetConfig("akka.actor.debug");
+            debug.Should().NotBeNull();
+            debug.GetBoolean("receive").Should().BeFalse();
+            debug.GetBoolean("autoreceive").Should().BeFalse();
+            debug.GetBoolean("lifecycle").Should().BeFalse();
+            debug.GetBoolean("fsm").Should().BeFalse();
+            debug.GetBoolean("event-stream").Should().BeFalse();
+            debug.GetBoolean("unhandled").Should().BeFalse();
+            debug.GetBoolean("router-misconfiguration").Should().BeFalse();
+            debug.GetBoolean("log-timers").Should().BeFalse();
+            
+            config.GetInt("akka.log-dead-letters").Should().Be(10);
+            config.GetBoolean("akka.log-dead-letters-during-shutdown").Should().BeFalse();
+            config.GetTimeSpan("akka.log-dead-letters-suspend-duration").Should().Be(TimeSpan.FromMinutes(5));
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
     }
     
     [Fact(DisplayName = "LoggerConfigBuilder should override config values")]
@@ -67,7 +102,7 @@ public class LoggerConfigBuilderSpecs
         builder.Configuration.HasValue.Should().BeTrue();
         var config = builder.Configuration.Value;
         config.GetString("akka.loglevel").Should().Be("Warning");
-        config.GetString("akka.log-config-on-start").Should().Be("true");
+        config.GetBoolean("akka.log-config-on-start").Should().BeTrue();
         var loggers = config.GetStringList("akka.loggers");
         loggers.Count.Should().Be(0);
         

--- a/src/Akka.Hosting.Tests/Logging/LoggerConfigBuilderSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerConfigBuilderSpecs.cs
@@ -138,9 +138,12 @@ public class LoggerConfigBuilderSpecs
         
         cfg = new DeadLetterOptions
         {
-            ShouldLog = TriStateValue.Some
+            LogCount = 10
         }.ToString();
         cfg.GetInt("akka.log-dead-letters").Should().Be(10);
+
+        cfg = new DeadLetterOptions().ToString();
+        cfg.IsEmpty.Should().BeTrue();
     }
 
     [Fact(DisplayName = "WithLogFilter should populate the LogFilterBuilder property")]

--- a/src/Akka.Hosting/AkkaOptions.cs
+++ b/src/Akka.Hosting/AkkaOptions.cs
@@ -33,7 +33,7 @@ public class DeadLetterOptions
     /// Number of dead letter messages to be logged. Only effective if <see cref="ShouldLog"/> is set to
     /// <see cref="TriStateValue.Some"/>
     /// </summary>
-    public int LogCount { get; set; } = 10;
+    public int? LogCount { get; set; }
     
     /// <summary>
     /// Flag to indicate that log letters should not be logged while the <see cref="ActorSystem"/> is shutting down.
@@ -49,17 +49,32 @@ public class DeadLetterOptions
     public override string ToString()
     {
         var sb = new StringBuilder();
-        sb.AppendLine("akka {");
-        sb.AppendLine($@"log-dead-letters = {ShouldLog switch
+
+        if (ShouldLog is not TriStateValue.Some)
         {
-            TriStateValue.All => "on",
-            TriStateValue.None => "off",
-            _ => LogCount
-        }}");
-        if (LogDuringShutdown is { })
+            switch (ShouldLog)
+            {
+                case TriStateValue.All:
+                    sb.AppendLine("log-dead-letters = on");
+                    break;
+                case TriStateValue.None:
+                    sb.AppendLine("log-dead-letters = off");
+                    break;
+                default:
+                    throw new IndexOutOfRangeException($"Unknown TriStateValue: {ShouldLog}");
+            }
+        } else if(LogCount is not null)
+            sb.AppendLine($"log-dead-letters = {LogCount.Value}");
+        
+        if (LogDuringShutdown is not null)
             sb.AppendLine($"log-dead-letters-during-shutdown = {LogDuringShutdown.ToHocon()}");
-        if (LogSuspendDuration is { })
+        if (LogSuspendDuration is not null)
             sb.AppendLine($"log-dead-letters-suspend-duration = {LogSuspendDuration.ToHocon(allowInfinite: true, zeroIsInfinite: true)}");
+        
+        if(sb.Length == 0)
+            return string.Empty;
+
+        sb.Insert(0, "akka {");
         sb.AppendLine("}");
         return sb.ToString();
     }

--- a/src/Akka.Hosting/LoggerConfigBuilder.cs
+++ b/src/Akka.Hosting/LoggerConfigBuilder.cs
@@ -16,8 +16,8 @@ namespace Akka.Hosting
 {
     public sealed class LoggerConfigBuilder
     {
-        private readonly List<Type> _loggers = new() { typeof(DefaultLogger) };
-        private Type _logMessageFormatter = typeof(DefaultLogMessageFormatter);
+        private readonly List<Type> _loggers = [];
+        private Type? _logMessageFormatter;
         internal AkkaConfigurationBuilder Builder { get; }
 
         internal LoggerConfigBuilder(AkkaConfigurationBuilder builder)
@@ -31,7 +31,7 @@ namespace Akka.Hosting
         /// </para>
         /// Defaults to <c>LogLevel.InfoLevel</c>
         /// </summary>
-        public LogLevel LogLevel { get; set; } = LogLevel.InfoLevel;
+        public LogLevel? LogLevel { get; set; }
         
         /// <summary>
         /// <para>
@@ -40,7 +40,7 @@ namespace Akka.Hosting
         /// </para>
         /// Defaults to false.
         /// </summary>
-        public bool LogConfigOnStart { get; set; } = false;
+        public bool? LogConfigOnStart { get; set; }
 
         public DeadLetterOptions? DeadLetterOptions { get; set; }
 
@@ -51,13 +51,13 @@ namespace Akka.Hosting
         [Obsolete("Use the WithDefaultLogMessageFormatter<T> method instead")]
         public Type LogMessageFormatter
         {
-            get => _logMessageFormatter;
+            get => _logMessageFormatter ?? typeof(SemanticLogMessageFormatter);
             set
             {
                 if (!typeof(ILogMessageFormatter).IsAssignableFrom(value))
                     throw new ConfigurationException($"{nameof(LogMessageFormatter)} must implement {nameof(ILogMessageFormatter)}");
 
-                var ctor = value.GetConstructor(new Type[]{});
+                var ctor = value.GetConstructor([]);
                 if (ctor is null)
                     throw new ConfigurationException($"{nameof(LogMessageFormatter)} Type must have an empty constructor");
                         
@@ -116,38 +116,49 @@ namespace Akka.Hosting
             _loggers.Add(logger);
         }
         
-        private Config ToConfig()
+        private Config? ToConfig()
         {
-            var sb = new StringBuilder()
-                .Append("akka.loglevel=").AppendLine(ParseLogLevel(LogLevel))
-                .Append("akka.loggers=[").Append(string.Join(",", _loggers.Select(t => $"\"{t.AssemblyQualifiedName}\""))).AppendLine("]")
-                .Append("akka.log-config-on-start=").AppendLine(LogConfigOnStart ? "true" : "false")
-                .Append("akka.logger-formatter=").AppendLine(_logMessageFormatter.AssemblyQualifiedName.ToHocon());
+            var sb = new StringBuilder();
+            
+            if(LogLevel is not null)
+                sb .Append("akka.loglevel=").AppendLine(ParseLogLevel(LogLevel).ToHocon());
+            
+            if(_loggers.Count > 0)
+                sb.Append("akka.loggers=[").Append(string.Join(",", _loggers.Select(t => $"\"{t.AssemblyQualifiedName}\""))).AppendLine("]");
+            
+            if(LogConfigOnStart is not null)
+                sb.Append("akka.log-config-on-start=").AppendLine(LogConfigOnStart.Value.ToHocon());
+            
+            if(_logMessageFormatter is not null)
+                sb.Append("akka.logger-formatter=").AppendLine(_logMessageFormatter.AssemblyQualifiedName.ToHocon());
                 
-            if (DebugOptions is { })
+            if (DebugOptions is not null)
                 sb.AppendLine(DebugOptions.ToString());
-            if (DeadLetterOptions is { })
+            
+            if (DeadLetterOptions is not null)
                 sb.AppendLine(DeadLetterOptions.ToString());
             
-            return ConfigurationFactory.ParseString(sb.ToString());
+            return sb.Length > 0 ? ConfigurationFactory.ParseString(sb.ToString()) : null;
         }
 
         internal AkkaConfigurationBuilder Build(AkkaConfigurationBuilder builder)
         {
-            builder.AddHoconConfiguration(ToConfig(), HoconAddMode.Prepend);
+            var config = ToConfig();
+            if(config is not null)
+                builder.AddHoconConfiguration(config, HoconAddMode.Prepend);
             if (LogFilterBuilder is not null)
                 builder.AddSetup(LogFilterBuilder.Build());
             
             return builder;
         }
 
-        private static string ParseLogLevel(LogLevel logLevel)
+        private static string ParseLogLevel(LogLevel? logLevel)
             => logLevel switch
             {
-                LogLevel.DebugLevel => "Debug",
-                LogLevel.InfoLevel => "Info",
-                LogLevel.WarningLevel => "Warning",
-                LogLevel.ErrorLevel => "Error",
+                Akka.Event.LogLevel.DebugLevel => "Debug",
+                Akka.Event.LogLevel.InfoLevel => "Info",
+                Akka.Event.LogLevel.WarningLevel => "Warning",
+                Akka.Event.LogLevel.ErrorLevel => "Error",
                 _ => throw new ConfigurationException($"Unknown {nameof(LogLevel)} enum value: {logLevel}")
             };
     }

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -91,7 +91,7 @@ namespace Akka.Hosting.Logging
             // Use LogMessage.ToString() which applies the correct formatter (SemanticLogMessageFormatter)
             // instead of string.Format() which only works with positional {0} placeholders
             _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
-                (s, ex) => log.Message is LogMessage logMsg ? logMsg.ToString() ?? string.Empty : log.Message?.ToString() ?? string.Empty);
+                (s, ex) => log.Message?.ToString() ?? string.Empty);
         }
 
         private static LogLevel GetLogLevel(Event.LogLevel level)

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -90,8 +90,20 @@ namespace Akka.Hosting.Logging
             // Log with structured state
             // Use LogMessage.ToString() which applies the correct formatter (SemanticLogMessageFormatter)
             // instead of string.Format() which only works with positional {0} placeholders
-            _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
-                (s, ex) => log.Message?.ToString() ?? string.Empty);
+            _akkaLogger.Log(logLevel, new EventId(), state, log.Cause, (s, ex) =>
+            {
+                try
+                {
+                    return log.ToString();
+                }
+                catch
+                {
+                    if(log.Message is LogMessage msg)
+                        return $"Received a malformed formatted message. Log level: [{log.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Unformatted())}]";
+                    
+                    return $"Received a malformed formatted message. Log level: [{log.LogLevel()}], Message: [{log.Message}]";
+                }
+            });
         }
 
         private static LogLevel GetLogLevel(Event.LogLevel level)

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -87,8 +87,10 @@ namespace Akka.Hosting.Logging
                 state["{OriginalFormat}"] = log.GetTemplate();
 
                 // Log with structured state
+                // Use LogMessage.ToString() which applies the correct formatter (SemanticLogMessageFormatter)
+                // instead of string.Format() which only works with positional {0} placeholders
                 _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
-                    (s, ex) => FormatMessage(log.GetTemplate(), log.GetParameters().ToArray()));
+                    (s, ex) => log.Message is LogMessage logMsg ? logMsg.ToString() ?? string.Empty : log.Message?.ToString() ?? string.Empty);
             }
             else
             {
@@ -98,19 +100,6 @@ namespace Akka.Hosting.Logging
             }
         }
 
-        private static string FormatMessage(string template, object[] args)
-        {
-            try
-            {
-                return args.Length == 0 ? template : string.Format(template, args);
-            }
-            catch
-            {
-                // If formatting fails, return the template as-is
-                return template;
-            }
-        }
-        
         private static LogLevel GetLogLevel(Event.LogLevel level)
         {
             return level switch

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -64,40 +64,34 @@ namespace Akka.Hosting.Logging
         {
             var logLevel = GetLogLevel(log.LogLevel());
 
+            // Create state dictionary with structured properties from the log message
+            var state = new Dictionary<string, object>();
+
             // Use semantic logging to extract structured properties
             if (log.TryGetProperties(out var properties) && properties is not null)
             {
-                // Create state dictionary with structured properties from the log message
-                var state = new Dictionary<string, object>(properties.Count + 4);
-
                 // Add structured properties from the message template
                 foreach (var prop in properties)
                 {
                     state[prop.Key] = prop.Value;
                 }
-
-                // Add Akka metadata properties
-                state["ActorPath"] = path.ToString();
-                state["Timestamp"] = log.Timestamp;
-                state["Thread"] = log.Thread.ManagedThreadId;
-                state["LogSource"] = log.LogSource;
-
-                // Add {OriginalFormat} key per MEL convention for structured logging
-                // This allows MEL sinks to recognize and preserve the message template
-                state["{OriginalFormat}"] = log.GetTemplate();
-
-                // Log with structured state
-                // Use LogMessage.ToString() which applies the correct formatter (SemanticLogMessageFormatter)
-                // instead of string.Format() which only works with positional {0} placeholders
-                _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
-                    (s, ex) => log.Message is LogMessage logMsg ? logMsg.ToString() ?? string.Empty : log.Message?.ToString() ?? string.Empty);
             }
-            else
-            {
-                // Fallback for non-structured messages (plain strings)
-                _akkaLogger.Log<LogEvent>(logLevel, new EventId(), log, log.Cause,
-                    (@event, exception) => @event.ToString());
-            }
+            
+            // Add Akka metadata properties
+            state["ActorPath"] = path.ToString();
+            state["Timestamp"] = log.Timestamp;
+            state["Thread"] = log.Thread.ManagedThreadId;
+            state["LogSource"] = log.LogSource;
+
+            // Add {OriginalFormat} key per MEL convention for structured logging
+            // This allows MEL sinks to recognize and preserve the message template
+            state["{OriginalFormat}"] = log.GetTemplate();
+
+            // Log with structured state
+            // Use LogMessage.ToString() which applies the correct formatter (SemanticLogMessageFormatter)
+            // instead of string.Format() which only works with positional {0} placeholders
+            _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
+                (s, ex) => log.Message is LogMessage logMsg ? logMsg.ToString() ?? string.Empty : log.Message?.ToString() ?? string.Empty);
         }
 
         private static LogLevel GetLogLevel(Event.LogLevel level)


### PR DESCRIPTION
Fixes #701

## Changes

* Refactor all `LoggerConfigBuilder` properties to be optional
* Refactor message formatting code

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.

