### PR TITLE
feat: add OpenTelemetry trace correlation for LoggerFactoryLogger

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: "dotnet test"
         shell: bash
-        run: dotnet test -c Release 
+        run: dotnet test -c Release
 
       - name: "dotnet pack"
         run: dotnet pack -c Release -o ./bin/nuget

--- a/Akka.Hosting.sln
+++ b/Akka.Hosting.sln
@@ -44,6 +44,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Remote.Hosting.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.LoggingDemo", "src\Examples\Akka.Hosting.LoggingDemo\Akka.Hosting.LoggingDemo.csproj", "{298D7727-FDC6-49B2-9030-CC7F0E09B0B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.OpenTelemetry.Demo", "src\Examples\Akka.Hosting.OpenTelemetry.Demo\Akka.Hosting.OpenTelemetry.Demo.csproj", "{6BCB9636-DAD2-4364-8A83-3D2888FE5AB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.OpenTelemetry.AppHost", "src\Examples\Akka.Hosting.OpenTelemetry.AppHost\Akka.Hosting.OpenTelemetry.AppHost.csproj", "{CC22F505-B648-420E-BC8A-0FCE46082986}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -110,6 +114,14 @@ Global
 		{298D7727-FDC6-49B2-9030-CC7F0E09B0B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{298D7727-FDC6-49B2-9030-CC7F0E09B0B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{298D7727-FDC6-49B2-9030-CC7F0E09B0B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BCB9636-DAD2-4364-8A83-3D2888FE5AB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BCB9636-DAD2-4364-8A83-3D2888FE5AB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BCB9636-DAD2-4364-8A83-3D2888FE5AB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BCB9636-DAD2-4364-8A83-3D2888FE5AB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC22F505-B648-420E-BC8A-0FCE46082986}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC22F505-B648-420E-BC8A-0FCE46082986}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC22F505-B648-420E-BC8A-0FCE46082986}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC22F505-B648-420E-BC8A-0FCE46082986}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -118,6 +130,8 @@ Global
 		{5F6A7BE8-6906-46CE-BA1C-72EA11EFA33B} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
 		{4F79325B-9EE7-4501-800F-7A1F8DFBCC80} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
 		{298D7727-FDC6-49B2-9030-CC7F0E09B0B8} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
+		{6BCB9636-DAD2-4364-8A83-3D2888FE5AB2} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
+		{CC22F505-B648-420E-BC8A-0FCE46082986} = {EFA970FF-6BCC-4C38-84D8-324D40F2BF03}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B99E6BB8-642A-4A68-86DF-69567CBA700A}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.57</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <PackageReleaseNotes>**New Features**
-* [Add semantic logging support for Akka.NET 1.5.56+](https://github.com/akkadotnet/Akka.Hosting/pull/693) - enables Microsoft.Extensions.Logging to receive properly structured state dictionaries instead of pre-formatted strings. When using Akka.NET 1.5.56+, log messages now include structured properties from the semantic logging API along with Akka metadata (ActorPath, Timestamp, Thread, LogSource). Fully backwards compatible with older Akka.NET versions.
+* [Add OpenTelemetry trace correlation support for LoggerFactoryLogger](https://github.com/akkadotnet/Akka.Hosting/issues/700) - enables proper trace correlation for logs emitted from actor code. Solves the problem that Activity.Current doesn't flow across actor mailbox boundaries. When using Akka.NET 1.5.59+, LogEvent.ActivityContext captures trace context at log creation time and flows it through to OpenTelemetry LogRecords via the new AkkaTraceContextProcessor.
 **Updates**
-* [Bump Akka version from 1.5.55 to 1.5.57](https://github.com/akkadotnet/akka.net/releases/tag/1.5.57)</PackageReleaseNotes>
+* [Bump Akka version from 1.5.57 to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* Added OpenTelemetry dependency (1.9.0+) for trace correlation support</PackageReleaseNotes>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>
       https://github.com/akkadotnet/Akka.Hosting
@@ -28,9 +29,9 @@
     <TestSdkVersion>17.11.1</TestSdkVersion>
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
-    <AkkaVersion>1.5.57</AkkaVersion>
-    <MicrosoftExtensionsVersion>[6.0.0,)</MicrosoftExtensionsVersion>
-    <SystemTextJsonVersion>[6.0.10,)</SystemTextJsonVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
+    <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
+    <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,8 +35,8 @@
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
     <AkkaVersion>1.5.59</AkkaVersion>
-    <MicrosoftExtensionsVersion>[6.0.0,)</MicrosoftExtensionsVersion>
-    <SystemTextJsonVersion>[6.0.10,)</SystemTextJsonVersion>
+    <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
+    <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,8 +35,8 @@
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
     <AkkaVersion>1.5.59</AkkaVersion>
-    <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
-    <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
+    <MicrosoftExtensionsVersion>[6.0.0,)</MicrosoftExtensionsVersion>
+    <SystemTextJsonVersion>[6.0.10,)</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See the ["Introduction to Akka.Hosting - HOCON-less, "Pit of Success" Akka.NET R
     * [Microsoft.Extensions.Logging.ILoggerFactory Logging Support](#microsoftextensionsloggingiloggerfactory-logging-support)
     * [Serilog Support](#serilog-support)
     * [Microsoft.Extensions.Logging Log Event Filtering](#microsoftextensionslogging-log-event-filtering)
+- [OpenTelemetry Trace Correlation](#opentelemetry-trace-correlation)
 - [Microsoft.Extensions.Diagnostics.HealthChecks Integration](#healthchecks)
     * [Dependency Injected Health Checks](#healthcheck-di)
     * [Built-in HealthChecks](#healthcheck-builtin)
@@ -626,6 +627,44 @@ To set up the `Microsoft.Extensions.Logging` log filtering, you will need to edi
   }
 }
 ```
+
+[Back to top](#akkahosting)
+
+<a id="opentelemetry-trace-correlation"></a>
+# OpenTelemetry Trace Correlation
+
+Akka.NET processes log events asynchronously, which means `Activity.Current` does not flow across actor mailbox boundaries. To preserve trace correlation, Akka.Hosting captures the `ActivityContext` at log creation time and includes it in the log state. The `AkkaTraceContextProcessor` then applies that context to OpenTelemetry `LogRecord`s so exporters can correlate logs with traces.
+
+Minimal setup:
+
+```csharp
+using Akka.Hosting;
+using Akka.Hosting.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+
+builder.Logging.AddOpenTelemetry(options =>
+{
+    options.SetResourceBuilder(ResourceBuilder.CreateDefault()
+        .AddService("my-service"));
+
+    // Register before exporters
+    options.AddAkkaTraceCorrelation();
+
+    options.AddOtlpExporter();
+});
+
+builder.Services.AddAkka("MySystem", configBuilder =>
+{
+    configBuilder.ConfigureLoggers(setup =>
+    {
+        setup.ClearLoggers();
+        setup.AddLoggerFactory();
+    });
+});
+```
+
+See the demo in `src/Examples/Akka.Hosting.OpenTelemetry.AppHost` and `src/Examples/Akka.Hosting.OpenTelemetry.Demo` for a working Aspire setup.
 
 [Back to top](#akkahosting)
 

--- a/README.md
+++ b/README.md
@@ -651,6 +651,8 @@ builder.Logging.AddOpenTelemetry(options =>
     // Register before exporters
     options.AddAkkaTraceCorrelation();
 
+    // Add OTLP exporter if you have not configured it elsewhere.
+    // Your mileage may vary; use the OpenTelemetry configuration that fits your app.
     options.AddOtlpExporter();
 });
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 1.5.59 January 2026 ####
+
+**New Features**
+* [Add OpenTelemetry trace correlation support for LoggerFactoryLogger](https://github.com/akkadotnet/Akka.Hosting/issues/700) - enables proper trace correlation for logs emitted from actor code. Solves the problem that `Activity.Current` doesn't flow across actor mailbox boundaries because it uses `AsyncLocal<T>`. When using Akka.NET 1.5.59+, `LogEvent.ActivityContext` captures trace context at log creation time and flows it through to OpenTelemetry `LogRecord`s via the new `AkkaTraceContextProcessor`. Register with `options.AddAkkaTraceCorrelation()` in your OpenTelemetry logging configuration.
+
+**Updates**
+* [Bump Akka version from 1.5.57 to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* Added `OpenTelemetry` package dependency (1.9.0+) for trace correlation support
+
 #### 1.5.57 December 16th 2025 ####
 
 **New Features**

--- a/src/Akka.Cluster.Hosting.Tests/ClusterOptionsSpec.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterOptionsSpec.cs
@@ -144,7 +144,7 @@ public class ClusterOptionsSpec
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
         var jsonConfig = new ConfigurationBuilder().AddJsonStream(stream).Build();
         
-        var clusterOptions = jsonConfig.GetSection("Akka:ClusterOptions").Get<ClusterOptions>();
+        var clusterOptions = jsonConfig.GetSection("Akka:ClusterOptions").Get<ClusterOptions>()!;
         clusterOptions.SplitBrainResolver = jsonConfig.GetSection("Akka:KeepMajorityOption").Get<KeepMajorityOption>();
         
         var builder = new AkkaConfigurationBuilder(new ServiceCollection(), "")

--- a/src/Akka.Cluster.Hosting.Tests/XUnitLogger.cs
+++ b/src/Akka.Cluster.Hosting.Tests/XUnitLogger.cs
@@ -58,7 +58,7 @@ public class XUnitLogger: ILogger
         };
     }
 
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         throw new NotImplementedException();
     }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -99,6 +99,10 @@ namespace Akka.Hosting
         public static Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck(this Akka.Hosting.AkkaConfigurationBuilder builder, string name, Akka.Hosting.IAkkaHealthCheck healthCheck, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
         public static Akka.Hosting.AkkaConfigurationBuilder WithHealthCheck(this Akka.Hosting.AkkaConfigurationBuilder builder, string name, System.Func<Akka.Actor.ActorSystem, Akka.Hosting.ActorRegistry, System.Threading.CancellationToken, System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult>> healthCheck, Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus? failureStatus = default, System.Collections.Generic.IEnumerable<string>? tags = null, System.TimeSpan? timeout = default) { }
     }
+    public static class AkkaOpenTelemetryExtensions
+    {
+        public static OpenTelemetry.Logs.OpenTelemetryLoggerOptions AddAkkaTraceCorrelation(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions options) { }
+    }
     public class DeadLetterOptions
     {
         public DeadLetterOptions() { }
@@ -251,6 +255,21 @@ namespace Akka.Hosting.HealthChecks
 }
 namespace Akka.Hosting.Logging
 {
+    public readonly struct AkkaLogState : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.IEnumerable
+    {
+        public const string SpanIdKey = "Akka.SpanId";
+        public const string TraceFlagsKey = "Akka.TraceFlags";
+        public const string TraceIdKey = "Akka.TraceId";
+        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, string formattedMessage) { }
+        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, System.Collections.Generic.IReadOnlyDictionary<string, object> semanticProperties, string actorPath, System.DateTimeOffset timestamp, int threadId, string logSource, string template, string formattedMessage) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { }
+        public override string ToString() { }
+    }
+    public sealed class AkkaTraceContextProcessor : OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord>
+    {
+        public AkkaTraceContextProcessor() { }
+        public override void OnEnd(OpenTelemetry.Logs.LogRecord data) { }
+    }
     public class LoggerFactoryLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
         protected readonly Akka.Event.ILoggingAdapter InternalLogger;

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -261,7 +261,7 @@ namespace Akka.Hosting.Logging
         public const string TraceFlagsKey = "Akka.TraceFlags";
         public const string TraceIdKey = "Akka.TraceId";
         public AkkaLogState(System.Diagnostics.ActivityContext activityContext, string formattedMessage) { }
-        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, System.Collections.Generic.IReadOnlyDictionary<string, object> semanticProperties, string actorPath, System.DateTimeOffset timestamp, int threadId, string logSource, string template, string formattedMessage) { }
+        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, System.Collections.Generic.IReadOnlyDictionary<string, object> semanticProperties, string actorPath, System.DateTime timestamp, int threadId, string logSource, string template, string formattedMessage) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { }
         public override string ToString() { }
     }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -255,16 +255,6 @@ namespace Akka.Hosting.HealthChecks
 }
 namespace Akka.Hosting.Logging
 {
-    public readonly struct AkkaLogState : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.IEnumerable
-    {
-        public const string SpanIdKey = "Akka.SpanId";
-        public const string TraceFlagsKey = "Akka.TraceFlags";
-        public const string TraceIdKey = "Akka.TraceId";
-        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, string formattedMessage) { }
-        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, System.Collections.Generic.IReadOnlyDictionary<string, object> semanticProperties, string actorPath, System.DateTimeOffset timestamp, int threadId, string logSource, string template, string formattedMessage) { }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { }
-        public override string ToString() { }
-    }
     public sealed class AkkaTraceContextProcessor : OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord>
     {
         public AkkaTraceContextProcessor() { }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -261,7 +261,7 @@ namespace Akka.Hosting.Logging
         public const string TraceFlagsKey = "Akka.TraceFlags";
         public const string TraceIdKey = "Akka.TraceId";
         public AkkaLogState(System.Diagnostics.ActivityContext activityContext, string formattedMessage) { }
-        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, System.Collections.Generic.IReadOnlyDictionary<string, object> semanticProperties, string actorPath, System.DateTime timestamp, int threadId, string logSource, string template, string formattedMessage) { }
+        public AkkaLogState(System.Diagnostics.ActivityContext activityContext, System.Collections.Generic.IReadOnlyDictionary<string, object> semanticProperties, string actorPath, System.DateTimeOffset timestamp, int threadId, string logSource, string template, string formattedMessage) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { }
         public override string ToString() { }
     }

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -9,7 +9,8 @@ namespace Akka.Hosting.TestKit.Internals
     public class XUnitLogger : Microsoft.Extensions.Logging.ILogger
     {
         public XUnitLogger(string category, Xunit.Abstractions.ITestOutputHelper helper, Microsoft.Extensions.Logging.LogLevel logLevel) { }
-        public System.IDisposable BeginScope<TState>(TState state) { }
+        public System.IDisposable? BeginScope<TState>(TState state)
+            where TState :  notnull { }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { }
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }

--- a/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />

--- a/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
+++ b/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />

--- a/src/Akka.Hosting.TestKit/Internals/XUnitLogger.cs
+++ b/src/Akka.Hosting.TestKit/Internals/XUnitLogger.cs
@@ -68,7 +68,7 @@ namespace Akka.Hosting.TestKit.Internals
             };
         }
 
-        public IDisposable BeginScope<TState>(TState state) 
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         {
             return NullScope.Instance;
         }

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Akka.Hosting.Tests/Logging/AkkaLogStateSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/AkkaLogStateSpecs.cs
@@ -1,0 +1,261 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaLogStateSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Akka.Hosting.Logging;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.Tests.Logging;
+
+public class AkkaLogStateSpecs
+{
+    [Fact]
+    public void AkkaLogState_WithSemanticProperties_ShouldYieldAllProperties()
+    {
+        // Arrange
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded);
+
+        var semanticProperties = new Dictionary<string, object>
+        {
+            { "UserId", 123 },
+            { "Action", "Login" }
+        };
+
+        var actorPath = "akka://test/user/myactor";
+        var timestamp = DateTimeOffset.UtcNow;
+        var threadId = 42;
+        var logSource = "MyActor";
+        var template = "User {UserId} performed {Action}";
+        var formattedMessage = "User 123 performed Login";
+
+        // Act
+        var state = new AkkaLogState(
+            activityContext,
+            semanticProperties,
+            actorPath,
+            timestamp,
+            threadId,
+            logSource,
+            template,
+            formattedMessage);
+
+        var items = state.ToList();
+
+        // Assert
+        // Should have: 3 trace context + 2 semantic props + 4 Akka metadata + 1 OriginalFormat = 10
+        items.Should().HaveCount(10);
+
+        // Verify trace context (should be ActivityTraceId/ActivitySpanId, not strings)
+        items.Should().Contain(kvp => kvp.Key == AkkaLogState.TraceIdKey && kvp.Value is ActivityTraceId);
+        items.Should().Contain(kvp => kvp.Key == AkkaLogState.SpanIdKey && kvp.Value is ActivitySpanId);
+        items.Should().Contain(kvp => kvp.Key == AkkaLogState.TraceFlagsKey && (int)kvp.Value! == (int)ActivityTraceFlags.Recorded);
+
+        // Verify semantic properties
+        items.Should().Contain(kvp => kvp.Key == "UserId" && (int)kvp.Value! == 123);
+        items.Should().Contain(kvp => kvp.Key == "Action" && (string)kvp.Value! == "Login");
+
+        // Verify Akka metadata
+        items.Should().Contain(kvp => kvp.Key == "ActorPath" && (string)kvp.Value! == actorPath);
+        items.Should().Contain(kvp => kvp.Key == "Timestamp" && (DateTimeOffset)kvp.Value! == timestamp);
+        items.Should().Contain(kvp => kvp.Key == "Thread" && (int)kvp.Value! == threadId);
+        items.Should().Contain(kvp => kvp.Key == "LogSource" && (string)kvp.Value! == logSource);
+
+        // Verify OriginalFormat
+        items.Should().Contain(kvp => kvp.Key == "{OriginalFormat}" && (string)kvp.Value! == template);
+    }
+
+    [Fact]
+    public void AkkaLogState_WithoutTraceContext_ShouldOmitTraceProperties()
+    {
+        // Arrange
+        var activityContext = default(ActivityContext); // No trace context
+
+        var semanticProperties = new Dictionary<string, object>
+        {
+            { "Message", "Hello" }
+        };
+
+        // Act
+        var state = new AkkaLogState(
+            activityContext,
+            semanticProperties,
+            "akka://test/user/actor",
+            DateTimeOffset.UtcNow,
+            1,
+            "Source",
+            "Template",
+            "Formatted");
+
+        var items = state.ToList();
+
+        // Assert
+        // Should have: 0 trace context + 1 semantic prop + 4 Akka metadata + 1 OriginalFormat = 6
+        items.Should().HaveCount(6);
+
+        // Should NOT contain trace context keys
+        items.Should().NotContain(kvp => kvp.Key == AkkaLogState.TraceIdKey);
+        items.Should().NotContain(kvp => kvp.Key == AkkaLogState.SpanIdKey);
+        items.Should().NotContain(kvp => kvp.Key == AkkaLogState.TraceFlagsKey);
+    }
+
+    [Fact]
+    public void AkkaLogState_NonStructuredMessage_ShouldYieldMinimalProperties()
+    {
+        // Arrange
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.None);
+        var message = "Plain text message";
+
+        // Act
+        var state = new AkkaLogState(activityContext, message);
+        var items = state.ToList();
+
+        // Assert
+        // Should have: 3 trace context + 1 OriginalFormat = 4
+        items.Should().HaveCount(4);
+
+        // Verify trace context is present
+        items.Should().Contain(kvp => kvp.Key == AkkaLogState.TraceIdKey);
+        items.Should().Contain(kvp => kvp.Key == AkkaLogState.SpanIdKey);
+        items.Should().Contain(kvp => kvp.Key == AkkaLogState.TraceFlagsKey);
+
+        // Verify OriginalFormat
+        items.Should().Contain(kvp => kvp.Key == "{OriginalFormat}" && (string)kvp.Value! == message);
+
+        // Should NOT contain Akka metadata (ActorPath, etc.)
+        items.Should().NotContain(kvp => kvp.Key == "ActorPath");
+    }
+
+    [Fact]
+    public void AkkaLogState_NonStructuredMessage_WithoutTraceContext_ShouldYieldOnlyOriginalFormat()
+    {
+        // Arrange
+        var activityContext = default(ActivityContext);
+        var message = "Plain text message";
+
+        // Act
+        var state = new AkkaLogState(activityContext, message);
+        var items = state.ToList();
+
+        // Assert
+        // Should have: 0 trace context + 1 OriginalFormat = 1
+        items.Should().HaveCount(1);
+        items.Single().Key.Should().Be("{OriginalFormat}");
+        items.Single().Value.Should().Be(message);
+    }
+
+    [Fact]
+    public void AkkaLogState_ToString_ShouldReturnFormattedMessage()
+    {
+        // Arrange
+        var semanticProperties = new Dictionary<string, object> { { "Name", "World" } };
+        var formattedMessage = "Hello World!";
+
+        var state = new AkkaLogState(
+            default,
+            semanticProperties,
+            "path",
+            DateTimeOffset.UtcNow,
+            1,
+            "source",
+            "Hello {Name}!",
+            formattedMessage);
+
+        // Act & Assert
+        state.ToString().Should().Be(formattedMessage);
+    }
+
+    [Fact]
+    public void AkkaLogState_ShouldBeEnumerableMultipleTimes()
+    {
+        // Arrange
+        var semanticProperties = new Dictionary<string, object> { { "Key", "Value" } };
+        var state = new AkkaLogState(
+            default,
+            semanticProperties,
+            "path",
+            DateTimeOffset.UtcNow,
+            1,
+            "source",
+            "template",
+            "formatted");
+
+        // Act - enumerate multiple times
+        var firstPass = state.ToList();
+        var secondPass = state.ToList();
+
+        // Assert
+        firstPass.Should().BeEquivalentTo(secondPass);
+    }
+
+    [Fact]
+    public void AkkaLogState_TraceContext_ShouldStoreStructsDirectly()
+    {
+        // Arrange - this test verifies we're not allocating strings for TraceId/SpanId
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded);
+
+        var state = new AkkaLogState(
+            activityContext,
+            new Dictionary<string, object>(),
+            "path",
+            DateTimeOffset.UtcNow,
+            1,
+            "source",
+            "template",
+            "formatted");
+
+        // Act
+        var items = state.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        // Assert - values should be the actual struct types, not strings
+        items[AkkaLogState.TraceIdKey].Should().BeOfType<ActivityTraceId>();
+        items[AkkaLogState.SpanIdKey].Should().BeOfType<ActivitySpanId>();
+        items[AkkaLogState.TraceFlagsKey].Should().BeOfType<int>();
+
+        // Verify the actual values match
+        ((ActivityTraceId)items[AkkaLogState.TraceIdKey]!).Should().Be(traceId);
+        ((ActivitySpanId)items[AkkaLogState.SpanIdKey]!).Should().Be(spanId);
+        ((int)items[AkkaLogState.TraceFlagsKey]!).Should().Be((int)ActivityTraceFlags.Recorded);
+    }
+
+    [Fact]
+    public void AkkaLogState_EmptySemanticProperties_ShouldStillYieldAkkaMetadata()
+    {
+        // Arrange
+        var emptyProperties = new Dictionary<string, object>();
+
+        var state = new AkkaLogState(
+            default,
+            emptyProperties,
+            "akka://test/user/actor",
+            DateTimeOffset.UtcNow,
+            99,
+            "TestSource",
+            "template",
+            "formatted");
+
+        // Act
+        var items = state.ToList();
+
+        // Assert
+        // Should have: 0 trace context + 0 semantic props + 4 Akka metadata + 1 OriginalFormat = 5
+        items.Should().HaveCount(5);
+        items.Should().Contain(kvp => kvp.Key == "ActorPath");
+        items.Should().Contain(kvp => kvp.Key == "Timestamp");
+        items.Should().Contain(kvp => kvp.Key == "Thread" && (int)kvp.Value! == 99);
+        items.Should().Contain(kvp => kvp.Key == "LogSource" && (string)kvp.Value! == "TestSource");
+        items.Should().Contain(kvp => kvp.Key == "{OriginalFormat}");
+    }
+}

--- a/src/Akka.Hosting.Tests/Logging/AkkaLogStateSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/AkkaLogStateSpecs.cs
@@ -31,7 +31,7 @@ public class AkkaLogStateSpecs
         };
 
         var actorPath = "akka://test/user/myactor";
-        var timestamp = DateTime.UtcNow;
+        var timestamp = DateTimeOffset.UtcNow;
         var threadId = 42;
         var logSource = "MyActor";
         var template = "User {UserId} performed {Action}";
@@ -65,7 +65,7 @@ public class AkkaLogStateSpecs
 
         // Verify Akka metadata
         items.Should().Contain(kvp => kvp.Key == "ActorPath" && (string)kvp.Value! == actorPath);
-        items.Should().Contain(kvp => kvp.Key == "Timestamp" && (DateTime)kvp.Value! == timestamp);
+        items.Should().Contain(kvp => kvp.Key == "Timestamp" && (DateTimeOffset)kvp.Value! == timestamp);
         items.Should().Contain(kvp => kvp.Key == "Thread" && (int)kvp.Value! == threadId);
         items.Should().Contain(kvp => kvp.Key == "LogSource" && (string)kvp.Value! == logSource);
 
@@ -89,7 +89,7 @@ public class AkkaLogStateSpecs
             activityContext,
             semanticProperties,
             "akka://test/user/actor",
-            DateTime.UtcNow,
+            DateTimeOffset.UtcNow,
             1,
             "Source",
             "Template",
@@ -165,7 +165,7 @@ public class AkkaLogStateSpecs
             default,
             semanticProperties,
             "path",
-            DateTime.UtcNow,
+            DateTimeOffset.UtcNow,
             1,
             "source",
             "Hello {Name}!",
@@ -184,7 +184,7 @@ public class AkkaLogStateSpecs
             default,
             semanticProperties,
             "path",
-            DateTime.UtcNow,
+            DateTimeOffset.UtcNow,
             1,
             "source",
             "template",
@@ -210,7 +210,7 @@ public class AkkaLogStateSpecs
             activityContext,
             new Dictionary<string, object>(),
             "path",
-            DateTime.UtcNow,
+            DateTimeOffset.UtcNow,
             1,
             "source",
             "template",
@@ -240,7 +240,7 @@ public class AkkaLogStateSpecs
             default,
             emptyProperties,
             "akka://test/user/actor",
-            DateTime.UtcNow,
+            DateTimeOffset.UtcNow,
             99,
             "TestSource",
             "template",

--- a/src/Akka.Hosting.Tests/Logging/AkkaLogStateSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/AkkaLogStateSpecs.cs
@@ -31,7 +31,7 @@ public class AkkaLogStateSpecs
         };
 
         var actorPath = "akka://test/user/myactor";
-        var timestamp = DateTimeOffset.UtcNow;
+        var timestamp = DateTime.UtcNow;
         var threadId = 42;
         var logSource = "MyActor";
         var template = "User {UserId} performed {Action}";
@@ -65,7 +65,7 @@ public class AkkaLogStateSpecs
 
         // Verify Akka metadata
         items.Should().Contain(kvp => kvp.Key == "ActorPath" && (string)kvp.Value! == actorPath);
-        items.Should().Contain(kvp => kvp.Key == "Timestamp" && (DateTimeOffset)kvp.Value! == timestamp);
+        items.Should().Contain(kvp => kvp.Key == "Timestamp" && (DateTime)kvp.Value! == timestamp);
         items.Should().Contain(kvp => kvp.Key == "Thread" && (int)kvp.Value! == threadId);
         items.Should().Contain(kvp => kvp.Key == "LogSource" && (string)kvp.Value! == logSource);
 
@@ -89,7 +89,7 @@ public class AkkaLogStateSpecs
             activityContext,
             semanticProperties,
             "akka://test/user/actor",
-            DateTimeOffset.UtcNow,
+            DateTime.UtcNow,
             1,
             "Source",
             "Template",
@@ -165,7 +165,7 @@ public class AkkaLogStateSpecs
             default,
             semanticProperties,
             "path",
-            DateTimeOffset.UtcNow,
+            DateTime.UtcNow,
             1,
             "source",
             "Hello {Name}!",
@@ -184,7 +184,7 @@ public class AkkaLogStateSpecs
             default,
             semanticProperties,
             "path",
-            DateTimeOffset.UtcNow,
+            DateTime.UtcNow,
             1,
             "source",
             "template",
@@ -210,7 +210,7 @@ public class AkkaLogStateSpecs
             activityContext,
             new Dictionary<string, object>(),
             "path",
-            DateTimeOffset.UtcNow,
+            DateTime.UtcNow,
             1,
             "source",
             "template",
@@ -240,7 +240,7 @@ public class AkkaLogStateSpecs
             default,
             emptyProperties,
             "akka://test/user/actor",
-            DateTimeOffset.UtcNow,
+            DateTime.UtcNow,
             99,
             "TestSource",
             "template",

--- a/src/Akka.Hosting.Tests/Logging/AkkaTraceContextProcessorSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/AkkaTraceContextProcessorSpecs.cs
@@ -245,7 +245,7 @@ public class AkkaTraceContextProcessorSpecs
             activityContext,
             new Dictionary<string, object> { { "Key", "Value" } },
             "akka://test/user/actor",
-            DateTime.UtcNow,
+            DateTimeOffset.UtcNow,
             1,
             "TestSource",
             "Template with {Key}",

--- a/src/Akka.Hosting.Tests/Logging/AkkaTraceContextProcessorSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/AkkaTraceContextProcessorSpecs.cs
@@ -245,7 +245,7 @@ public class AkkaTraceContextProcessorSpecs
             activityContext,
             new Dictionary<string, object> { { "Key", "Value" } },
             "akka://test/user/actor",
-            DateTimeOffset.UtcNow,
+            DateTime.UtcNow,
             1,
             "TestSource",
             "Template with {Key}",

--- a/src/Akka.Hosting.Tests/Logging/AkkaTraceContextProcessorSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/AkkaTraceContextProcessorSpecs.cs
@@ -1,0 +1,326 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaTraceContextProcessorSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Akka.Hosting.Logging;
+using FluentAssertions;
+using OpenTelemetry.Logs;
+using Xunit;
+
+namespace Akka.Hosting.Tests.Logging;
+
+public class AkkaTraceContextProcessorSpecs
+{
+    [Fact]
+    public void Processor_ShouldExtractTraceContext_FromActivityTraceIdAndSpanId()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var traceFlags = ActivityTraceFlags.Recorded;
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, traceId),
+            new(AkkaLogState.SpanIdKey, spanId),
+            new(AkkaLogState.TraceFlagsKey, (int)traceFlags)
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert
+        logRecord.TraceId.Should().Be(traceId);
+        logRecord.SpanId.Should().Be(spanId);
+        logRecord.TraceFlags.Should().Be(traceFlags);
+    }
+
+    [Fact]
+    public void Processor_ShouldExtractTraceContext_FromStringRepresentation()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+
+        // Use string representation (backwards compatibility path)
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, traceId.ToString()),
+            new(AkkaLogState.SpanIdKey, spanId.ToString()),
+            new(AkkaLogState.TraceFlagsKey, (int)ActivityTraceFlags.None)
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert
+        logRecord.TraceId.Should().Be(traceId);
+        logRecord.SpanId.Should().Be(spanId);
+    }
+
+    [Fact]
+    public void Processor_ShouldSkip_WhenTraceIdAlreadySet()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var existingTraceId = ActivityTraceId.CreateRandom();
+        var existingSpanId = ActivitySpanId.CreateRandom();
+        var newTraceId = ActivityTraceId.CreateRandom();
+        var newSpanId = ActivitySpanId.CreateRandom();
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, newTraceId),
+            new(AkkaLogState.SpanIdKey, newSpanId),
+            new(AkkaLogState.TraceFlagsKey, (int)ActivityTraceFlags.Recorded)
+        };
+
+        var logRecord = CreateLogRecordWithExistingTrace(attributes, existingTraceId, existingSpanId);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert - should keep existing trace context
+        logRecord.TraceId.Should().Be(existingTraceId);
+        logRecord.SpanId.Should().Be(existingSpanId);
+    }
+
+    [Fact]
+    public void Processor_ShouldSkip_WhenNoAttributes()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var logRecord = CreateLogRecord(null);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert - should remain default
+        logRecord.TraceId.Should().Be(default(ActivityTraceId));
+        logRecord.SpanId.Should().Be(default(ActivitySpanId));
+    }
+
+    [Fact]
+    public void Processor_ShouldSkip_WhenMissingTraceId()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var spanId = ActivitySpanId.CreateRandom();
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            // Missing TraceId
+            new(AkkaLogState.SpanIdKey, spanId),
+            new(AkkaLogState.TraceFlagsKey, 0)
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert - should not set partial trace context
+        logRecord.TraceId.Should().Be(default(ActivityTraceId));
+        logRecord.SpanId.Should().Be(default(ActivitySpanId));
+    }
+
+    [Fact]
+    public void Processor_ShouldSkip_WhenMissingSpanId()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var traceId = ActivityTraceId.CreateRandom();
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, traceId),
+            // Missing SpanId
+            new(AkkaLogState.TraceFlagsKey, 0)
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert - should not set partial trace context
+        logRecord.TraceId.Should().Be(default(ActivityTraceId));
+        logRecord.SpanId.Should().Be(default(ActivitySpanId));
+    }
+
+    [Fact]
+    public void Processor_ShouldHandle_InvalidStringTraceId()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var spanId = ActivitySpanId.CreateRandom();
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, "invalid-trace-id"), // Invalid format
+            new(AkkaLogState.SpanIdKey, spanId),
+            new(AkkaLogState.TraceFlagsKey, 0)
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert - should not crash, should not set invalid trace context
+        logRecord.TraceId.Should().Be(default(ActivityTraceId));
+    }
+
+    [Fact]
+    public void Processor_ShouldHandle_UnexpectedValueTypes()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, 12345), // Wrong type (int instead of ActivityTraceId or string)
+            new(AkkaLogState.SpanIdKey, new object()), // Wrong type
+            new(AkkaLogState.TraceFlagsKey, "not-an-int")
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act - should not throw
+        var act = () => processor.OnEnd(logRecord);
+
+        // Assert
+        act.Should().NotThrow();
+        logRecord.TraceId.Should().Be(default(ActivityTraceId));
+    }
+
+    [Fact]
+    public void Processor_ShouldDefaultTraceFlags_WhenNotProvided()
+    {
+        // Arrange
+        var processor = new AkkaTraceContextProcessor();
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new(AkkaLogState.TraceIdKey, traceId),
+            new(AkkaLogState.SpanIdKey, spanId)
+            // No TraceFlags
+        };
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert
+        logRecord.TraceId.Should().Be(traceId);
+        logRecord.SpanId.Should().Be(spanId);
+        logRecord.TraceFlags.Should().Be(ActivityTraceFlags.None);
+    }
+
+    [Fact]
+    public void Processor_ShouldWork_WithAkkaLogState()
+    {
+        // Arrange - integration test with actual AkkaLogState
+        var processor = new AkkaTraceContextProcessor();
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded);
+
+        var state = new AkkaLogState(
+            activityContext,
+            new Dictionary<string, object> { { "Key", "Value" } },
+            "akka://test/user/actor",
+            DateTimeOffset.UtcNow,
+            1,
+            "TestSource",
+            "Template with {Key}",
+            "Template with Value");
+
+        // Convert state to attributes list (simulating what MEL does)
+        var attributes = new List<KeyValuePair<string, object?>>();
+        foreach (var kvp in state)
+        {
+            attributes.Add(kvp);
+        }
+
+        var logRecord = CreateLogRecord(attributes);
+
+        // Act
+        processor.OnEnd(logRecord);
+
+        // Assert
+        logRecord.TraceId.Should().Be(traceId);
+        logRecord.SpanId.Should().Be(spanId);
+        logRecord.TraceFlags.Should().Be(ActivityTraceFlags.Recorded);
+    }
+
+    /// <summary>
+    /// Creates a LogRecord instance using UnsafeAccessor to call the internal constructor.
+    /// </summary>
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+    private static extern LogRecord CreateLogRecordInstance();
+
+    /// <summary>
+    /// Sets the Attributes property on a LogRecord using UnsafeAccessor.
+    /// </summary>
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Attributes")]
+    private static extern void SetAttributes(LogRecord record, IReadOnlyList<KeyValuePair<string, object?>>? value);
+
+    /// <summary>
+    /// Sets the TraceId property on a LogRecord using UnsafeAccessor.
+    /// </summary>
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_TraceId")]
+    private static extern void SetTraceId(LogRecord record, ActivityTraceId value);
+
+    /// <summary>
+    /// Sets the SpanId property on a LogRecord using UnsafeAccessor.
+    /// </summary>
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_SpanId")]
+    private static extern void SetSpanId(LogRecord record, ActivitySpanId value);
+
+    /// <summary>
+    /// Creates a LogRecord with the specified attributes.
+    /// </summary>
+    private static LogRecord CreateLogRecord(IReadOnlyList<KeyValuePair<string, object?>>? attributes)
+    {
+        var logRecord = CreateLogRecordInstance();
+
+        if (attributes != null)
+        {
+            SetAttributes(logRecord, attributes);
+        }
+
+        return logRecord;
+    }
+
+    /// <summary>
+    /// Creates a LogRecord with existing trace context set.
+    /// </summary>
+    private static LogRecord CreateLogRecordWithExistingTrace(
+        IReadOnlyList<KeyValuePair<string, object?>>? attributes,
+        ActivityTraceId traceId,
+        ActivitySpanId spanId)
+    {
+        var logRecord = CreateLogRecord(attributes);
+
+        SetTraceId(logRecord, traceId);
+        SetSpanId(logRecord, spanId);
+
+        return logRecord;
+    }
+}

--- a/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
@@ -61,7 +61,7 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
         entry.State.Should().ContainKey("{OriginalFormat}");
         
         entry.State["ActorPath"].Should().BeOfType<string>();
-        entry.State["Timestamp"].Should().BeOfType<DateTimeOffset>();
+        entry.State["Timestamp"].Should().BeOfType<DateTime>();
         entry.State["Thread"].Should().BeOfType<int>();
         entry.State["LogSource"].Should().BeOfType<string>();
         entry.State["{OriginalFormat}"].Should().BeOfType<string>();

--- a/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
@@ -61,7 +61,7 @@ public class Issue701SemanticLoggingRegressionSpecs : TestKit.TestKit
         entry.State.Should().ContainKey("{OriginalFormat}");
         
         entry.State["ActorPath"].Should().BeOfType<string>();
-        entry.State["Timestamp"].Should().BeOfType<DateTime>();
+        entry.State["Timestamp"].Should().BeOfType<DateTimeOffset>();
         entry.State["Thread"].Should().BeOfType<int>();
         entry.State["LogSource"].Should().BeOfType<string>();
         entry.State["{OriginalFormat}"].Should().BeOfType<string>();

--- a/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
@@ -277,7 +277,7 @@ public class BugReproTestSink : ILogger
 
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public IDisposable BeginScope<TState>(TState state) => EmptyDisposable.Instance;
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => EmptyDisposable.Instance;
 }
 
 public class BugReproLogEntry

--- a/src/Akka.Hosting.Tests/Logging/SemanticLoggingSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/SemanticLoggingSpecs.cs
@@ -377,7 +377,7 @@ public class SemanticTestLogger : ILogger
 
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public IDisposable BeginScope<TState>(TState state) => EmptyDisposable.Instance;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => EmptyDisposable.Instance;
 }
 
 public class LogEntry

--- a/src/Akka.Hosting.Tests/Logging/TestLogger.cs
+++ b/src/Akka.Hosting.Tests/Logging/TestLogger.cs
@@ -76,7 +76,7 @@ public class TestLogger : ILogger
         return true;
     }
 
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         return EmptyDisposable.Instance;
     }

--- a/src/Akka.Hosting.Tests/XUnitLogger.cs
+++ b/src/Akka.Hosting.Tests/XUnitLogger.cs
@@ -58,7 +58,7 @@ public class XUnitLogger: ILogger
         };
     }
 
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         throw new NotImplementedException();
     }

--- a/src/Akka.Hosting/Akka.Hosting.csproj
+++ b/src/Akka.Hosting/Akka.Hosting.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="OpenTelemetry" Version="[1.9.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Hosting/AkkaOpenTelemetryExtensions.cs
+++ b/src/Akka.Hosting/AkkaOpenTelemetryExtensions.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaOpenTelemetryExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Hosting.Logging;
+using OpenTelemetry.Logs;
+
+namespace Akka.Hosting
+{
+    /// <summary>
+    /// Extension methods for integrating Akka.NET logging with OpenTelemetry.
+    /// </summary>
+    public static class AkkaOpenTelemetryExtensions
+    {
+        /// <summary>
+        /// Adds the Akka.NET trace correlation processor to the OpenTelemetry logging pipeline.
+        /// </summary>
+        /// <param name="options">The OpenTelemetry logger options.</param>
+        /// <returns>The options instance for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// This processor extracts trace context (TraceId, SpanId, TraceFlags) from Akka.NET
+        /// log events and applies them to OpenTelemetry <see cref="OpenTelemetry.Logs.LogRecord"/>
+        /// instances. This enables proper trace correlation for logs emitted from actor code,
+        /// solving the problem that <see cref="System.Diagnostics.Activity.Current"/> doesn't
+        /// flow across actor mailbox boundaries.
+        /// </para>
+        /// <para>
+        /// <b>Important:</b> This processor should be registered <b>before</b> any exporters
+        /// to ensure the trace context is applied before logs are exported.
+        /// </para>
+        /// <example>
+        /// <code>
+        /// builder.Logging.AddOpenTelemetry(options =>
+        /// {
+        ///     options.SetResourceBuilder(ResourceBuilder.CreateDefault()
+        ///         .AddService("my-service"));
+        ///
+        ///     // Register Akka trace correlation FIRST (before exporters)
+        ///     options.AddAkkaTraceCorrelation();
+        ///
+        ///     options.AddOtlpExporter();
+        /// });
+        /// </code>
+        /// </example>
+        /// </remarks>
+        public static OpenTelemetryLoggerOptions AddAkkaTraceCorrelation(this OpenTelemetryLoggerOptions options)
+        {
+            options.AddProcessor(new AkkaTraceContextProcessor());
+            return options;
+        }
+    }
+}

--- a/src/Akka.Hosting/Logging/AkkaLogState.cs
+++ b/src/Akka.Hosting/Logging/AkkaLogState.cs
@@ -47,7 +47,7 @@ namespace Akka.Hosting.Logging
         private readonly ActivityContext _activityContext;
         private readonly IReadOnlyDictionary<string, object>? _semanticProperties;
         private readonly string _actorPath;
-        private readonly DateTimeOffset _timestamp;
+        private readonly DateTime _timestamp;
         private readonly int _threadId;
         private readonly string _logSource;
         private readonly string _template;
@@ -69,7 +69,7 @@ namespace Akka.Hosting.Logging
             ActivityContext activityContext,
             IReadOnlyDictionary<string, object> semanticProperties,
             string actorPath,
-            DateTimeOffset timestamp,
+            DateTime timestamp,
             int threadId,
             string logSource,
             string template,

--- a/src/Akka.Hosting/Logging/AkkaLogState.cs
+++ b/src/Akka.Hosting/Logging/AkkaLogState.cs
@@ -47,7 +47,7 @@ namespace Akka.Hosting.Logging
         private readonly ActivityContext _activityContext;
         private readonly IReadOnlyDictionary<string, object>? _semanticProperties;
         private readonly string _actorPath;
-        private readonly DateTime _timestamp;
+        private readonly DateTimeOffset _timestamp;
         private readonly int _threadId;
         private readonly string _logSource;
         private readonly string _template;
@@ -69,7 +69,7 @@ namespace Akka.Hosting.Logging
             ActivityContext activityContext,
             IReadOnlyDictionary<string, object> semanticProperties,
             string actorPath,
-            DateTime timestamp,
+            DateTimeOffset timestamp,
             int threadId,
             string logSource,
             string template,

--- a/src/Akka.Hosting/Logging/AkkaLogState.cs
+++ b/src/Akka.Hosting/Logging/AkkaLogState.cs
@@ -1,0 +1,151 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaLogState.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Akka.Hosting.Logging
+{
+    /// <summary>
+    /// Log state struct that carries both structured log properties and OpenTelemetry trace context.
+    /// Implements <see cref="IEnumerable{T}"/> for compatibility with Microsoft.Extensions.Logging.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This struct is designed for minimal allocations - it holds references to existing data
+    /// and yields values lazily via the enumerator rather than copying into a new collection.
+    /// </para>
+    /// <para>
+    /// This struct is used to propagate trace context (TraceId, SpanId, TraceFlags) from the
+    /// originating actor thread to the logging infrastructure, solving the problem that
+    /// <see cref="Activity.Current"/> doesn't flow across actor mailbox boundaries because
+    /// it uses <see cref="AsyncLocal{T}"/>.
+    /// </para>
+    /// </remarks>
+    public readonly struct AkkaLogState : IEnumerable<KeyValuePair<string, object?>>
+    {
+        /// <summary>
+        /// Key for the trace ID in the log state dictionary.
+        /// </summary>
+        public const string TraceIdKey = "Akka.TraceId";
+
+        /// <summary>
+        /// Key for the span ID in the log state dictionary.
+        /// </summary>
+        public const string SpanIdKey = "Akka.SpanId";
+
+        /// <summary>
+        /// Key for the trace flags in the log state dictionary.
+        /// </summary>
+        public const string TraceFlagsKey = "Akka.TraceFlags";
+
+        private readonly ActivityContext _activityContext;
+        private readonly IReadOnlyDictionary<string, object>? _semanticProperties;
+        private readonly string _actorPath;
+        private readonly DateTimeOffset _timestamp;
+        private readonly int _threadId;
+        private readonly string _logSource;
+        private readonly string _template;
+        private readonly string _formattedMessage;
+        private readonly bool _hasSemanticProperties;
+
+        /// <summary>
+        /// Creates an <see cref="AkkaLogState"/> with trace context, semantic properties, and Akka metadata.
+        /// </summary>
+        /// <param name="activityContext">The activity context containing trace correlation IDs.</param>
+        /// <param name="semanticProperties">Structured properties from the log message template (referenced, not copied).</param>
+        /// <param name="actorPath">The path of the actor that generated the log.</param>
+        /// <param name="timestamp">The timestamp when the log was created.</param>
+        /// <param name="threadId">The managed thread ID of the originating thread.</param>
+        /// <param name="logSource">The source of the log event.</param>
+        /// <param name="template">The message template string.</param>
+        /// <param name="formattedMessage">The pre-formatted message for display.</param>
+        public AkkaLogState(
+            ActivityContext activityContext,
+            IReadOnlyDictionary<string, object> semanticProperties,
+            string actorPath,
+            DateTimeOffset timestamp,
+            int threadId,
+            string logSource,
+            string template,
+            string formattedMessage)
+        {
+            _activityContext = activityContext;
+            _semanticProperties = semanticProperties;
+            _actorPath = actorPath;
+            _timestamp = timestamp;
+            _threadId = threadId;
+            _logSource = logSource;
+            _template = template;
+            _formattedMessage = formattedMessage;
+            _hasSemanticProperties = true;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="AkkaLogState"/> with trace context for non-structured messages.
+        /// </summary>
+        /// <param name="activityContext">The activity context containing trace correlation IDs.</param>
+        /// <param name="formattedMessage">The formatted log message.</param>
+        public AkkaLogState(ActivityContext activityContext, string formattedMessage)
+        {
+            _activityContext = activityContext;
+            _formattedMessage = formattedMessage;
+            _semanticProperties = null;
+            _actorPath = string.Empty;
+            _timestamp = default;
+            _threadId = 0;
+            _logSource = string.Empty;
+            _template = formattedMessage;
+            _hasSemanticProperties = false;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            // Yield trace context if present (store structs directly, no ToString() allocation)
+            if (_activityContext.TraceId != default)
+            {
+                yield return new KeyValuePair<string, object?>(TraceIdKey, _activityContext.TraceId);
+                yield return new KeyValuePair<string, object?>(SpanIdKey, _activityContext.SpanId);
+                yield return new KeyValuePair<string, object?>(TraceFlagsKey, (int)_activityContext.TraceFlags);
+            }
+
+            if (_hasSemanticProperties)
+            {
+                // Yield semantic properties (referenced, not copied)
+                if (_semanticProperties != null)
+                {
+                    foreach (var prop in _semanticProperties)
+                    {
+                        yield return new KeyValuePair<string, object?>(prop.Key, prop.Value);
+                    }
+                }
+
+                // Yield Akka metadata
+                yield return new KeyValuePair<string, object?>("ActorPath", _actorPath);
+                yield return new KeyValuePair<string, object?>("Timestamp", _timestamp);
+                yield return new KeyValuePair<string, object?>("Thread", _threadId);
+                yield return new KeyValuePair<string, object?>("LogSource", _logSource);
+
+                // Yield OriginalFormat for MEL convention
+                yield return new KeyValuePair<string, object?>("{OriginalFormat}", _template);
+            }
+            else
+            {
+                // For non-structured messages, just yield OriginalFormat
+                yield return new KeyValuePair<string, object?>("{OriginalFormat}", _template);
+            }
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        public override string ToString() => _formattedMessage;
+    }
+}

--- a/src/Akka.Hosting/Logging/AkkaLogState.cs
+++ b/src/Akka.Hosting/Logging/AkkaLogState.cs
@@ -27,7 +27,7 @@ namespace Akka.Hosting.Logging
     /// it uses <see cref="AsyncLocal{T}"/>.
     /// </para>
     /// </remarks>
-    public readonly struct AkkaLogState : IEnumerable<KeyValuePair<string, object?>>
+    internal readonly struct AkkaLogState : IEnumerable<KeyValuePair<string, object?>>
     {
         /// <summary>
         /// Key for the trace ID in the log state dictionary.

--- a/src/Akka.Hosting/Logging/AkkaTraceContextProcessor.cs
+++ b/src/Akka.Hosting/Logging/AkkaTraceContextProcessor.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 
@@ -112,11 +111,18 @@ namespace Akka.Hosting.Logging
 
         private static void SetTraceContext(LogRecord record, ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags)
         {
+            // LogRecord has internal setters, so we need to use reflection
             try
             {
-                SetTraceId(record, traceId);
-                SetSpanId(record, spanId);
-                SetTraceFlags(record, traceFlags);
+                var recordType = typeof(LogRecord);
+
+                var traceIdProp = recordType.GetProperty("TraceId");
+                var spanIdProp = recordType.GetProperty("SpanId");
+                var traceFlagsProp = recordType.GetProperty("TraceFlags");
+
+                traceIdProp?.SetValue(record, traceId);
+                spanIdProp?.SetValue(record, spanId);
+                traceFlagsProp?.SetValue(record, traceFlags);
             }
             catch
             {
@@ -124,15 +130,6 @@ namespace Akka.Hosting.Logging
                 // The trace context attributes are still present in the log state
             }
         }
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_TraceId")]
-        private static extern void SetTraceId(LogRecord record, ActivityTraceId value);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_SpanId")]
-        private static extern void SetSpanId(LogRecord record, ActivitySpanId value);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_TraceFlags")]
-        private static extern void SetTraceFlags(LogRecord record, ActivityTraceFlags value);
 
         private static ActivityTraceId? TryParseTraceId(string traceIdStr)
         {

--- a/src/Akka.Hosting/Logging/AkkaTraceContextProcessor.cs
+++ b/src/Akka.Hosting/Logging/AkkaTraceContextProcessor.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 
@@ -111,18 +112,11 @@ namespace Akka.Hosting.Logging
 
         private static void SetTraceContext(LogRecord record, ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags)
         {
-            // LogRecord has internal setters, so we need to use reflection
             try
             {
-                var recordType = typeof(LogRecord);
-
-                var traceIdProp = recordType.GetProperty("TraceId");
-                var spanIdProp = recordType.GetProperty("SpanId");
-                var traceFlagsProp = recordType.GetProperty("TraceFlags");
-
-                traceIdProp?.SetValue(record, traceId);
-                spanIdProp?.SetValue(record, spanId);
-                traceFlagsProp?.SetValue(record, traceFlags);
+                SetTraceId(record, traceId);
+                SetSpanId(record, spanId);
+                SetTraceFlags(record, traceFlags);
             }
             catch
             {
@@ -130,6 +124,15 @@ namespace Akka.Hosting.Logging
                 // The trace context attributes are still present in the log state
             }
         }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_TraceId")]
+        private static extern void SetTraceId(LogRecord record, ActivityTraceId value);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_SpanId")]
+        private static extern void SetSpanId(LogRecord record, ActivitySpanId value);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_TraceFlags")]
+        private static extern void SetTraceFlags(LogRecord record, ActivityTraceFlags value);
 
         private static ActivityTraceId? TryParseTraceId(string traceIdStr)
         {

--- a/src/Akka.Hosting/Logging/AkkaTraceContextProcessor.cs
+++ b/src/Akka.Hosting/Logging/AkkaTraceContextProcessor.cs
@@ -1,0 +1,168 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaTraceContextProcessor.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace Akka.Hosting.Logging
+{
+    /// <summary>
+    /// OpenTelemetry log processor that extracts trace context from Akka.NET log events
+    /// and applies it to the <see cref="LogRecord"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This processor solves the problem that <see cref="Activity.Current"/> doesn't flow
+    /// across actor mailbox boundaries because it uses <see cref="AsyncLocal{T}"/>.
+    /// </para>
+    /// <para>
+    /// When <see cref="LoggerFactoryLogger"/> emits logs, it includes the original
+    /// <see cref="ActivityContext"/> captured at log creation time as attributes
+    /// (Akka.TraceId, Akka.SpanId, Akka.TraceFlags). This processor extracts those
+    /// attributes and sets them on the <see cref="LogRecord"/> so that the log
+    /// is properly correlated with the originating trace.
+    /// </para>
+    /// </remarks>
+    public sealed class AkkaTraceContextProcessor : BaseProcessor<LogRecord>
+    {
+        /// <inheritdoc />
+        public override void OnEnd(LogRecord data)
+        {
+            // Skip if TraceId is already set (e.g., from Activity.Current that happened to be present)
+            if (data.TraceId != default)
+            {
+                return;
+            }
+
+            // Try to extract trace context from Akka log state attributes
+            var attributes = data.Attributes;
+            if (attributes == null)
+            {
+                return;
+            }
+
+            ActivityTraceId? traceId = null;
+            ActivitySpanId? spanId = null;
+            ActivityTraceFlags traceFlags = ActivityTraceFlags.None;
+
+            foreach (var attr in attributes)
+            {
+                switch (attr.Key)
+                {
+                    case AkkaLogState.TraceIdKey:
+                        traceId = ExtractTraceId(attr.Value);
+                        break;
+
+                    case AkkaLogState.SpanIdKey:
+                        spanId = ExtractSpanId(attr.Value);
+                        break;
+
+                    case AkkaLogState.TraceFlagsKey when attr.Value is int flagsInt:
+                        traceFlags = (ActivityTraceFlags)flagsInt;
+                        break;
+                }
+            }
+
+            // Only set trace context if we found both TraceId and SpanId
+            if (traceId.HasValue && spanId.HasValue)
+            {
+                SetTraceContext(data, traceId.Value, spanId.Value, traceFlags);
+            }
+        }
+
+        private static ActivityTraceId? ExtractTraceId(object? value)
+        {
+            // Handle ActivityTraceId directly (no allocation path)
+            if (value is ActivityTraceId traceId)
+            {
+                return traceId;
+            }
+
+            // Fallback: handle string representation (for backwards compatibility)
+            if (value is string traceIdStr)
+            {
+                return TryParseTraceId(traceIdStr);
+            }
+
+            return null;
+        }
+
+        private static ActivitySpanId? ExtractSpanId(object? value)
+        {
+            // Handle ActivitySpanId directly (no allocation path)
+            if (value is ActivitySpanId spanId)
+            {
+                return spanId;
+            }
+
+            // Fallback: handle string representation (for backwards compatibility)
+            if (value is string spanIdStr)
+            {
+                return TryParseSpanId(spanIdStr);
+            }
+
+            return null;
+        }
+
+        private static void SetTraceContext(LogRecord record, ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags)
+        {
+            // LogRecord has internal setters, so we need to use reflection
+            try
+            {
+                var recordType = typeof(LogRecord);
+
+                var traceIdProp = recordType.GetProperty("TraceId");
+                var spanIdProp = recordType.GetProperty("SpanId");
+                var traceFlagsProp = recordType.GetProperty("TraceFlags");
+
+                traceIdProp?.SetValue(record, traceId);
+                spanIdProp?.SetValue(record, spanId);
+                traceFlagsProp?.SetValue(record, traceFlags);
+            }
+            catch
+            {
+                // Silently ignore reflection failures
+                // The trace context attributes are still present in the log state
+            }
+        }
+
+        private static ActivityTraceId? TryParseTraceId(string traceIdStr)
+        {
+            try
+            {
+                // ActivityTraceId expects a 32 character hex string
+                if (traceIdStr.Length == 32)
+                {
+                    return ActivityTraceId.CreateFromString(traceIdStr.AsSpan());
+                }
+            }
+            catch
+            {
+                // Ignore parse failures
+            }
+            return null;
+        }
+
+        private static ActivitySpanId? TryParseSpanId(string spanIdStr)
+        {
+            try
+            {
+                // ActivitySpanId expects a 16 character hex string
+                if (spanIdStr.Length == 16)
+                {
+                    return ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
+                }
+            }
+            catch
+            {
+                // Ignore parse failures
+            }
+            return null;
+        }
+    }
+}

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -65,7 +65,7 @@ namespace Akka.Hosting.Logging
             var logLevel = GetLogLevel(log.LogLevel());
 
             // Capture ActivityContext (Akka.NET 1.5.59+) for trace correlation
-            var activityContext = log.ActivityContext;
+            var activityContext = log.ActivityContext ?? default;
 
             // Use semantic logging to extract structured properties
             if (log.TryGetProperties(out var properties) && properties is not null)
@@ -90,7 +90,7 @@ namespace Akka.Hosting.Logging
             {
                 var formattedMessage = SafeFormat(log);
 
-                if (activityContext.TraceId != default)
+                if (log.ActivityContext.HasValue)
                 {
                     // Preserve trace context even for non-structured logs
                     var state = new AkkaLogState(activityContext, formattedMessage);

--- a/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
+++ b/src/Akka.Hosting/Logging/LoggerFactoryLogger.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Akka.Actor;
@@ -64,38 +65,76 @@ namespace Akka.Hosting.Logging
         {
             var logLevel = GetLogLevel(log.LogLevel());
 
+            // Try to get ActivityContext for OpenTelemetry trace correlation
+            // This captures trace context that was active when the log was created,
+            // solving the problem that Activity.Current doesn't flow across mailbox boundaries
+            var activityContext = TryGetActivityContext(log);
+
             // Use semantic logging to extract structured properties
             if (log.TryGetProperties(out var properties) && properties is not null)
             {
-                // Create state dictionary with structured properties from the log message
-                var state = new Dictionary<string, object>(properties.Count + 4);
+                var formattedMessage = FormatMessage(log.GetTemplate(), log.GetParameters().ToArray());
 
-                // Add structured properties from the message template
-                foreach (var prop in properties)
-                {
-                    state[prop.Key] = prop.Value;
-                }
+                // Use AkkaLogState to include trace context with structured properties
+                var state = new AkkaLogState(
+                    activityContext,
+                    properties,
+                    path.ToString(),
+                    log.Timestamp,
+                    log.Thread.ManagedThreadId,
+                    log.LogSource,
+                    log.GetTemplate(),
+                    formattedMessage);
 
-                // Add Akka metadata properties
-                state["ActorPath"] = path.ToString();
-                state["Timestamp"] = log.Timestamp;
-                state["Thread"] = log.Thread.ManagedThreadId;
-                state["LogSource"] = log.LogSource;
-
-                // Add {OriginalFormat} key per MEL convention for structured logging
-                // This allows MEL sinks to recognize and preserve the message template
-                state["{OriginalFormat}"] = log.GetTemplate();
-
-                // Log with structured state
+                // Log with structured state including trace context
                 _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
-                    (s, ex) => FormatMessage(log.GetTemplate(), log.GetParameters().ToArray()));
+                    (s, ex) => s.ToString());
             }
             else
             {
                 // Fallback for non-structured messages (plain strings)
-                _akkaLogger.Log<LogEvent>(logLevel, new EventId(), log, log.Cause,
-                    (@event, exception) => @event.ToString());
+                // Still include trace context if available
+                if (activityContext.TraceId != default)
+                {
+                    var state = new AkkaLogState(activityContext, log.ToString());
+                    _akkaLogger.Log(logLevel, new EventId(), state, log.Cause,
+                        (s, ex) => s.ToString());
+                }
+                else
+                {
+                    _akkaLogger.Log<LogEvent>(logLevel, new EventId(), log, log.Cause,
+                        (@event, exception) => @event.ToString());
+                }
             }
+        }
+
+        /// <summary>
+        /// Attempts to extract the ActivityContext from a LogEvent.
+        /// Uses reflection to maintain compatibility with older Akka.NET versions
+        /// that don't have the ActivityContext property.
+        /// </summary>
+        private static ActivityContext TryGetActivityContext(LogEvent log)
+        {
+            // Try to get ActivityContext via the property added in Akka.NET 1.5.59
+            // Use reflection for backwards compatibility with older versions
+            try
+            {
+                var activityContextProperty = log.GetType().GetProperty("ActivityContext");
+                if (activityContextProperty != null)
+                {
+                    var value = activityContextProperty.GetValue(log);
+                    if (value is ActivityContext context)
+                    {
+                        return context;
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore reflection errors - just return default
+            }
+
+            return default;
         }
 
         private static string FormatMessage(string template, object[] args)

--- a/src/Akka.Remote.Hosting.Tests/RemoteConfigurationSpecs.cs
+++ b/src/Akka.Remote.Hosting.Tests/RemoteConfigurationSpecs.cs
@@ -651,7 +651,7 @@ public class RemoteConfigurationSpecs
         // arrange
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
         var jsonConfig = new ConfigurationBuilder().AddJsonStream(stream).Build();
-        var remoteOptions = jsonConfig.GetSection("Akka:RemoteOptions").Get<RemoteOptions>();
+        var remoteOptions = jsonConfig.GetSection("Akka:RemoteOptions").Get<RemoteOptions>()!;
 
         using var host = new HostBuilder().ConfigureServices(services =>
         {

--- a/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.2" />
-    <PackageReference Include="Aspire.Hosting.Seq" Version="8.2.2" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0" />
+    <PackageReference Include="Aspire.Hosting.Seq" Version="9.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsAspireHost>true</IsAspireHost>
     <IsPackable>false</IsPackable>
     <UserSecretsId>3f42e154-c98e-4c42-9f2b-8f8f8f8f8f8f</UserSecretsId>
   </PropertyGroup>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0" />
-    <PackageReference Include="Aspire.Hosting.Seq" Version="9.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Akka.Hosting.OpenTelemetry.AppHost.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAspireHost>true</IsAspireHost>
+    <IsPackable>false</IsPackable>
+    <UserSecretsId>3f42e154-c98e-4c42-9f2b-8f8f8f8f8f8f</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.2" />
+    <PackageReference Include="Aspire.Hosting.Seq" Version="8.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Hosting.OpenTelemetry.Demo\Akka.Hosting.OpenTelemetry.Demo.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Program.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Program.cs
@@ -6,12 +6,7 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-// Add Seq for log collection and visualization
-var seq = builder.AddSeq("seq")
-    .WithDataVolume();
-
-// Add the Akka.NET demo service with Seq reference for OTLP export
-builder.AddProject<Projects.Akka_Hosting_OpenTelemetry_Demo>("demo")
-    .WithReference(seq);
+// Add the Akka.NET demo service
+builder.AddProject<Projects.Akka_Hosting_OpenTelemetry_Demo>("demo");
 
 builder.Build().Run();

--- a/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Program.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.AppHost/Program.cs
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Program.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Add Seq for log collection and visualization
+var seq = builder.AddSeq("seq")
+    .WithDataVolume();
+
+// Add the Akka.NET demo service with Seq reference for OTLP export
+builder.AddProject<Projects.Akka_Hosting_OpenTelemetry_Demo>("demo")
+    .WithReference(seq);
+
+builder.Build().Run();

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Actors/TraceDemoActor.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Actors/TraceDemoActor.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+//  <copyright file="TraceDemoActor.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.Hosting.OpenTelemetry.Demo.Actors;
+
+/// <summary>
+/// Messages for the trace demo actor.
+/// </summary>
+public sealed record ProcessRequest(string RequestId, string Data);
+public sealed record ProcessResponse(string RequestId, string Result);
+
+/// <summary>
+/// Actor that demonstrates OpenTelemetry trace correlation.
+/// Logs are emitted with the trace context from the originating request,
+/// even though Activity.Current doesn't flow across mailbox boundaries.
+/// </summary>
+public sealed class TraceDemoActor : ReceiveActor
+{
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+
+    public TraceDemoActor()
+    {
+        Receive<ProcessRequest>(HandleProcessRequest);
+    }
+
+    private void HandleProcessRequest(ProcessRequest request)
+    {
+        // This log will include the TraceId and SpanId from the originating request
+        // even though we're on a different thread after crossing the mailbox boundary
+        _log.Info("Processing request {RequestId} with data: {Data}", request.RequestId, request.Data);
+
+        // Simulate some processing
+        var result = $"Processed: {request.Data.ToUpperInvariant()}";
+
+        _log.Info("Completed processing request {RequestId}, result: {Result}", request.RequestId, result);
+
+        Sender.Tell(new ProcessResponse(request.RequestId, result));
+    }
+}
+
+/// <summary>
+/// Actor that forwards messages to demonstrate trace context flowing through actor chains.
+/// </summary>
+public sealed class ForwarderActor : ReceiveActor
+{
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+    private readonly IActorRef _target;
+
+    public ForwarderActor(IActorRef target)
+    {
+        _target = target;
+
+        Receive<ProcessRequest>(request =>
+        {
+            _log.Info("Forwarding request {RequestId} to processor", request.RequestId);
+            _target.Forward(request);
+        });
+    }
+}

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Seq" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Seq" Version="8.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Akka.Hosting\Akka.Hosting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Extensions.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Extensions.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Extensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Trace;
+
+namespace Akka.Hosting.OpenTelemetry.Demo;
+
+/// <summary>
+/// Extension methods for configuring Aspire service defaults.
+/// </summary>
+public static class Extensions
+{
+    /// <summary>
+    /// Adds Aspire service defaults including OpenTelemetry and health checks.
+    /// </summary>
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        // Add service discovery
+        builder.Services.AddServiceDiscovery();
+
+        // Configure OpenTelemetry tracing
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource("Akka.Hosting.OpenTelemetry.Demo");
+            });
+
+        // Add OTLP exporters if configured
+        var otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+        {
+            builder.Services.AddOpenTelemetry()
+                .WithTracing(tracing =>
+                {
+                    tracing.AddOtlpExporter(options =>
+                    {
+                        options.Endpoint = new Uri(otlpEndpoint);
+                    });
+                });
+        }
+
+        // Add health checks
+        builder.Services.AddHealthChecks();
+
+        return builder;
+    }
+}

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Extensions.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Extensions.cs
@@ -4,7 +4,6 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 
 namespace Akka.Hosting.OpenTelemetry.Demo;
@@ -28,20 +27,6 @@ public static class Extensions
             {
                 tracing.AddSource("Akka.Hosting.OpenTelemetry.Demo");
             });
-
-        // Add OTLP exporters if configured
-        var otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
-        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
-        {
-            builder.Services.AddOpenTelemetry()
-                .WithTracing(tracing =>
-                {
-                    tracing.AddOtlpExporter(options =>
-                    {
-                        options.Endpoint = new Uri(otlpEndpoint);
-                    });
-                });
-        }
 
         // Add health checks
         builder.Services.AddHealthChecks();

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Extensions.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Extensions.cs
@@ -26,6 +26,7 @@ public static class Extensions
             .WithTracing(tracing =>
             {
                 tracing.AddSource("Akka.Hosting.OpenTelemetry.Demo");
+                tracing.AddOtlpExporter();
             });
 
         // Add health checks

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Program.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Program.cs
@@ -15,7 +15,7 @@ using OpenTelemetry.Resources;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-// Add Aspire service defaults (includes Seq integration via OTLP)
+// Add Aspire service defaults (service discovery + tracing)
 builder.AddServiceDefaults();
 
 // Configure OpenTelemetry logging with Akka trace correlation
@@ -31,6 +31,15 @@ builder.Logging.AddOpenTelemetry(options =>
     // Include formatted message for easier debugging
     options.IncludeFormattedMessage = true;
     options.IncludeScopes = true;
+
+    var otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+    if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+    {
+        options.AddOtlpExporter(exporterOptions =>
+        {
+            exporterOptions.Endpoint = new Uri(otlpEndpoint);
+        });
+    }
 });
 
 // Configure Akka.NET with LoggerFactoryLogger

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Program.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Program.cs
@@ -32,14 +32,7 @@ builder.Logging.AddOpenTelemetry(options =>
     options.IncludeFormattedMessage = true;
     options.IncludeScopes = true;
 
-    var otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
-    if (!string.IsNullOrWhiteSpace(otlpEndpoint))
-    {
-        options.AddOtlpExporter(exporterOptions =>
-        {
-            exporterOptions.Endpoint = new Uri(otlpEndpoint);
-        });
-    }
+    options.AddOtlpExporter();
 });
 
 // Configure Akka.NET with LoggerFactoryLogger

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Program.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Program.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Program.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.Logging;
+using Akka.Hosting.OpenTelemetry.Demo;
+using Akka.Hosting.OpenTelemetry.Demo.Actors;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Add Aspire service defaults (includes Seq integration via OTLP)
+builder.AddServiceDefaults();
+
+// Configure OpenTelemetry logging with Akka trace correlation
+builder.Logging.AddOpenTelemetry(options =>
+{
+    options.SetResourceBuilder(ResourceBuilder.CreateDefault()
+        .AddService("akka-otel-demo"));
+
+    // CRITICAL: Register Akka trace correlation processor FIRST (before exporters)
+    // This extracts trace context from Akka log attributes and applies it to LogRecords
+    options.AddAkkaTraceCorrelation();
+
+    // Include formatted message for easier debugging
+    options.IncludeFormattedMessage = true;
+    options.IncludeScopes = true;
+});
+
+// Configure Akka.NET with LoggerFactoryLogger
+builder.Services.AddAkka("TraceDemo", configBuilder =>
+{
+    configBuilder.ConfigureLoggers(setup =>
+    {
+        setup.ClearLoggers();
+        setup.AddLoggerFactory();
+    });
+
+    // Register actors
+    configBuilder.WithActors((system, registry, resolver) =>
+    {
+        var processor = system.ActorOf(Props.Create<TraceDemoActor>(), "processor");
+        var forwarder = system.ActorOf(Props.Create(() => new ForwarderActor(processor)), "forwarder");
+
+        registry.Register<TraceDemoActor>(processor);
+        registry.Register<ForwarderActor>(forwarder);
+    });
+});
+
+// Add background service to demonstrate trace correlation
+builder.Services.AddHostedService<TraceDemoService>();
+
+var app = builder.Build();
+app.Run();

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/TraceDemoService.cs
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/TraceDemoService.cs
@@ -1,0 +1,101 @@
+// -----------------------------------------------------------------------
+//  <copyright file="TraceDemoService.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.OpenTelemetry.Demo.Actors;
+
+namespace Akka.Hosting.OpenTelemetry.Demo;
+
+/// <summary>
+/// Background service that demonstrates OpenTelemetry trace correlation with Akka.NET actors.
+/// Creates traced operations and sends messages to actors, verifying that logs from actors
+/// are correlated with the originating trace.
+/// </summary>
+public sealed class TraceDemoService : BackgroundService
+{
+    private static readonly ActivitySource ActivitySource = new("Akka.Hosting.OpenTelemetry.Demo");
+
+    private readonly ILogger<TraceDemoService> _logger;
+    private readonly IRequiredActor<TraceDemoActor> _processorActor;
+    private readonly IRequiredActor<ForwarderActor> _forwarderActor;
+    private int _requestCounter;
+
+    public TraceDemoService(
+        ILogger<TraceDemoService> logger,
+        IRequiredActor<TraceDemoActor> processorActor,
+        IRequiredActor<ForwarderActor> forwarderActor)
+    {
+        _logger = logger;
+        _processorActor = processorActor;
+        _forwarderActor = forwarderActor;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Wait a moment for the actor system to fully initialize
+        await Task.Delay(2000, stoppingToken);
+
+        _logger.LogInformation("Starting trace correlation demo...");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                // Create a traced operation
+                using var activity = ActivitySource.StartActivity("ProcessMessage");
+
+                var requestId = $"REQ-{++_requestCounter:D4}";
+                var data = $"Sample data for request {requestId}";
+
+                _logger.LogInformation("Sending request {RequestId} to actor within trace {TraceId}",
+                    requestId, activity?.TraceId.ToString() ?? "none");
+
+                // Send directly to processor
+                var processor = await _processorActor.GetAsync(stoppingToken);
+                var response = await processor.Ask<ProcessResponse>(
+                    new ProcessRequest(requestId, data),
+                    TimeSpan.FromSeconds(5),
+                    stoppingToken);
+
+                _logger.LogInformation("Received response for {RequestId}: {Result}",
+                    response.RequestId, response.Result);
+
+                // Now test forwarding through multiple actors
+                using var forwardActivity = ActivitySource.StartActivity("ForwardMessage");
+
+                var forwardRequestId = $"FWD-{_requestCounter:D4}";
+                var forwardData = $"Forwarded data for request {forwardRequestId}";
+
+                _logger.LogInformation("Sending forwarded request {RequestId} within trace {TraceId}",
+                    forwardRequestId, forwardActivity?.TraceId.ToString() ?? "none");
+
+                var forwarder = await _forwarderActor.GetAsync(stoppingToken);
+                var forwardResponse = await forwarder.Ask<ProcessResponse>(
+                    new ProcessRequest(forwardRequestId, forwardData),
+                    TimeSpan.FromSeconds(5),
+                    stoppingToken);
+
+                _logger.LogInformation("Received forwarded response for {RequestId}: {Result}",
+                    forwardResponse.RequestId, forwardResponse.Result);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during trace demo iteration");
+            }
+
+            // Wait before next iteration
+            await Task.Delay(5000, stoppingToken);
+        }
+
+        _logger.LogInformation("Trace correlation demo stopped.");
+    }
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #700: Add OpenTelemetry trace correlation support to `LoggerFactoryLogger`.

**Problem:** `Activity.Current` (used by OpenTelemetry) doesn't flow across actor mailbox boundaries because it uses `AsyncLocal<T>`. This means logs generated by actors lose their trace context correlation.

**Solution:** Leverage `LogEvent.ActivityContext` added in Akka.NET 1.5.59, which captures trace context at log event creation time before the mailbox crossing.

## Changes

- **`AkkaLogState`** - Low-allocation struct using lazy enumeration (`yield return`) to propagate trace context in MEL state dictionaries. Stores `ActivityTraceId`/`ActivitySpanId` as structs directly to avoid `ToString()` allocations.

- **`AkkaTraceContextProcessor`** - `BaseProcessor<LogRecord>` that extracts `Akka.TraceId`, `Akka.SpanId`, `Akka.TraceFlags` from log attributes and sets them on `LogRecord` for OpenTelemetry exporters.

- **`AddAkkaTraceCorrelation()`** - Extension method on `OpenTelemetryLoggerOptions` for easy configuration.

- **`LoggerFactoryLogger`** - Updated to include `ActivityContext` in log state when available.

- **Dependencies** - Bumped Akka.NET to 1.5.59, Microsoft.Extensions to 8.0.0

- **Aspire Demo** - Added demo project (`src/Examples/Akka.Hosting.OpenTelemetry.Demo/`) with Seq for visual validation

## Usage

```csharp
builder.Logging.AddOpenTelemetry(options =>
{
    options.SetResourceBuilder(ResourceBuilder.CreateDefault()
        .AddService("my-service"));

    // Register processor FIRST (before exporters)
    options.AddAkkaTraceCorrelation();

    options.AddOtlpExporter();
});

services.AddAkka("MySystem", configBuilder =>
{
    configBuilder.ConfigureLoggers(setup =>
    {
        setup.ClearLoggers();
        setup.AddLoggerFactory();
    });
});
```

## Test plan

- [x] Unit tests for `AkkaLogState` (8 tests)
- [x] Unit tests for `AkkaTraceContextProcessor` (10 tests)
- [x] All existing tests pass (297 tests)
- [ ] Manual validation with Aspire demo

Closes #700