### PR TITLE
Fix WithDefaultLogMessageFormatter rejecting built-in formatters

### DIFF
--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveCore.verified.txt
@@ -194,6 +194,8 @@ namespace Akka.Hosting
         public Akka.Hosting.LoggerConfigBuilder AddLogger<T>()
             where T : Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics> { }
         public Akka.Hosting.LoggerConfigBuilder ClearLoggers() { }
+        [System.Obsolete("SemanticLogMessageFormatter is now the default. Only use this method if you have " +
+            "a custom ILogMessageFormatter implementation.")]
         public Akka.Hosting.LoggerConfigBuilder WithDefaultLogMessageFormatter<T>()
             where T : Akka.Event.ILogMessageFormatter { }
         public Akka.Hosting.LoggerConfigBuilder WithLogFilter(System.Action<Akka.Event.LogFilterBuilder> filterBuilder) { }

--- a/src/Akka.Hosting.Tests/Logging/LogMessageFormatterSpec.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogMessageFormatterSpec.cs
@@ -63,6 +63,44 @@ public class LogMessageFormatterSpec
             .Should().ThrowAsync<ConfigurationException>().WithMessage("*must have an empty constructor*");
     }
 
+    [Fact(DisplayName = "SemanticLogMessageFormatter should be accepted (GitHub issue #703)")]
+    public async Task SemanticLogMessageFormatterShouldBeAcceptedTest()
+    {
+        // SemanticLogMessageFormatter has a private constructor - verify it doesn't throw
+#pragma warning disable CS0618
+        using var host = await SetupHost<SemanticLogMessageFormatter>();
+#pragma warning restore CS0618
+
+        try
+        {
+            var sys = host.Services.GetRequiredService<ActorSystem>();
+            sys.Settings.LogFormatter.Should().BeOfType<SemanticLogMessageFormatter>();
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
+    [Fact(DisplayName = "DefaultLogMessageFormatter should be accepted")]
+    public async Task DefaultLogMessageFormatterShouldBeAcceptedTest()
+    {
+        // DefaultLogMessageFormatter has a private constructor - verify it doesn't throw
+#pragma warning disable CS0618
+        using var host = await SetupHost<DefaultLogMessageFormatter>();
+#pragma warning restore CS0618
+
+        try
+        {
+            var sys = host.Services.GetRequiredService<ActorSystem>();
+            sys.Settings.LogFormatter.Should().BeOfType<DefaultLogMessageFormatter>();
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
     private async Task<IHost> SetupHost<TFormatter>() where TFormatter : ILogMessageFormatter
     {
         var host = new HostBuilder()
@@ -79,7 +117,9 @@ public class LogMessageFormatterSpec
                         {
                             setup.LogLevel = Event.LogLevel.DebugLevel;
                             setup.AddLoggerFactory();
+#pragma warning disable CS0618
                             setup.WithDefaultLogMessageFormatter<TFormatter>();
+#pragma warning restore CS0618
                         });
                 });
             }).Build();

--- a/src/Akka.Hosting.Tests/Logging/SerilogLoggerEnd2EndSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/SerilogLoggerEnd2EndSpecs.cs
@@ -69,7 +69,9 @@ public class SerilogLoggerEnd2EndSpecs : TestKit.TestKit
             setup.ClearLoggers();
             setup.AddLogger<SerilogLogger>();
             setup.LogLevel = Event.LogLevel.DebugLevel;
+#pragma warning disable CS0618
             setup.WithDefaultLogMessageFormatter<SerilogLogMessageFormatter>();
+#pragma warning restore CS0618
         });
     }
 

--- a/src/Akka.Hosting/LoggerConfigBuilder.cs
+++ b/src/Akka.Hosting/LoggerConfigBuilder.cs
@@ -57,10 +57,15 @@ namespace Akka.Hosting
                 if (!typeof(ILogMessageFormatter).IsAssignableFrom(value))
                     throw new ConfigurationException($"{nameof(LogMessageFormatter)} must implement {nameof(ILogMessageFormatter)}");
 
-                var ctor = value.GetConstructor([]);
-                if (ctor is null)
-                    throw new ConfigurationException($"{nameof(LogMessageFormatter)} Type must have an empty constructor");
-                        
+                // Built-in formatters use private constructors with singleton Instance properties;
+                // Akka.NET's Settings.cs handles these as special cases at runtime.
+                if (value != typeof(SemanticLogMessageFormatter) && value != typeof(DefaultLogMessageFormatter))
+                {
+                    var ctor = value.GetConstructor([]);
+                    if (ctor is null)
+                        throw new ConfigurationException($"{nameof(LogMessageFormatter)} Type must have an empty constructor");
+                }
+
                 _logMessageFormatter = value;
             }
         }
@@ -87,8 +92,14 @@ namespace Akka.Hosting
         }
         
         /// <summary>
-        /// Sets the formatter used by the logger
+        /// Sets the formatter used by the logger.
         /// </summary>
+        /// <remarks>
+        /// As of Akka.NET 1.5.58, <see cref="SemanticLogMessageFormatter"/> is the default formatter
+        /// and is configured automatically. This method is only needed if you have a custom
+        /// <see cref="ILogMessageFormatter"/> implementation.
+        /// </remarks>
+        [Obsolete("SemanticLogMessageFormatter is now the default. Only use this method if you have a custom ILogMessageFormatter implementation.")]
         public LoggerConfigBuilder WithDefaultLogMessageFormatter<T>() where T: ILogMessageFormatter
         {
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
Closes #703

## Summary

- **Fix**: `WithDefaultLogMessageFormatter<T>()` now accepts `SemanticLogMessageFormatter` and `DefaultLogMessageFormatter`, which have private constructors (they use singleton `Instance` properties). The validation was too strict — `GetConstructor([])` only finds public constructors, but core Akka.NET's `Settings.cs` already special-cases these types at runtime.
- **Deprecate**: Mark `WithDefaultLogMessageFormatter<T>()` as `[Obsolete]` since `SemanticLogMessageFormatter` is now the default as of Akka.NET 1.5.58. The method still works for custom `ILogMessageFormatter` implementations.

## Test plan

- [x] New test: `SemanticLogMessageFormatterShouldBeAcceptedTest` — verifies the formatter is accepted and produces the correct `Settings.LogFormatter`
- [x] New test: `DefaultLogMessageFormatterShouldBeAcceptedTest` — same for `DefaultLogMessageFormatter`
- [x] Existing test: `InvalidLogMessageFormatterThrowsTest` — still rejects formatters without a public parameterless constructor
- [x] Existing test: `TransformMessagesTest` — custom formatters still work
- [x] API approval snapshot updated with new `[Obsolete]` attribute