### PR TITLE
Add Verify snapshot tests for LoggerFactoryLogger log state

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,4 +28,8 @@
 # Needed for API Approvals
 *.txt text eol=crlf
 
+# Verify snapshot files — must use LF to match Verify's output on all platforms
+*.verified.txt text eol=lf
+*.received.txt text eol=lf
+
 build.sh eol=lf

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
+    <PackageReference Include="Verify.Xunit" Version="22.11.1" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PlainStringLog_StateKeys.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PlainStringLog_StateKeys.verified.txt
@@ -1,24 +1,8 @@
 ﻿{
   LogLevel: Information,
-  MessageContainsValue: true,
-  StateKeys: [
-    {OriginalFormat},
-    ActorPath,
-    LogSource,
-    Thread,
-    Timestamp
-  ],
-  StateValueTypes: {
-    {OriginalFormat}: String,
-    ActorPath: String,
-    LogSource: String,
-    Thread: Int32,
-    Timestamp: DateTime
-  },
   HasActorPath: true,
   HasTimestamp: true,
   HasThread: true,
   HasLogSource: true,
-  HasOriginalFormat: true,
-  OriginalFormat: Server started successfully
+  HasOriginalFormat: true
 }

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PlainStringLog_StateKeys.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PlainStringLog_StateKeys.verified.txt
@@ -1,0 +1,24 @@
+﻿{
+  LogLevel: Information,
+  MessageContainsValue: true,
+  StateKeys: [
+    {OriginalFormat},
+    ActorPath,
+    LogSource,
+    Thread,
+    Timestamp
+  ],
+  StateValueTypes: {
+    {OriginalFormat}: String,
+    ActorPath: String,
+    LogSource: String,
+    Thread: Int32,
+    Timestamp: DateTime
+  },
+  HasActorPath: true,
+  HasTimestamp: true,
+  HasThread: true,
+  HasLogSource: true,
+  HasOriginalFormat: true,
+  OriginalFormat: Server started successfully
+}

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PlainStringLog_StateSnapshot.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PlainStringLog_StateSnapshot.verified.txt
@@ -1,0 +1,8 @@
+﻿LogLevel: Information
+Message: [LEVEL][DateTime][Thread 0001][ActorSystem(test)] Server started successfully
+State:
+  [{OriginalFormat}] = Server started successfully
+  [ActorPath] = akka://test/...
+  [LogSource] = LogSource
+  [Thread] = 1
+  [Timestamp] = DateTime

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PositionalPlaceholderLog_StateKeys.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PositionalPlaceholderLog_StateKeys.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  LogLevel: Information,
+  MessageContainsValue: true,
+  StateKeys: [
+    {OriginalFormat},
+    0,
+    ActorPath,
+    LogSource,
+    Thread,
+    Timestamp
+  ],
+  StateValueTypes: {
+    {OriginalFormat}: String,
+    0: Int32,
+    ActorPath: String,
+    LogSource: String,
+    Thread: Int32,
+    Timestamp: DateTime
+  },
+  HasActorPath: true,
+  HasTimestamp: true,
+  HasThread: true,
+  HasLogSource: true,
+  HasOriginalFormat: true,
+  OriginalFormat: User {0} logged in,
+  HasSemanticProperty_0: true,
+  Value_0: 99
+}

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PositionalPlaceholderLog_StateKeys.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PositionalPlaceholderLog_StateKeys.verified.txt
@@ -1,22 +1,5 @@
 ﻿{
   LogLevel: Information,
-  MessageContainsValue: true,
-  StateKeys: [
-    {OriginalFormat},
-    0,
-    ActorPath,
-    LogSource,
-    Thread,
-    Timestamp
-  ],
-  StateValueTypes: {
-    {OriginalFormat}: String,
-    0: Int32,
-    ActorPath: String,
-    LogSource: String,
-    Thread: Int32,
-    Timestamp: DateTime
-  },
   HasActorPath: true,
   HasTimestamp: true,
   HasThread: true,

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PositionalPlaceholderLog_StateSnapshot.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.PositionalPlaceholderLog_StateSnapshot.verified.txt
@@ -1,0 +1,9 @@
+﻿LogLevel: Information
+Message: [LEVEL][DateTime][Thread 0001][ActorSystem(test)] User 99 logged in
+State:
+  [{OriginalFormat}] = User {0} logged in
+  [0] = 99
+  [ActorPath] = akka://test/...
+  [LogSource] = LogSource
+  [Thread] = 1
+  [Timestamp] = DateTime

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.StructuredLog_StateKeys.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.StructuredLog_StateKeys.verified.txt
@@ -1,0 +1,32 @@
+﻿{
+  LogLevel: Information,
+  MessageContainsValue: true,
+  StateKeys: [
+    {OriginalFormat},
+    Action,
+    ActorPath,
+    LogSource,
+    Thread,
+    Timestamp,
+    UserId
+  ],
+  StateValueTypes: {
+    {OriginalFormat}: String,
+    Action: String,
+    ActorPath: String,
+    LogSource: String,
+    Thread: Int32,
+    Timestamp: DateTime,
+    UserId: Int32
+  },
+  HasActorPath: true,
+  HasTimestamp: true,
+  HasThread: true,
+  HasLogSource: true,
+  HasOriginalFormat: true,
+  OriginalFormat: User {UserId} performed {Action},
+  HasSemanticProperty_UserId: true,
+  HasSemanticProperty_Action: true,
+  UserId: 12345,
+  Action: Login
+}

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.StructuredLog_StateKeys.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.StructuredLog_StateKeys.verified.txt
@@ -1,24 +1,5 @@
 ﻿{
   LogLevel: Information,
-  MessageContainsValue: true,
-  StateKeys: [
-    {OriginalFormat},
-    Action,
-    ActorPath,
-    LogSource,
-    Thread,
-    Timestamp,
-    UserId
-  ],
-  StateValueTypes: {
-    {OriginalFormat}: String,
-    Action: String,
-    ActorPath: String,
-    LogSource: String,
-    Thread: Int32,
-    Timestamp: DateTime,
-    UserId: Int32
-  },
   HasActorPath: true,
   HasTimestamp: true,
   HasThread: true,

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.StructuredLog_StateSnapshot.verified.txt
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.StructuredLog_StateSnapshot.verified.txt
@@ -1,0 +1,10 @@
+﻿LogLevel: Information
+Message: [LEVEL][DateTime][Thread 0001][ActorSystem(test)] User 12345 performed Login
+State:
+  [{OriginalFormat}] = User {UserId} performed {Action}
+  [Action] = Login
+  [ActorPath] = akka://test/...
+  [LogSource] = LogSource
+  [Thread] = 1
+  [Timestamp] = DateTime
+  [UserId] = 12345

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Akka.Actor;
 using Akka.Event;
 using Akka.Hosting;
@@ -21,9 +23,9 @@ namespace Akka.Hosting.Tests.Logging;
 /// <summary>
 /// Verify snapshot tests for LoggerFactoryLogger structured state output.
 ///
-/// These tests capture the structure of the log state dictionary that
-/// LoggerFactoryLogger passes to ILogger.Log(). Any change to the metadata
-/// presence will cause a snapshot mismatch.
+/// Captures both the formatted message and the structured state dictionary
+/// from ILogger.Log(), sanitizes volatile values (timestamps, thread IDs,
+/// actor paths), and snapshots the result as plain text.
 /// </summary>
 [UsesVerify]
 public class LogStateSnapshotSpecs : TestKit.TestKit
@@ -45,96 +47,76 @@ public class LogStateSnapshotSpecs : TestKit.TestKit
         });
     }
 
-    /// <summary>
-    /// Snapshot the state dictionary for a structured log with named placeholders.
-    /// Expected: semantic properties (UserId, Action) + Akka metadata (ActorPath, Timestamp, Thread, LogSource) + {OriginalFormat}
-    /// </summary>
     [Fact]
-    public System.Threading.Tasks.Task StructuredLog_StateKeys()
+    public System.Threading.Tasks.Task StructuredLog_StateSnapshot()
     {
         _sink.Clear();
-
         Sys.Log.Info("User {UserId} performed {Action}", 12345, "Login");
-
         AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("12345")));
-
         var entry = _sink.Entries.First(e => e.Message.Contains("12345"));
-
-        var snapshot = new
-        {
-            entry.LogLevel,
-            HasActorPath = entry.State.ContainsKey("ActorPath"),
-            HasTimestamp = entry.State.ContainsKey("Timestamp"),
-            HasThread = entry.State.ContainsKey("Thread"),
-            HasLogSource = entry.State.ContainsKey("LogSource"),
-            HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
-            OriginalFormat = entry.State.GetValueOrDefault("{OriginalFormat}")?.ToString(),
-            HasSemanticProperty_UserId = entry.State.ContainsKey("UserId"),
-            HasSemanticProperty_Action = entry.State.ContainsKey("Action"),
-            UserId = entry.State.GetValueOrDefault("UserId"),
-            Action = entry.State.GetValueOrDefault("Action"),
-        };
-
-        return Verifier.Verify(snapshot);
+        return Verifier.Verify(FormatEntry(entry));
     }
 
-    /// <summary>
-    /// Snapshot the state dictionary for a plain string log (no template placeholders).
-    /// Expected: Akka metadata (ActorPath, Timestamp, Thread, LogSource) + {OriginalFormat}
-    /// This is the scenario that regressed — plain string logs must still carry metadata.
-    /// </summary>
     [Fact]
-    public System.Threading.Tasks.Task PlainStringLog_StateKeys()
+    public System.Threading.Tasks.Task PlainStringLog_StateSnapshot()
     {
         _sink.Clear();
-
         Sys.Log.Info("Server started successfully");
-
         AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("Server started successfully")));
-
         var entry = _sink.Entries.First(e => e.Message.Contains("Server started successfully"));
-
-        var snapshot = new
-        {
-            entry.LogLevel,
-            HasActorPath = entry.State.ContainsKey("ActorPath"),
-            HasTimestamp = entry.State.ContainsKey("Timestamp"),
-            HasThread = entry.State.ContainsKey("Thread"),
-            HasLogSource = entry.State.ContainsKey("LogSource"),
-            HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
-        };
-
-        return Verifier.Verify(snapshot);
+        return Verifier.Verify(FormatEntry(entry));
     }
 
-    /// <summary>
-    /// Snapshot the state dictionary for a log with positional placeholders.
-    /// Expected: semantic properties (0) + Akka metadata + {OriginalFormat}
-    /// </summary>
     [Fact]
-    public System.Threading.Tasks.Task PositionalPlaceholderLog_StateKeys()
+    public System.Threading.Tasks.Task PositionalPlaceholderLog_StateSnapshot()
     {
         _sink.Clear();
-
         Sys.Log.Info("User {0} logged in", 99);
-
         AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("99")));
-
         var entry = _sink.Entries.First(e => e.Message.Contains("99"));
+        return Verifier.Verify(FormatEntry(entry));
+    }
 
-        var snapshot = new
+    private static string FormatEntry(BugReproLogEntry entry)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"LogLevel: {entry.LogLevel}");
+        sb.AppendLine($"Message: {SanitizeMessage(entry.Message)}");
+        sb.AppendLine("State:");
+        foreach (var kvp in entry.State.OrderBy(k => k.Key))
         {
-            entry.LogLevel,
-            HasActorPath = entry.State.ContainsKey("ActorPath"),
-            HasTimestamp = entry.State.ContainsKey("Timestamp"),
-            HasThread = entry.State.ContainsKey("Thread"),
-            HasLogSource = entry.State.ContainsKey("LogSource"),
-            HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
-            OriginalFormat = entry.State.GetValueOrDefault("{OriginalFormat}")?.ToString(),
-            HasSemanticProperty_0 = entry.State.ContainsKey("0"),
-            Value_0 = entry.State.GetValueOrDefault("0"),
-        };
+            sb.AppendLine($"  [{kvp.Key}] = {SanitizeValue(kvp.Key, kvp.Value)}");
+        }
+        return sb.ToString();
+    }
 
-        return Verifier.Verify(snapshot);
+    private static string SanitizeMessage(string message)
+    {
+        // Replace [LEVEL][datetime][Thread NNNN][logSource] prefix with sanitized constants
+        message = Regex.Replace(message,
+            @"\[(DEBUG|INFO|WARNING|ERROR)\]",
+            "[LEVEL]");
+        message = Regex.Replace(message,
+            @"\[\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}\.\d{3}Z?\]",
+            "[DateTime]");
+        message = Regex.Replace(message,
+            @"\[Thread \d+\]",
+            "[Thread 0001]");
+        message = Regex.Replace(message,
+            @"\[akka://[^\]]+\]",
+            "[ActorPath]");
+        return message;
+    }
+
+    private static string SanitizeValue(string key, object? value)
+    {
+        return key switch
+        {
+            "ActorPath" => "akka://test/...",
+            "Timestamp" => "DateTime",
+            "Thread" => "1",
+            "LogSource" => "LogSource",
+            _ => value?.ToString() ?? "null"
+        };
     }
 }

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
@@ -21,9 +21,9 @@ namespace Akka.Hosting.Tests.Logging;
 /// <summary>
 /// Verify snapshot tests for LoggerFactoryLogger structured state output.
 ///
-/// These tests capture the exact structure of the log state dictionary that
-/// LoggerFactoryLogger passes to ILogger.Log(). Any change to the state keys,
-/// value types, or metadata presence will cause a snapshot mismatch.
+/// These tests capture the structure of the log state dictionary that
+/// LoggerFactoryLogger passes to ILogger.Log(). Any change to the metadata
+/// presence will cause a snapshot mismatch.
 /// </summary>
 [UsesVerify]
 public class LogStateSnapshotSpecs : TestKit.TestKit
@@ -60,15 +60,9 @@ public class LogStateSnapshotSpecs : TestKit.TestKit
 
         var entry = _sink.Entries.First(e => e.Message.Contains("12345"));
 
-        // Snapshot the state keys and value types (scrub volatile values)
         var snapshot = new
         {
             entry.LogLevel,
-            MessageContainsValue = entry.Message.Contains("12345"),
-            StateKeys = entry.State.Keys.OrderBy(k => k).ToArray(),
-            StateValueTypes = entry.State
-                .OrderBy(kvp => kvp.Key)
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.GetType().Name ?? "null"),
             HasActorPath = entry.State.ContainsKey("ActorPath"),
             HasTimestamp = entry.State.ContainsKey("Timestamp"),
             HasThread = entry.State.ContainsKey("Thread"),
@@ -103,17 +97,11 @@ public class LogStateSnapshotSpecs : TestKit.TestKit
         var snapshot = new
         {
             entry.LogLevel,
-            MessageContainsValue = entry.Message.Contains("Server started successfully"),
-            StateKeys = entry.State.Keys.OrderBy(k => k).ToArray(),
-            StateValueTypes = entry.State
-                .OrderBy(kvp => kvp.Key)
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.GetType().Name ?? "null"),
             HasActorPath = entry.State.ContainsKey("ActorPath"),
             HasTimestamp = entry.State.ContainsKey("Timestamp"),
             HasThread = entry.State.ContainsKey("Thread"),
             HasLogSource = entry.State.ContainsKey("LogSource"),
             HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
-            OriginalFormat = entry.State.GetValueOrDefault("{OriginalFormat}")?.ToString(),
         };
 
         return Verifier.Verify(snapshot);
@@ -137,11 +125,6 @@ public class LogStateSnapshotSpecs : TestKit.TestKit
         var snapshot = new
         {
             entry.LogLevel,
-            MessageContainsValue = entry.Message.Contains("99"),
-            StateKeys = entry.State.Keys.OrderBy(k => k).ToArray(),
-            StateValueTypes = entry.State
-                .OrderBy(kvp => kvp.Key)
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.GetType().Name ?? "null"),
             HasActorPath = entry.State.ContainsKey("ActorPath"),
             HasTimestamp = entry.State.ContainsKey("Timestamp"),
             HasThread = entry.State.ContainsKey("Thread"),

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------
+//  <copyright file="LogStateSnapshotSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting;
+using Microsoft.Extensions.Logging;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Akka.Hosting.Tests.Logging;
+
+/// <summary>
+/// Verify snapshot tests for LoggerFactoryLogger structured state output.
+///
+/// These tests capture the exact structure of the log state dictionary that
+/// LoggerFactoryLogger passes to ILogger.Log(). Any change to the state keys,
+/// value types, or metadata presence will cause a snapshot mismatch.
+/// </summary>
+[UsesVerify]
+public class LogStateSnapshotSpecs : TestKit.TestKit
+{
+    private readonly BugReproTestSink _sink;
+
+    public LogStateSnapshotSpecs(ITestOutputHelper output) : base(output: output)
+    {
+        _sink = new BugReproTestSink(output);
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.ConfigureLoggers(setup =>
+        {
+            setup.LogLevel = Event.LogLevel.InfoLevel;
+            setup.ClearLoggers();
+            setup.AddLoggerFactory(new BugReproTestLoggerFactory(_sink));
+        });
+    }
+
+    /// <summary>
+    /// Snapshot the state dictionary for a structured log with named placeholders.
+    /// Expected: semantic properties (UserId, Action) + Akka metadata (ActorPath, Timestamp, Thread, LogSource) + {OriginalFormat}
+    /// </summary>
+    [Fact]
+    public System.Threading.Tasks.Task StructuredLog_StateKeys()
+    {
+        _sink.Clear();
+
+        Sys.Log.Info("User {UserId} performed {Action}", 12345, "Login");
+
+        AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("12345")));
+
+        var entry = _sink.Entries.First(e => e.Message.Contains("12345"));
+
+        // Snapshot the state keys and value types (scrub volatile values)
+        var snapshot = new
+        {
+            entry.LogLevel,
+            MessageContainsValue = entry.Message.Contains("12345"),
+            StateKeys = entry.State.Keys.OrderBy(k => k).ToArray(),
+            StateValueTypes = entry.State
+                .OrderBy(kvp => kvp.Key)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.GetType().Name ?? "null"),
+            HasActorPath = entry.State.ContainsKey("ActorPath"),
+            HasTimestamp = entry.State.ContainsKey("Timestamp"),
+            HasThread = entry.State.ContainsKey("Thread"),
+            HasLogSource = entry.State.ContainsKey("LogSource"),
+            HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
+            OriginalFormat = entry.State.GetValueOrDefault("{OriginalFormat}")?.ToString(),
+            HasSemanticProperty_UserId = entry.State.ContainsKey("UserId"),
+            HasSemanticProperty_Action = entry.State.ContainsKey("Action"),
+            UserId = entry.State.GetValueOrDefault("UserId"),
+            Action = entry.State.GetValueOrDefault("Action"),
+        };
+
+        return Verifier.Verify(snapshot);
+    }
+
+    /// <summary>
+    /// Snapshot the state dictionary for a plain string log (no template placeholders).
+    /// Expected: Akka metadata (ActorPath, Timestamp, Thread, LogSource) + {OriginalFormat}
+    /// This is the scenario that regressed — plain string logs must still carry metadata.
+    /// </summary>
+    [Fact]
+    public System.Threading.Tasks.Task PlainStringLog_StateKeys()
+    {
+        _sink.Clear();
+
+        Sys.Log.Info("Server started successfully");
+
+        AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("Server started successfully")));
+
+        var entry = _sink.Entries.First(e => e.Message.Contains("Server started successfully"));
+
+        var snapshot = new
+        {
+            entry.LogLevel,
+            MessageContainsValue = entry.Message.Contains("Server started successfully"),
+            StateKeys = entry.State.Keys.OrderBy(k => k).ToArray(),
+            StateValueTypes = entry.State
+                .OrderBy(kvp => kvp.Key)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.GetType().Name ?? "null"),
+            HasActorPath = entry.State.ContainsKey("ActorPath"),
+            HasTimestamp = entry.State.ContainsKey("Timestamp"),
+            HasThread = entry.State.ContainsKey("Thread"),
+            HasLogSource = entry.State.ContainsKey("LogSource"),
+            HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
+            OriginalFormat = entry.State.GetValueOrDefault("{OriginalFormat}")?.ToString(),
+        };
+
+        return Verifier.Verify(snapshot);
+    }
+
+    /// <summary>
+    /// Snapshot the state dictionary for a log with positional placeholders.
+    /// Expected: semantic properties (0) + Akka metadata + {OriginalFormat}
+    /// </summary>
+    [Fact]
+    public System.Threading.Tasks.Task PositionalPlaceholderLog_StateKeys()
+    {
+        _sink.Clear();
+
+        Sys.Log.Info("User {0} logged in", 99);
+
+        AwaitCondition(() => _sink.Entries.Any(e => e.Message.Contains("99")));
+
+        var entry = _sink.Entries.First(e => e.Message.Contains("99"));
+
+        var snapshot = new
+        {
+            entry.LogLevel,
+            MessageContainsValue = entry.Message.Contains("99"),
+            StateKeys = entry.State.Keys.OrderBy(k => k).ToArray(),
+            StateValueTypes = entry.State
+                .OrderBy(kvp => kvp.Key)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.GetType().Name ?? "null"),
+            HasActorPath = entry.State.ContainsKey("ActorPath"),
+            HasTimestamp = entry.State.ContainsKey("Timestamp"),
+            HasThread = entry.State.ContainsKey("Thread"),
+            HasLogSource = entry.State.ContainsKey("LogSource"),
+            HasOriginalFormat = entry.State.ContainsKey("{OriginalFormat}"),
+            OriginalFormat = entry.State.GetValueOrDefault("{OriginalFormat}")?.ToString(),
+            HasSemanticProperty_0 = entry.State.ContainsKey("0"),
+            Value_0 = entry.State.GetValueOrDefault("0"),
+        };
+
+        return Verifier.Verify(snapshot);
+    }
+}


### PR DESCRIPTION
## Summary

Snapshot tests using Verify that capture the exact structure of the state dictionary passed to `ILogger.Log()` by `LoggerFactoryLogger`. Branched from the commit **before** PR #706 (trace correlation) to establish a baseline.

Three scenarios covered:
- **Structured log** (named placeholders): metadata + semantic properties
- **Plain string log** (no placeholders): metadata only
- **Positional placeholder log**: metadata + positional properties

All three verify that `ActorPath`, `Timestamp`, `Thread`, and `LogSource` are always present as structured state properties.

## How to validate the regression

1. CI should pass on this branch (pre-#706 baseline)
2. Hit **Update branch** to merge current `dev` (which includes #706)
3. `PlainStringLog_StateKeys` and `PositionalPlaceholderLog_StateKeys` should **fail** — proving the metadata regression
4. After merging #724 (the fix), the snapshots should pass again

## Test plan

- [x] All 3 snapshot tests pass against pre-#706 code
- [ ] Tests fail after merging dev (proves regression)
- [ ] Tests pass after merging #724 (proves fix)