### PR TITLE
[xUnit 3] Convert Akka.Hosting.TestKit and all tests to xUnit 3

### DIFF
--- a/Akka.Hosting.sln
+++ b/Akka.Hosting.sln
@@ -48,6 +48,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.OpenTelemetry.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.OpenTelemetry.AppHost", "src\Examples\Akka.Hosting.OpenTelemetry.AppHost\Akka.Hosting.OpenTelemetry.AppHost.csproj", "{CC22F505-B648-420E-BC8A-0FCE46082986}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.TestKit.Xunit2", "src\Akka.Hosting.TestKit.Xunit2\Akka.Hosting.TestKit.Xunit2.csproj", "{AA79C523-DA30-4B92-9AD5-235AFFAF9C28}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hosting.TestKit.Xunit2.Tests", "src\Akka.Hosting.TestKit.Xunit2.Tests\Akka.Hosting.TestKit.Xunit2.Tests.csproj", "{403A293F-C78C-418A-A80C-980C97048D87}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +126,14 @@ Global
 		{CC22F505-B648-420E-BC8A-0FCE46082986}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC22F505-B648-420E-BC8A-0FCE46082986}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC22F505-B648-420E-BC8A-0FCE46082986}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA79C523-DA30-4B92-9AD5-235AFFAF9C28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA79C523-DA30-4B92-9AD5-235AFFAF9C28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA79C523-DA30-4B92-9AD5-235AFFAF9C28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA79C523-DA30-4B92-9AD5-235AFFAF9C28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{403A293F-C78C-418A-A80C-980C97048D87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{403A293F-C78C-418A-A80C-980C97048D87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{403A293F-C78C-418A-A80C-980C97048D87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{403A293F-C78C-418A-A80C-980C97048D87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
       https://github.com/akkadotnet/Akka.Hosting
     </PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;xUnit1051</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <PropertyGroup>
@@ -27,9 +27,11 @@
     <NetLibraryFramework>net6.0</NetLibraryFramework>
     <TestsNetCoreFramework>net8.0</TestsNetCoreFramework>
     <XunitVersion>2.8.1</XunitVersion>
+    <Xunit3Version>3.2.2</Xunit3Version>
     <TestSdkVersion>17.11.1</TestSdkVersion>
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
+    <Xunit3RunneVisualstudio>3.1.5</Xunit3RunneVisualstudio>
     <AkkaVersion>1.5.64</AkkaVersion>
     <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
     <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
+        <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -6,7 +6,6 @@ using Akka.DistributedData;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingSpecs.cs
@@ -8,7 +8,6 @@ using Akka.Configuration;
 using Akka.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonSpecs.cs
@@ -4,7 +4,7 @@ using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
+
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/ClusterSingletonWithDiSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterSingletonWithDiSpecs.cs
@@ -5,7 +5,6 @@ using Akka.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/DistributedPubSubSpecs.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Cluster.Hosting.Tests;
@@ -24,7 +23,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
     private ActorSystem? _system;
     private ILoggingAdapter? _log;
     private Cluster? _cluster;
-    private TestKit.Xunit2.TestKit? _testKit;
+    private TestKit.Xunit.TestKit? _testKit;
 
     private IActorRef? _mediator;
 
@@ -68,7 +67,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
         return Task.CompletedTask;
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
@@ -83,12 +82,12 @@ public class DistributedPubSubSpecs : IAsyncLifetime
                     .AddAkka("TestSys", (configurationBuilder, _) =>
                     {
                         configurationBuilder
-                            .AddHocon(TestKit.Xunit2.TestKit.DefaultConfig, HoconAddMode.Append)
+                            .AddHocon(TestKit.Xunit.TestKit.DefaultConfig, HoconAddMode.Append)
                             .WithRemoting("localhost", 0)
                             .WithClustering(_clusterOptions)
                             .WithActors((system, _) =>
                             {
-                                _testKit = new TestKit.Xunit2.TestKit(system, _helper);
+                                _testKit = new TestKit.Xunit.TestKit(system, _helper);
                                 _system = system;
                                 _log = Logging.GetLogger(system, this);
                                 _cluster = Cluster.Get(system);
@@ -116,7 +115,7 @@ public class DistributedPubSubSpecs : IAsyncLifetime
         _mediator = registry.Get<DistributedPubSub>();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (_host != null) 
             await _host.StopAsync();

--- a/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessProxySpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessProxySpecs.cs
@@ -7,7 +7,7 @@ using Akka.Hosting;
 using Akka.Remote.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
+
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ShardedDaemonProcessSpecs.cs
@@ -9,7 +9,7 @@ using Akka.Remote.Hosting;
 using Akka.TestKit;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
+
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/SplitBrainResolverSpecs.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Cluster.Hosting.Tests;

--- a/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
+++ b/src/Akka.Cluster.Hosting.Tests/TestHelper.cs
@@ -7,10 +7,10 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.Hosting;
 using Akka.Remote.Hosting;
-using Akka.TestKit.Xunit2.Internals;
+using Akka.TestKit.Xunit.Internals;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
+
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/XUnitLogger.cs
+++ b/src/Akka.Cluster.Hosting.Tests/XUnitLogger.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Cluster.Hosting.Tests/XUnitLoggerProvider.cs
+++ b/src/Akka.Cluster.Hosting.Tests/XUnitLoggerProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Cluster.Hosting.Tests;
 

--- a/src/Akka.Hosting.API.Tests/Akka.Hosting.API.Tests.csproj
+++ b/src/Akka.Hosting.API.Tests/Akka.Hosting.API.Tests.csproj
@@ -3,13 +3,14 @@
     <PropertyGroup>
         <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
         <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
+        <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -18,8 +19,8 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
-        <PackageReference Include="Verify.Xunit" Version="22.11.1" />
-        <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
+        <PackageReference Include="Verify.XunitV3" Version="31.14.0" />
+        <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Akka.Hosting.API.Tests/CoreApiSpec.cs
+++ b/src/Akka.Hosting.API.Tests/CoreApiSpec.cs
@@ -10,7 +10,6 @@ using static VerifyXunit.Verifier;
 
 namespace Akka.Hosting.API.Tests;
 
-[UsesVerify]
 public class CoreApiSpec
 {
     static CoreApiSpec()

--- a/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
+++ b/src/Akka.Hosting.API.Tests/verify/CoreApiSpec.ApproveTestKit.verified.txt
@@ -8,7 +8,7 @@ namespace Akka.Hosting.TestKit.Internals
     }
     public class XUnitLogger : Microsoft.Extensions.Logging.ILogger
     {
-        public XUnitLogger(string category, Xunit.Abstractions.ITestOutputHelper helper, Microsoft.Extensions.Logging.LogLevel logLevel) { }
+        public XUnitLogger(string category, Xunit.ITestOutputHelper helper, Microsoft.Extensions.Logging.LogLevel logLevel) { }
         public System.IDisposable? BeginScope<TState>(TState state)
             where TState :  notnull { }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) { }
@@ -16,7 +16,7 @@ namespace Akka.Hosting.TestKit.Internals
     }
     public class XUnitLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable
     {
-        public XUnitLoggerProvider(Xunit.Abstractions.ITestOutputHelper helper, Microsoft.Extensions.Logging.LogLevel logLevel) { }
+        public XUnitLoggerProvider(Xunit.ITestOutputHelper helper, Microsoft.Extensions.Logging.LogLevel logLevel) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) { }
         public void Dispose() { }
     }
@@ -26,7 +26,7 @@ namespace Akka.Hosting.TestKit
     public abstract class PersistenceTestKit : Akka.Hosting.TestKit.TestKit
     {
         public static readonly Akka.Configuration.Config DefaultConfiguration;
-        public PersistenceTestKit(string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null, System.TimeSpan? startupTimeout = default, Microsoft.Extensions.Logging.LogLevel logLevel = 2) { }
+        public PersistenceTestKit(string? actorSystemName = null, Xunit.ITestOutputHelper? output = null, System.TimeSpan? startupTimeout = default, Microsoft.Extensions.Logging.LogLevel logLevel = 2) { }
         public Akka.Persistence.TestKit.ITestJournal Journal { get; }
         public Akka.Actor.IActorRef JournalActorRef { get; }
         public Akka.Persistence.TestKit.ITestSnapshotStore Snapshots { get; }
@@ -43,18 +43,18 @@ namespace Akka.Hosting.TestKit
         public System.Threading.Tasks.Task WithSnapshotSave(System.Func<Akka.Persistence.TestKit.SnapshotStoreSaveBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Action execution) { }
         public System.Threading.Tasks.Task WithSnapshotSave(System.Func<Akka.Persistence.TestKit.SnapshotStoreSaveBehavior, System.Threading.Tasks.Task> behaviorSelector, System.Func<System.Threading.Tasks.Task> execution) { }
     }
-    public abstract class TestKit : Akka.TestKit.TestKitBase, Xunit.IAsyncLifetime
+    public abstract class TestKit : Akka.TestKit.TestKitBase, System.IAsyncDisposable, Xunit.IAsyncLifetime
     {
-        protected TestKit(string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null, System.TimeSpan? startupTimeout = default, Microsoft.Extensions.Logging.LogLevel logLevel = 2) { }
+        protected TestKit(string? actorSystemName = null, Xunit.ITestOutputHelper? output = null, System.TimeSpan? startupTimeout = default, Microsoft.Extensions.Logging.LogLevel logLevel = 2) { }
         public Akka.Hosting.ActorRegistry ActorRegistry { get; }
         public string ActorSystemName { get; }
         protected virtual Akka.Configuration.Config? Config { get; }
         public Microsoft.Extensions.Hosting.IHost Host { get; }
         public Microsoft.Extensions.Logging.LogLevel LogLevel { get; }
-        public Xunit.Abstractions.ITestOutputHelper? Output { get; }
+        public Xunit.ITestOutputHelper? Output { get; }
         public System.TimeSpan StartupTimeout { get; }
         public new Akka.Actor.ActorSystem Sys { get; }
-        protected static Akka.TestKit.Xunit2.XunitAssertions Assertions { get; }
+        protected static Akka.TestKit.Xunit.XunitAssertions Assertions { get; }
         protected virtual System.Threading.Tasks.Task AfterAllAsync() { }
         protected virtual System.Threading.Tasks.Task BeforeTestStart() { }
         protected abstract void ConfigureAkka(Akka.Hosting.AkkaConfigurationBuilder builder, System.IServiceProvider provider);
@@ -63,9 +63,9 @@ namespace Akka.Hosting.TestKit
         protected virtual void ConfigureHostConfiguration(Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { }
         protected virtual void ConfigureLogging(Microsoft.Extensions.Logging.ILoggingBuilder builder) { }
         protected virtual void ConfigureServices(Microsoft.Extensions.Hosting.HostBuilderContext context, Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
-        public System.Threading.Tasks.Task DisposeAsync() { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { }
         [Akka.Annotations.InternalApi]
-        public System.Threading.Tasks.Task InitializeAsync() { }
+        public System.Threading.Tasks.ValueTask InitializeAsync() { }
         protected override sealed void InitializeTest(Akka.Actor.ActorSystem system, Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName, string testActorName) { }
     }
 }

--- a/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -11,9 +13,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
+        <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Akka.Hosting.TestKit.Tests/DiPropsFailTest.cs
+++ b/src/Akka.Hosting.TestKit.Tests/DiPropsFailTest.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Hosting.TestKit.Tests;
 

--- a/src/Akka.Hosting.TestKit.Tests/HostingSpecSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/HostingSpecSpec.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit.TestActors;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.TestKit.Tests

--- a/src/Akka.Hosting.TestKit.Tests/LoggerSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/LoggerSpec.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.Hosting.TestKit.Internals;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.TestKit.Tests;

--- a/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestActorStartupDeadlockSpec.cs
@@ -1,6 +1,5 @@
 ﻿using Akka.TestKit;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Akka.Hosting.TestKit.Tests;
 
@@ -40,8 +39,8 @@ file sealed class HostedTestKitRunner : TestKit, IAsyncLifetime  // TestKit alre
     }
 
     // Optional convenience wrappers so the test code reads cleanly
-    public Task StartAsync() => InitializeAsync();
-    public Task StopAsync()  => DisposeAsync();
+    public ValueTask StartAsync() => InitializeAsync();
+    public ValueTask StopAsync()  => DisposeAsync();
 
     public Task ExpectStartupAsync(TimeSpan? timeout = null)
         => ExpectMsgAsync("startup-ping", timeout ?? TimeSpan.FromSeconds(5)).AsTask();
@@ -82,7 +81,7 @@ public class TestActorStartupDeadlockSpec
 
             // --- START (bounded) ---
             _output.WriteLine($"[{id}] Calling StartAsync");
-            var startTask = kit.StartAsync();
+            var startTask = kit.StartAsync().AsTask();
             var startDone = await Task.WhenAny(startTask, Task.Delay(startTimeout));
             if (startDone != startTask)
             {
@@ -123,7 +122,7 @@ public class TestActorStartupDeadlockSpec
             finally
             {
                 // --- STOP (bounded) ---
-                var stopTask = kit.StopAsync();
+                var stopTask = kit.StopAsync().AsTask();
                 var stopDone = await Task.WhenAny(stopTask, Task.Delay(stopTimeout));
                 if (stopDone == stopTask)
                     await stopTask;

--- a/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
@@ -11,7 +11,6 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 using static FluentAssertions.FluentActions;
 

--- a/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Event;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
 {

--- a/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using System;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests;
 

--- a/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
+++ b/src/Akka.Hosting.TestKit.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests;
 

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/Akka.Hosting.TestKit.Xunit2.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/Akka.Hosting.TestKit.Xunit2.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Akka.Hosting.TestKit.Xunit2\Akka.Hosting.TestKit.Xunit2.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+        <PackageReference Include="xunit" Version="$(XunitVersion)" />
+        <PackageReference Include="FluentAssertions" Version="6.12.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="xunit.runner.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+    
+</Project>

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/DiPropsFailTest.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/DiPropsFailTest.cs
@@ -1,0 +1,54 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="DiPropsFailTest.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+// Regression test for https://github.com/akkadotnet/Akka.Hosting/issues/343
+public class DiPropsFailTest: TestKit
+{
+    public DiPropsFailTest(ITestOutputHelper output) : base(nameof(DiPropsFailTest), output)
+    {}
+    
+    protected override void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        base.ConfigureServices(context, services);
+        services.AddLogging();
+    }
+    
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    { }
+
+    [Fact]
+    public void DiTest()
+    {
+        var actor = Sys.ActorOf(NonRootActorWithDi.Props(Sys));
+        actor.Tell("test");
+        ExpectMsg<string>("test");
+    }
+    
+    private class NonRootActorWithDi: ReceiveActor
+    {
+        public static Props Props(ActorSystem system) => DependencyResolver.For(system).Props<NonRootActorWithDi>();
+        
+        public NonRootActorWithDi(ILogger<NonRootActorWithDi> log)
+        {
+            ReceiveAny(msg =>
+            {
+                log.LogInformation("Received {Msg}", msg);
+                Sender.Tell(msg);
+            });
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/HostingSpecSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/HostingSpecSpec.cs
@@ -1,0 +1,63 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HostingSpecSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using Xunit;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests
+{
+    public class HostingSpecSpec: TestKit
+    {
+        private enum Echo
+        { }
+
+        public HostingSpecSpec(ITestOutputHelper output)
+            : base(nameof(HostingSpecSpec), output, logLevel: LogLevel.Debug)
+        {
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            builder.WithActors((system, registry) =>
+            {
+                var echo = system.ActorOf(Props.Create(() => new SimpleEchoActor()));
+                registry.Register<Echo>(echo);
+            });
+        }
+
+        [Fact]
+        public void ActorTest()
+        {
+            var echo = ActorRegistry.Get<Echo>();
+            var probe = CreateTestProbe();
+            
+            echo.Tell("TestMessage", probe);
+            var msg = probe.ExpectMsg("TestMessage");
+            Log.Info(msg);
+        }
+        
+        private class SimpleEchoActor : ReceiveActor
+        {
+            public SimpleEchoActor()
+            {
+                var log = Context.GetLogger();
+                
+                ReceiveAny(msg =>
+                {
+                    log.Info($"Received {msg}");
+                    Sender.Tell(msg);
+                });
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/LoggerSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/LoggerSpec.cs
@@ -1,0 +1,82 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="LoggerSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.TestKit.Internals;
+using Xunit;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+public class LoggerSpec: TestKit
+{
+    public LoggerSpec(ITestOutputHelper output): base(output: output, logLevel: LogLevel.Debug)
+    {
+    }
+
+    internal override async Task LoggerHook(ActorSystem system, IActorRegistry registry)
+    {
+        var extSystem = (ExtendedActorSystem)system;
+        var logger = extSystem.SystemActorOf(Props.Create(() => new MockLogger()), "log-test");
+        registry.Register<MockLogger>(logger);
+        await logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream));
+    }
+    
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact(DisplayName = "TestKit ILoggerFactory logger should log messages")]
+    public void TestKitLoggerFactoryLoggerTest()
+    {
+        var loggerActor = ActorRegistry.Get<MockLogger>();
+        loggerActor.Tell(TestActor);
+
+        var logger = Event.Logging.GetLogger(Sys, "log-test");
+        
+        logger.Debug("debug");
+        ExpectMsg<Debug>(i => i.Message.ToString() == "debug");
+        
+        logger.Info("info");
+        ExpectMsg<Info>(i => i.Message.ToString() == "info");
+        
+        logger.Warning("warn");
+        ExpectMsg<Warning>(i => i.Message.ToString() == "warn");
+        
+        logger.Error("err");
+        ExpectMsg<Error>(i => i.Message.ToString() == "err");
+    }
+    
+    private class MockLogger: TestKitLoggerFactoryLogger
+    {
+        private IActorRef? _probe;
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case IActorRef actor:
+                    _probe = actor;
+                    return true;
+                default:
+                    return base.Receive(message);
+            }
+        }
+
+        protected override void Log(LogEvent log, ActorPath path)
+        {
+            if(log.LogSource.StartsWith("log-test"))
+                _probe.Tell(log);
+            base.Log(log, path);
+        }
+    }
+
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/NoImplicitSenderSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/NoImplicitSenderSpec.cs
@@ -1,0 +1,75 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NoImplicitSenderSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+public class NoImplicitSenderSpec : TestKit, INoImplicitSender
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        
+    }
+
+    [Fact]
+    public void When_Not_ImplicitSender_then_testActor_is_not_sender()
+    {
+        var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
+        echoActor.Tell("message");
+        var actorRef = ExpectMsg<IActorRef>();
+        actorRef.Should().Be(Sys.DeadLetters);
+    }
+
+}
+
+public class ImplicitSenderSpec : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        
+    }
+
+    [Fact]
+    public void ImplicitSender_should_have_testActor_as_sender()
+    {
+        var echoActor = Sys.ActorOf(c => c.ReceiveAny((m, ctx) => TestActor.Tell(ctx.Sender)));
+        echoActor.Tell("message");
+        ExpectMsg<IActorRef>(actorRef => Equals(actorRef, TestActor));
+
+        //Test that it works after we know that context has been changed
+        echoActor.Tell("message");
+        ExpectMsg<IActorRef>(actorRef => Equals(actorRef, TestActor));
+
+    }
+
+
+    [Fact]
+    public void ImplicitSender_should_not_change_when_creating_Testprobes()
+    {
+        //Verifies that bug #459 has been fixed
+        var testProbe = CreateTestProbe();
+        TestActor.Tell("message");
+        ReceiveOne();
+        LastSender.Should().Be(TestActor);
+    }
+
+    [Fact]
+    public void ImplicitSender_should_not_change_when_creating_TestActors()
+    {
+        var testActor2 = CreateTestActor("test2");
+        TestActor.Tell("message");
+        ReceiveOne();
+        LastSender.Should().Be(TestActor);
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/Properties/AssemblyInfo.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+using Xunit;
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b21496c0-a536-4953-9253-d2d0d526e42d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/BossActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/BossActor.cs
@@ -1,0 +1,55 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="BossActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.TestKit;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class BossActor : TActorBase
+{
+    private TestActorRef<InternalActor> _child;
+
+    public BossActor()
+    {
+        _child = new TestActorRef<InternalActor>(Context.System, Props.Create<InternalActor>(), Self, "child");
+    }
+
+    protected override SupervisorStrategy SupervisorStrategy()
+    {
+        return new OneForOneStrategy(maxNrOfRetries: 5, withinTimeRange: TimeSpan.FromSeconds(1), localOnlyDecider: ex => ex is ActorKilledException ? Directive.Restart : Directive.Escalate);
+    }
+
+    protected override bool ReceiveMessage(object message)
+    {
+        if(message is string && ((string)message) == "sendKill")
+        {
+            _child.Tell(Kill.Instance);
+            return true;
+        }
+        return false;
+    }
+
+    private class InternalActor : TActorBase
+    {
+        protected override void PreRestart(Exception reason, object message)
+        {
+            TestActorRefSpec.Counter--;
+        }
+
+        protected override void PostRestart(Exception reason)
+        {
+            TestActorRefSpec.Counter--;
+        }
+
+        protected override bool ReceiveMessage(object message)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/FsmActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/FsmActor.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="FsmActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public enum TestFsmState
+{
+    First,
+    Last
+}
+
+public class FsmActor : FSM<TestFsmState, string>
+{
+    private readonly IActorRef _replyActor;
+
+    public FsmActor(IActorRef replyActor)
+    {
+        _replyActor = replyActor;
+
+        When(TestFsmState.First, e =>
+        {
+            if (e.FsmEvent.Equals("check"))
+            {
+                _replyActor.Tell("first");
+            }
+            else if (e.FsmEvent.Equals("next"))
+            {
+                return GoTo(TestFsmState.Last);
+            }
+
+            return Stay();
+        });
+
+        When(TestFsmState.Last, e =>
+        {
+            if (e.FsmEvent.Equals("check"))
+            {
+                _replyActor.Tell("last");
+            }
+            else if (e.FsmEvent.Equals("next"))
+            {
+                return GoTo(TestFsmState.First);
+            }
+
+            return Stay();
+        });
+
+        StartWith(TestFsmState.First, "foo");
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/Logger.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/Logger.cs
@@ -1,0 +1,27 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Logger.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class Logger : ActorBase
+{
+    private int _count;
+    private string? _msg;
+    protected override bool Receive(object message)
+    {
+        if(message is Warning { Message: string } warning)
+        {
+            _count++;
+            _msg = (string)warning.Message;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/NestingActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/NestingActor.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NestingActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.TestKit;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class NestingActor : ActorBase
+{
+    private readonly IActorRef _nested;
+
+    public NestingActor(bool createTestActorRef)
+    {
+        _nested = createTestActorRef ? Context.ActorOf<NestedActor>() : new TestActorRef<NestedActor>(Context.System, Props.Create<NestedActor>(), null, null);
+    }
+
+    protected override bool Receive(object message)
+    {
+        Sender.Tell(_nested, Self);
+        return true;
+    }
+
+    private class NestedActor : ActorBase
+    {
+        protected override bool Receive(object message)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/PersistActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/PersistActor.cs
@@ -1,0 +1,72 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PersistActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
+{
+    using System;
+    using Actor;
+
+    public class PersistActor : UntypedPersistentActor
+    {
+        public PersistActor(IActorRef probe)
+        {
+            _probe = probe;
+        }
+
+        private readonly IActorRef _probe;
+
+        public override string PersistenceId => "foo";
+
+        protected override void OnCommand(object message)
+        {
+            switch (message)
+            {
+                case WriteMessage msg:
+                    Persist(msg.Data, _ =>
+                    {
+                        _probe.Tell("ack");
+                    });
+
+                    break;
+
+                default:
+                    return;
+            }
+        }
+
+        protected override void OnRecover(object message)
+        {
+            _probe.Tell(message);
+        }
+
+        protected override void OnPersistFailure(Exception cause, object @event, long sequenceNr)
+        {
+            _probe.Tell("failure");
+
+            base.OnPersistFailure(cause, @event, sequenceNr);
+        }
+
+        protected override void OnPersistRejected(Exception cause, object @event, long sequenceNr)
+        {
+            _probe.Tell("rejected");
+
+            base.OnPersistRejected(cause, @event, sequenceNr);
+        }
+
+        public class WriteMessage
+        {
+            public string Data { get; }
+
+            public WriteMessage(string data)
+            {
+                Data = data;
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/ReplyActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/ReplyActor.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReplyActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.TestKit;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class ReplyActor : TActorBase
+{
+    private IActorRef? _replyTo;
+
+    protected override bool ReceiveMessage(object message)
+    {
+        var strMessage = message as string;
+        switch(strMessage)
+        {
+            case "complexRequest":
+                _replyTo = Sender;
+                var worker = new TestActorRef<WorkerActor>(System, Props.Create<WorkerActor>());
+                worker.Tell("work");
+                return true;
+            case "complexRequest2":
+                var worker2 = new TestActorRef<WorkerActor>(System, Props.Create<WorkerActor>());
+                worker2.Tell(Sender, Self);
+                return true;
+            case "workDone":
+                if (_replyTo is null)
+                    throw new NullReferenceException("_replyTo is null, make sure that \"complexRequest\" is sent first");
+                
+                _replyTo.Tell("complexReply", Self);
+                return true;
+            case "simpleRequest":
+                Sender.Tell("simpleReply", Self);
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/SenderActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/SenderActor.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SenderActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class SenderActor : TActorBase
+{
+    private readonly IActorRef _replyActor;
+
+    public SenderActor(IActorRef replyActor)
+    {
+        _replyActor = replyActor;
+    }
+
+    protected override bool ReceiveMessage(object message)
+    {
+        var strMessage = message as string;
+        switch(strMessage)
+        {
+            case "complex":
+                _replyActor.Tell("complexRequest", Self);
+                return true;
+            case "complex2":
+                _replyActor.Tell("complexRequest2", Self);
+                return true;
+            case "simple":
+                _replyActor.Tell("simpleRequest", Self);
+                return true;
+            case "complexReply":
+                TestActorRefSpec.Counter--;
+                return true;
+            case "simpleReply":
+                TestActorRefSpec.Counter--;
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/SnapshotActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/SnapshotActor.cs
@@ -1,0 +1,100 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SnapshotActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.Persistence.TestKit.Tests
+{
+    using System;
+    using Actor;
+
+    public class SnapshotActor : UntypedPersistentActor
+    {
+        public SnapshotActor(IActorRef probe)
+        {
+            _probe = probe;
+        }
+
+        private readonly IActorRef _probe;
+
+        public override string PersistenceId => "bar";
+
+        protected override void OnCommand(object message)
+        {
+            switch (message)
+            {
+                case "save":
+                    SaveSnapshot(message);
+                    return;
+
+                case DeleteOne del:
+                    DeleteSnapshot(del.SequenceNr);
+                    return;
+
+                case DeleteMany del:
+                    DeleteSnapshots(del.Criteria);
+                    return;
+
+                case SaveSnapshotSuccess _:
+                case SaveSnapshotFailure _:
+                case DeleteSnapshotSuccess _:
+                case DeleteSnapshotFailure _:
+                case DeleteSnapshotsSuccess _:
+                case DeleteSnapshotsFailure _:
+                    _probe.Tell(message);
+                    return;
+
+                default:
+                    return;
+            }
+        }
+
+        protected override void OnRecover(object message)
+        {
+            if (message is SnapshotOffer snapshot)
+            {
+                _probe.Tell(message);
+            }
+        }
+
+        protected override void OnRecoveryFailure(Exception reason, object message)
+        {
+            _probe.Tell(new RecoveryFailure(reason, message));
+            base.OnRecoveryFailure(reason, message);
+        }
+
+        public class DeleteOne
+        {
+            public DeleteOne(long sequenceNr)
+            {
+                SequenceNr = sequenceNr;
+            }
+
+            public long SequenceNr { get; }
+        }
+
+        public class DeleteMany
+        {
+            public DeleteMany(SnapshotSelectionCriteria criteria)
+            {
+                Criteria = criteria;
+            }
+
+            public SnapshotSelectionCriteria Criteria { get; }
+        }
+
+        public class RecoveryFailure
+        {
+            public RecoveryFailure(Exception reason, object message)
+            {
+                Reason = reason;
+                Message = message;
+            }
+
+            public Exception Reason { get; }
+            public object Message { get; }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/TActorBase.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/TActorBase.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TActorBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading;
+using Akka.Actor;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+// ReSharper disable once InconsistentNaming
+public abstract class TActorBase : ActorBase
+{
+    protected sealed override bool Receive(object message)
+    {
+        var currentThread = Thread.CurrentThread;
+        if(currentThread != TestActorRefSpec.Thread)
+            TestActorRefSpec.OtherThread = currentThread;
+        return ReceiveMessage(message);
+    }
+
+    protected abstract bool ReceiveMessage(object message);
+
+    protected ActorSystem System
+    {
+        get { return ((LocalActorRef)Self).Cell.System; }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/TestActorRefSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/TestActorRefSpec.cs
@@ -1,0 +1,239 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestActorRefSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Dispatch;
+using Akka.TestKit;
+using Akka.TestKit.Internal;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
+{
+    public class TestActorRefSpec : TestKit
+    {
+        public static int Counter = 4;
+        public static readonly Thread Thread = Thread.CurrentThread;
+        public static Thread? OtherThread;
+
+        public TestActorRefSpec()
+        {
+        }
+        
+        private TimeSpan DefaultTimeout => Dilated(TestKitSettings.DefaultTimeout);
+
+        protected override Config Config => "test-dispatcher1.type=\"Akka.Dispatch.PinnedDispatcherConfigurator, Akka\"";
+
+        private void AssertThread()
+        {
+            Assert.True(OtherThread == null || OtherThread == Thread, "Thread");
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+        }
+
+        protected override async Task BeforeTestStart()
+        {
+            await base.BeforeTestStart();
+            OtherThread = null;
+        }
+
+        [Fact]
+        public void TestActorRef_name_must_start_with_double_dollar_sign()
+        {
+            //Looking at the scala code, this might not be obvious that the name starts with $$
+            //object TestActorRef (TestActorRef.scala) contain this code: 
+            //    private[testkit] def randomName: String = {
+            //      val l = number.getAndIncrement()
+            //      "$" + akka.util.Helpers.base64(l)
+            //    }
+            //So it adds one $. The second is added by akka.util.Helpers.base64(l) which by default 
+            //creates a StringBuilder and adds adds $. Hence, 2 $$
+            var testActorRef = new TestActorRef<ReplyActor>(Sys, Props.Create<ReplyActor>());
+
+            Assert.Equal("$$", testActorRef.Path.Name.Substring(0, 2));
+        }
+
+        [Fact]
+        public async Task TestActorRef_must_support_nested_Actor_creation_when_used_with_TestActorRef()
+        {
+            var a = new TestActorRef<NestingActor>(Sys, Props.Create(() => new NestingActor(true)));
+            Assert.NotNull(a);
+            var nested = await a.Ask<IActorRef>("any", DefaultTimeout);
+            Assert.NotNull(nested);
+            Assert.NotSame(a, nested);
+        }
+
+        [Fact]
+        public async Task TestActorRef_must_support_nested_Actor_creation_when_used_with_ActorRef()
+        {
+            var a = new TestActorRef<NestingActor>(Sys, Props.Create(() => new NestingActor(false)));
+            Assert.NotNull(a);
+            var nested = await a.Ask<IActorRef>("any", DefaultTimeout);
+            Assert.NotNull(nested);
+            Assert.NotSame(a, nested);
+        }
+
+        [Fact]
+        public void TestActorRef_must_support_reply_via_sender()
+        {
+            var serverRef = new TestActorRef<ReplyActor>(Sys, Props.Create<ReplyActor>());
+            var clientRef = new TestActorRef<SenderActor>(Sys, Props.Create(() => new SenderActor(serverRef)));
+
+            Counter = 4;
+            clientRef.Tell("complex");
+            clientRef.Tell("simple");
+            clientRef.Tell("simple");
+            clientRef.Tell("simple");
+            Counter.Should().Be(0);
+
+            Counter = 4;
+            clientRef.Tell("complex2");
+            clientRef.Tell("simple");
+            clientRef.Tell("simple");
+            clientRef.Tell("simple");
+            Counter.Should().Be(0);
+
+            AssertThread();
+        }
+
+        [Fact]
+        public void TestActorRef_must_stop_when_sent_a_PoisonPill()
+        {
+            //TODO: Should have this surrounding all code EventFilter[ActorKilledException]() intercept {
+            var probe = CreateTestProbe();
+            var a = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>(), null, "will-be-killed");
+            var actorRef = (InternalTestActorRef)a.Ref;
+            probe.Watch(actorRef);
+            Sys.ActorOf(Props.Create(() => new WatchAndForwardActor(a, TestActor)), "forwarder");
+            
+            a.Tell(PoisonPill.Instance);
+            ExpectMsg<WrappedTerminated>(w => w.Terminated.ActorRef == a, TimeSpan.FromSeconds(10), $"that the terminated actor was the one killed, i.e. {a.Path}");
+            probe.ExpectTerminated(actorRef);
+            AssertThread();
+        }
+
+        [Fact]
+        public void TestActorRef_must_restart_when_killed()
+        {
+            //TODO: Should have this surrounding all code EventFilter[ActorKilledException]() intercept {
+            Counter = 2;
+            var boss = new TestActorRef<BossActor>(Sys, Props.Create<BossActor>());
+
+            boss.Tell("sendKill");
+            Assert.Equal(0, Counter);
+            AssertThread();
+        }
+
+        [Fact]
+        public async Task TestActorRef_must_support_futures()
+        {
+            var worker = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>());
+            var task = worker.Ask("work");
+            Assert.True(task.IsCompleted, "Task should be completed");
+            var result = await task.WaitAsync(DefaultTimeout); //Using a timeout to stop the test if there is something wrong with the code
+            Assert.Equal("workDone", result);
+        }
+
+        [Fact]
+        public void TestActorRef_must_allow_access_to_internals()
+        {
+            var actorRef = new TestActorRef<SaveStringActor>(Sys, Props.Create<SaveStringActor>());
+            actorRef.Tell("Hejsan!");
+            var actor = actorRef.UnderlyingActor;
+            Assert.Equal("Hejsan!", actor.ReceivedString);
+        }
+
+        [Fact]
+        public void TestActorRef_must_set_ReceiveTimeout_to_None()
+        {
+            var a = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>());
+            ((IInternalActor)a.UnderlyingActor).ActorContext.ReceiveTimeout.Should().Be(null);
+        }
+
+        [Fact]
+        public void TestActorRef_must_set_CallingThreadDispatcher()
+        {
+            var a = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>());
+            var actorRef = (InternalTestActorRef)a.Ref;
+            Assert.IsType<CallingThreadDispatcher>(actorRef.Cell.Dispatcher);
+        }
+
+        [Fact]
+        public void TestActorRef_must_allow_override_of_dispatcher()
+        {
+            var a = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>().WithDispatcher("test-dispatcher1"));
+            var actorRef = (InternalTestActorRef)a.Ref;
+            Assert.IsType<PinnedDispatcher>(actorRef.Cell.Dispatcher);
+        }
+
+        [Fact]
+        public void TestActorRef_must_proxy_receive_for_the_underlying_actor_without_sender()
+        {
+            var a = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>());
+            var actorRef = (InternalTestActorRef)a.Ref;
+            Watch(actorRef);
+            a.Receive("work");
+            ExpectTerminated(actorRef);
+        }
+
+        [Fact]
+        public void TestActorRef_must_proxy_receive_for_the_underlying_actor_with_sender()
+        {
+            var a = new TestActorRef<WorkerActor>(Sys, Props.Create<WorkerActor>());
+            var probe = CreateTestProbe();
+            var actorRef = (InternalTestActorRef)a.Ref;
+            probe.Watch(actorRef);
+            a.Receive("work", TestActor);   //This will stop the actor
+            ExpectMsg("workDone");
+            probe.ExpectTerminated(actorRef);
+        }
+
+        [Fact]
+        public void TestFsmActorRef_must_proxy_receive_for_underlying_actor_with_sender()
+        {
+            var a = new TestFSMRef<FsmActor, TestFsmState, string>(Sys, Props.Create(() => new FsmActor(TestActor)));
+            a.Receive("check");
+            ExpectMsg("first");
+
+            // verify that we can change state
+            a.SetState(TestFsmState.Last);
+            a.Receive("check");
+            ExpectMsg("last");
+        }
+
+        [Fact]
+        public void BugFix1709_TestFsmActorRef_must_work_with_Fsms_with_constructor_arguments()
+        {
+            var a = ActorOfAsTestFSMRef<FsmActor, TestFsmState, string>(Props.Create(() => new FsmActor(TestActor)));
+            a.Receive("check");
+            ExpectMsg("first");
+
+            // verify that we can change state
+            a.SetState(TestFsmState.Last);
+            a.Receive("check");
+            ExpectMsg("last");
+        }
+
+        private class SaveStringActor : TActorBase
+        {
+            public string? ReceivedString { get; private set; }
+
+            protected override bool ReceiveMessage(object message)
+            {
+                ReceivedString = message as string;
+                return true;
+            }
+        }
+    }
+}
+

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/TestProbeSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/TestProbeSpec.cs
@@ -1,0 +1,123 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestProbeSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Akka.Util.Internal;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests
+{
+    public class TestProbeSpec : TestKit
+    {
+        [Fact]
+        public void TestProbe_should_equal_underlying_Ref()
+        {
+            var p = CreateTestProbe();
+            p.Equals(p.Ref).Should().BeTrue();
+            p.Ref.Equals(p).Should().BeTrue();
+            var hs = new HashSet<IActorRef> {p, p.Ref};
+            hs.Count.Should().Be(1);
+        }
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+        }
+
+        /// <summary>
+        /// Should be able to receive a <see cref="Terminated"/> message from a <see cref="TestProbe"/>
+        /// if we're deathwatching it and it terminates.
+        /// </summary>
+        [Fact]
+        public void TestProbe_should_send_Terminated_when_killed()
+        {
+            var p = CreateTestProbe();
+            Watch(p);
+            Sys.Stop(p);
+            ExpectTerminated(p);
+        }
+
+        /// <summary>
+        /// If we deathwatch the underlying actor ref or TestProbe itself, it shouldn't matter.
+        /// 
+        /// They should be equivalent either way.
+        /// </summary>
+        [Fact]
+        public void TestProbe_underlying_Ref_should_be_equivalent_to_TestProbe()
+        {
+            var p = CreateTestProbe();
+            Watch(p.Ref);
+            Sys.Stop(p);
+            ExpectTerminated(p);
+        }
+
+        /// <summary>
+        /// Should be able to receive a <see cref="Terminated"/> message from a <see cref="TestProbe.Ref"/>
+        /// if we're deathwatching it and it terminates.
+        /// </summary>
+        [Fact]
+        public void TestProbe_underlying_Ref_should_send_Terminated_when_killed()
+        {
+            var p = CreateTestProbe();
+            Watch(p.Ref);
+            Sys.Stop(p.Ref);
+            ExpectTerminated(p.Ref);
+        }
+
+        [Fact]
+        public void TestProbe_should_create_a_child_when_invoking_ChildActorOf()
+        {
+            var probe = CreateTestProbe();
+            var child = probe.ChildActorOf(Props.Create<EchoActor>());
+            child.Path.Parent.Should().Be(probe.Ref.Path);
+            var namedChild = probe.ChildActorOf<EchoActor>("actorName");
+            namedChild.Path.Name.Should().Be("actorName");
+        }
+
+        [Fact]
+        public async Task TestProbe_restart_a_failing_child_if_the_given_supervisor_says_so()
+        {
+            var probe = CreateTestProbe();
+            var restartWatcher = CreateTestProbe();
+            var child = probe.ChildActorOf(Props.Create(() => new FailingActor(restartWatcher)), SupervisorStrategy.DefaultStrategy);
+
+            // Send two messages that will cause failures and restarts
+            child.Tell("hello");
+            child.Tell("hello");
+
+            // Wait for exactly 2 restart notifications
+            await restartWatcher.ExpectMsgAsync("restarted");
+            await restartWatcher.ExpectMsgAsync("restarted");
+        }
+
+        class FailingActor : ActorBase
+        {
+            private readonly IActorRef _restartWatcher;
+
+            public FailingActor(IActorRef restartWatcher)
+            {
+                _restartWatcher = restartWatcher;
+            }
+
+            protected override bool Receive(object message)
+            {
+                throw new Exception("Simulated failure");
+            }
+
+            protected override void PostRestart(Exception reason)
+            {
+                _restartWatcher.Tell("restarted");
+                base.PostRestart(reason);
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/WatchAndForwardActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/WatchAndForwardActor.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="WatchAndForwardActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class WatchAndForwardActor : ActorBase
+{
+    private readonly IActorRef _forwardToActor;
+
+    public WatchAndForwardActor(IActorRef watchedActor, IActorRef forwardToActor)
+    {
+        _forwardToActor = forwardToActor;
+        Context.Watch(watchedActor);
+    }
+
+    protected override bool Receive(object message)
+    {
+        var terminated = message as Terminated;
+        if(terminated != null)
+            _forwardToActor.Tell(new WrappedTerminated(terminated), Sender);
+        else
+            _forwardToActor.Tell(message, Sender);
+        return true;
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/WorkerActor.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/WorkerActor.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="WorkerActor.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class WorkerActor : TActorBase
+{
+    protected override bool ReceiveMessage(object message)
+    {
+        if((message as string) == "work")
+        {
+            Sender.Tell("workDone");
+            Context.Stop(Self);
+            return true;
+
+        }
+        //TODO: case replyTo: Promise[_] ⇒ replyTo.asInstanceOf[Promise[Any]].success("complexReply")
+        if(message is IActorRef)
+        {
+            ((IActorRef)message).Tell("complexReply", Self);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/WrappedTerminated.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorRefTests/WrappedTerminated.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="WrappedTerminated.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+
+namespace Akka.Hosting.TestKit.Tests.TestActorRefTests;
+
+public class WrappedTerminated
+{
+    private readonly Terminated _terminated;
+
+    public WrappedTerminated(Terminated terminated)
+    {
+        _terminated = terminated;
+    }
+
+    public Terminated Terminated { get { return _terminated; } }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorStartupDeadlockSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestActorStartupDeadlockSpec.cs
@@ -1,0 +1,134 @@
+﻿using Akka.TestKit;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Actor;
+using Hosting;
+using Akka.Hosting.TestKit;
+using Xunit;
+
+file sealed class StartupPinger(IRequiredActor<TestProbe> testActorReq) : ReceiveActor
+{
+    protected override void PreStart()
+    {
+        // This should work now that TestProbe is registered in the first startup hook
+        var testActor = testActorReq.GetAsync().GetAwaiter().GetResult();
+        testActor.Tell("startup-ping");
+    }
+}
+
+file sealed class HostedTestKitRunner : TestKit, IAsyncLifetime  // TestKit already implements IAsyncLifetime, but we expose it here for clarity
+{
+    public HostedTestKitRunner(ITestOutputHelper output) 
+        : base($"{Guid.NewGuid():N}", startupTimeout: TimeSpan.FromSeconds(20), output: output, logLevel: LogLevel.Error)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        // WithActors runs during ActorSystem creation
+        // TestProbe should already be registered by the first startup hook
+        builder.WithActors((system, _, resolver) =>
+        {
+            system.ActorOf(resolver.Props<StartupPinger>(), "pinger");
+        });
+    }
+
+    // Optional convenience wrappers so the test code reads cleanly
+    public Task StartAsync() => InitializeAsync();
+    public Task StopAsync()  => DisposeAsync();
+
+    public Task ExpectStartupAsync(TimeSpan? timeout = null)
+        => ExpectMsgAsync("startup-ping", timeout ?? TimeSpan.FromSeconds(5)).AsTask();
+}
+
+public class TestActorStartupDeadlockSpec
+{
+    private readonly ITestOutputHelper _output;
+
+    public TestActorStartupDeadlockSpec(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+    
+    // Give the overall test plenty of time; we enforce our own short, per-step timeouts below.
+    [Fact(Timeout = 30000)] // Increased timeout for 30 parallel hosts
+    public async Task parallel_host_start_should_not_deadlock()
+    {
+        // Per-runner bounded timeouts
+        var startTimeout   = TimeSpan.FromSeconds(7); // pre-fix should trip this quickly
+        var expectTimeout  = TimeSpan.FromSeconds(10); // Increased timeout for high concurrency
+        var stopTimeout    = TimeSpan.FromSeconds(5);
+        var concurrentHosts = 30;
+
+        // Spin up N independent hosts concurrently inside the same theory
+        var runners = Enumerable.Range(0, concurrentHosts)
+                                .Select(_ => Task.Run(RunOneAsync))
+                                .ToArray();
+
+        await Task.WhenAll(runners);
+        return;
+
+        async Task RunOneAsync()
+        {
+            var id = Guid.NewGuid().ToString("N").Substring(0, 8);
+            _output.WriteLine($"[{id}] Starting runner");
+            var kit = new HostedTestKitRunner(_output);
+
+            // --- START (bounded) ---
+            _output.WriteLine($"[{id}] Calling StartAsync");
+            var startTask = kit.StartAsync();
+            var startDone = await Task.WhenAny(startTask, Task.Delay(startTimeout));
+            if (startDone != startTask)
+            {
+                _output.WriteLine($"[{id}] StartAsync timed out after {startTimeout}");
+                // Fail fast with a clear message rather than timing out the entire test method
+                Assert.Fail(
+                    $"Host did not start within {startTimeout}. " +
+                    "This indicates the known startup deadlock (TestKit initialized inline on the startup thread).");
+            }
+            _output.WriteLine($"[{id}] StartAsync completed");
+            // propagate any exception from StartAsync (e.g., watchdog TimeoutException)
+            try
+            {
+                await startTask;
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.StartsWith("Timeout waiting for test actor"))
+                    _output.WriteLine($"Original issue detected: {ex.Message}");
+                
+                throw;
+            }
+
+            try
+            {
+                // --- EXPECT (bounded) ---
+                _output.WriteLine($"[{id}] Expecting startup ping");
+                var expectTask = kit.ExpectStartupAsync(expectTimeout);
+                var expectDone = await Task.WhenAny(expectTask, Task.Delay(expectTimeout));
+                if (expectDone != expectTask)
+                {
+                    _output.WriteLine($"[{id}] ExpectStartupAsync timed out after {expectTimeout}");
+                    Assert.Fail($"Did not receive startup ping within {expectTimeout}.");
+                }
+                _output.WriteLine($"[{id}] Received startup ping");
+                await expectTask;
+            }
+            finally
+            {
+                // --- STOP (bounded) ---
+                var stopTask = kit.StopAsync();
+                var stopDone = await Task.WhenAny(stopTask, Task.Delay(stopTimeout));
+                if (stopDone == stopTask)
+                    await stopTask;
+                // else: swallow to avoid hanging the test process on shutdown in pre-fix scenarios
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
@@ -1,0 +1,344 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AllTestForEventFilterBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Event;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+using static FluentAssertions.FluentActions;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
+{
+    public abstract class AllTestForEventFilterBase<TLogEvent> : EventFilterTestBase where TLogEvent : LogEvent
+    {
+        // ReSharper disable ConvertToLambdaExpression
+        private EventFilterFactory? _testingEventFilter;
+
+        protected AllTestForEventFilterBase(LogLevel logLevel, ITestOutputHelper? output = null)
+            : base(logLevel, output)
+        {
+        }
+
+        protected override async Task BeforeTestStart()
+        {
+            await base.BeforeTestStart();
+            LogLevel = Event.Logging.LogLevelFor<TLogEvent>();
+            // ReSharper disable once VirtualMemberCallInConstructor
+            _testingEventFilter = CreateTestingEventFilter();
+        }
+
+        protected new LogLevel LogLevel { get; private set; }
+        protected abstract EventFilterFactory CreateTestingEventFilter();
+
+        protected void LogMessage(string message)
+        {
+            Log.Log(LogLevel, message);
+        }
+
+        protected override void SendRawLogEventMessage(object message)
+        {
+            PublishMessage(message, "test");
+        }
+
+        protected abstract void PublishMessage(object message, string source);
+
+        [Fact]
+        public void Single_message_is_intercepted()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel).ExpectOne(() => LogMessage("whatever"));
+            TestSuccessful = true;
+        }
+
+
+        [Fact]
+        public void Can_intercept_messages_when_start_is_specified()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, start: "what").ExpectOne(() => LogMessage("whatever"));
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Do_not_intercept_messages_when_start_does_not_match()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, start: "what").ExpectOne(() =>
+            {
+                LogMessage("let-me-thru");
+                LogMessage("whatever");
+            });
+            ExpectMsg<TLogEvent>(err => (string)err.Message == "let-me-thru");
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Can_intercept_messages_when_message_is_specified()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, message: "whatever").ExpectOne(() => LogMessage("whatever"));
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Do_not_intercept_messages_when_message_does_not_match()
+        {
+            EventFilter.ForLogLevel(LogLevel, message: "whatever").ExpectOne(() =>
+            {
+                LogMessage("let-me-thru");
+                LogMessage("whatever");
+            });
+            ExpectMsg<TLogEvent>(err => (string)err.Message == "let-me-thru");
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Can_intercept_messages_when_contains_is_specified()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, contains: "ate").ExpectOne(() => LogMessage("whatever"));
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Do_not_intercept_messages_when_contains_does_not_match()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, contains: "eve").ExpectOne(() =>
+            {
+                LogMessage("let-me-thru");
+                LogMessage("whatever");
+            });
+            ExpectMsg<TLogEvent>(err => (string)err.Message == "let-me-thru");
+            TestSuccessful = true;
+        }
+
+
+        [Fact]
+        public void Can_intercept_messages_when_source_is_specified()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, source: LogSource.FromType(GetType(), Sys)).ExpectOne(() => LogMessage("whatever"));
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Do_not_intercept_messages_when_source_does_not_match()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel, source: "expected-source").ExpectOne(() =>
+            {
+                PublishMessage("message", source: "expected-source");
+                PublishMessage("message", source: "let-me-thru");
+            });
+            ExpectMsg<TLogEvent>(err => err.LogSource == "let-me-thru");
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Specified_numbers_of_messages_and_be_intercepted()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel).Expect(2, () =>
+            {
+                LogMessage("whatever");
+                LogMessage("whatever");
+            });
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Expect_0_events_Should_work()
+        {
+            this.Invoking(_ =>
+            {
+                EventFilter.Error().Expect(0, () =>
+                {
+                    Log.Error("something");
+                });
+            }).Should().Throw<Exception>("Expected 0 events");
+        }
+
+        [Fact]
+        public async Task ExpectAsync_0_events_Should_work()
+        {
+            Exception? ex = null;
+            try
+            {
+                await EventFilter.Error().ExpectAsync(0, async () =>
+                {
+                    await Task.Delay(100); // bug only happens when error is not logged instantly
+                    Log.Error("something");
+                });
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
+            ex.Should().NotBeNull("Expected 0 errors logged, but there are error logs");
+        }
+
+        /// issue: InternalExpectAsync does not await actionAsync() - causing actionAsync to run as a detached task #5537
+        [Fact]
+        public async Task ExpectAsync_should_await_actionAsync()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            await Assert.ThrowsAnyAsync<FalseException>(async () =>
+            {
+                await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(0, actionAsync: async () =>
+                {
+                    Assert.False(true);
+                    await Task.CompletedTask;
+                });
+            });
+        }
+
+        // issue: InterceptAsync seems to run func() as a detached task #5586
+        [Fact]
+        public async Task InterceptAsync_should_await_func()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            await Assert.ThrowsAnyAsync<FalseException>(async () =>
+            {
+                await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(0, async () =>
+                {
+                    Assert.False(true);
+                    await Task.CompletedTask;
+                }, TimeSpan.FromSeconds(.1));
+            });
+        }
+
+        [Fact]
+        public void Messages_can_be_muted()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel).Mute(() =>
+            {
+                LogMessage("whatever");
+                LogMessage("whatever");
+            });
+            TestSuccessful = true;
+        }
+
+
+        [Fact]
+        public void Messages_can_be_muted_from_now_on()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            var unmutableFilter = _testingEventFilter.ForLogLevel(LogLevel).Mute();
+            LogMessage("whatever");
+            LogMessage("whatever");
+            unmutableFilter.Unmute();
+            TestSuccessful = true;
+        }
+
+        [Fact]
+        public void Messages_can_be_muted_from_now_on_with_using()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            using(_testingEventFilter.ForLogLevel(LogLevel).Mute())
+            {
+                LogMessage("whatever");
+                LogMessage("whatever");
+            }
+            TestSuccessful = true;
+        }
+
+
+        [Fact]
+        public void Make_sure_async_works()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter.ForLogLevel(LogLevel).Expect(1, TimeSpan.FromSeconds(2), () =>
+            {
+                Task.Delay(TimeSpan.FromMilliseconds(10)).ContinueWith(_ => { LogMessage("whatever"); });
+            });
+        }
+
+        [Fact]
+        public void Chain_many_filters()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            _testingEventFilter
+                .ForLogLevel(LogLevel,message:"Message 1").And
+                .ForLogLevel(LogLevel,message:"Message 3")
+                .Expect(2,() =>
+                 {
+                     LogMessage("Message 1");
+                     LogMessage("Message 2");
+                     LogMessage("Message 3");
+
+                 });
+            ExpectMsg<TLogEvent>(m => (string) m.Message == "Message 2");
+        }
+
+
+        [Fact]
+        public void Should_timeout_if_too_few_messages()
+        {
+            if (_testingEventFilter is null)
+                throw new NullReferenceException("_testingEventFilter should not be null, check CreateTestingEventFilter implementation.");
+            
+            Invoking(() =>
+            {
+                _testingEventFilter.ForLogLevel(LogLevel).Expect(2, TimeSpan.FromMilliseconds(50), () =>
+                {
+                    LogMessage("whatever");
+                });
+            }).Should().Throw<FailException>().WithMessage("timeout*");
+        }
+
+        [Fact]
+        public void Should_log_when_not_muting()
+        {
+            const string message = "This should end up in the log since it's not filtered";
+            LogMessage(message);
+            ExpectMsg<TLogEvent>( msg => (string)msg.Message == message);
+        }
+
+        // ReSharper restore ConvertToLambdaExpression
+
+    }
+}
+

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/AllTestForEventFilterBase_Instances.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/AllTestForEventFilterBase_Instances.cs
@@ -1,0 +1,131 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AllTestForEventFilterBase_Instances.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
+using Akka.TestKit;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests;
+
+public class EventFilterDebugTests : AllTestForEventFilterBase<Debug>
+{
+    public EventFilterDebugTests() : base(LogLevel.DebugLevel){}
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return EventFilter;
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Debug(source,GetType(),message));
+    }
+}
+
+public class CustomEventFilterDebugTests : AllTestForEventFilterBase<Debug>
+{
+    public CustomEventFilterDebugTests() : base(LogLevel.DebugLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return CreateEventFilter(Sys);
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Debug(source, GetType(), message));
+    }
+}
+
+public class EventFilterInfoTests : AllTestForEventFilterBase<Info>
+{
+    public EventFilterInfoTests() : base(LogLevel.InfoLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return EventFilter;
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Info(source, GetType(), message));
+    }
+}
+
+public class CustomEventFilterInfoTests : AllTestForEventFilterBase<Info>
+{
+    public CustomEventFilterInfoTests() : base(LogLevel.InfoLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return CreateEventFilter(Sys);
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Info(source, GetType(), message));
+    }
+}
+
+
+public class EventFilterWarningTests : AllTestForEventFilterBase<Warning>
+{
+    public EventFilterWarningTests() : base(LogLevel.WarningLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return EventFilter;
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Warning(source, GetType(), message));
+    }
+}
+
+public class CustomEventFilterWarningTests : AllTestForEventFilterBase<Warning>
+{
+    public CustomEventFilterWarningTests() : base(LogLevel.WarningLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return CreateEventFilter(Sys);
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Warning(source, GetType(), message));
+    }
+}
+
+public class EventFilterErrorTests : AllTestForEventFilterBase<Error>
+{
+    public EventFilterErrorTests() : base(LogLevel.ErrorLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return EventFilter;
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Error(null, source, GetType(), message));
+    }
+}
+
+public class CustomEventFilterErrorTests : AllTestForEventFilterBase<Error>
+{
+    public CustomEventFilterErrorTests() : base(LogLevel.ErrorLevel) { }
+
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return CreateEventFilter(Sys);
+    }
+
+    protected override void PublishMessage(object message, string source)
+    {
+        Sys.EventStream.Publish(new Error(null, source, GetType(), message));
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/ConfigTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/ConfigTests.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ConfigTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
+{
+    public class ConfigTests : TestKit
+    {
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+        }
+        
+        [Fact]
+        public void TestEventListener_is_in_config_by_default()
+        {
+            var configLoggers = Sys.Settings.Config.GetStringList("akka.loggers", new string[] { });
+            configLoggers.Any(logger => logger.Contains("Akka.TestKit.TestEventListener")).Should().BeTrue();
+            configLoggers.Any(logger => logger.Contains("Akka.Event.DefaultLogger")).Should().BeFalse();
+        }
+    }
+}
+

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/CustomEventFilterTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/CustomEventFilterTests.cs
@@ -1,0 +1,62 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CustomEventFilterTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests;
+
+public abstract class CustomEventFilterTestsBase : EventFilterTestBase
+{
+    // ReSharper disable ConvertToLambdaExpression
+    public CustomEventFilterTestsBase() : base(Event.LogLevel.ErrorLevel) { }
+
+    protected override void SendRawLogEventMessage(object message)
+    {
+        Sys.EventStream.Publish(new Error(null, "CustomEventFilterTests", GetType(), message));
+    }
+
+    protected abstract EventFilterFactory CreateTestingEventFilter();
+
+    [Fact]
+    public void Custom_filter_should_match()
+    {
+        var eventFilter = CreateTestingEventFilter();
+        eventFilter.Custom(logEvent => logEvent is Error && (string) logEvent.Message == "whatever").ExpectOne(() =>
+        {
+            Log.Error("whatever");
+        });
+    }
+
+    [Fact]
+    public void Custom_filter_should_match2()
+    {
+        var eventFilter = CreateTestingEventFilter();
+        eventFilter.Custom<Error>(logEvent => (string)logEvent.Message == "whatever").ExpectOne(() =>
+        {
+            Log.Error("whatever");
+        });
+    }
+    // ReSharper restore ConvertToLambdaExpression
+}
+
+public class CustomEventFilterTests : CustomEventFilterTestsBase
+{
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return EventFilter;
+    }
+}
+
+public class CustomEventFilterCustomFilterTests : CustomEventFilterTestsBase
+{
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return CreateEventFilter(Sys);
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
@@ -1,0 +1,70 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DeadLettersEventFilterTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests;
+
+public abstract class DeadLettersEventFilterTestsBase : EventFilterTestBase
+{
+    private IActorRef? _deadActor;
+
+    // ReSharper disable ConvertToLambdaExpression
+    protected DeadLettersEventFilterTestsBase() : base(Event.LogLevel.ErrorLevel)
+    {
+    }
+
+    protected override async Task BeforeTestStart()
+    {
+        await base.BeforeTestStart();
+        _deadActor = Sys.ActorOf(BlackHoleActor.Props, "dead-actor");
+        Watch(_deadActor);
+        Sys.Stop(_deadActor);
+        ExpectTerminated(_deadActor);
+    }
+
+    protected override void SendRawLogEventMessage(object message)
+    {
+        Sys.EventStream.Publish(new Error(null, "DeadLettersEventFilterTests", GetType(), message));
+    }
+
+    protected abstract EventFilterFactory CreateTestingEventFilter();
+
+    [Fact]
+    public void Should_be_able_to_filter_dead_letters()
+    {
+        var eventFilter = CreateTestingEventFilter();
+        eventFilter.DeadLetter().ExpectOne(() =>
+        {
+            _deadActor.Tell("whatever");
+        });
+    }
+
+
+    // ReSharper restore ConvertToLambdaExpression
+}
+
+public class DeadLettersEventFilterTests : DeadLettersEventFilterTestsBase
+{
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return EventFilter;
+    }
+}
+
+public class DeadLettersCustomEventFilterTests : DeadLettersEventFilterTestsBase
+{
+    protected override EventFilterFactory CreateTestingEventFilter()
+    {
+        return CreateEventFilter(Sys);
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -1,0 +1,85 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventFilterTestBase.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Event;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests
+{
+    public abstract class EventFilterTestBase : TestKit
+    {
+        private readonly LogLevel _logLevel;
+        
+        /// <summary>
+        /// Used to signal that the test was successful and that we should ensure no more messages were logged
+        /// </summary>
+        protected bool TestSuccessful;
+
+        protected EventFilterTestBase(LogLevel logLevel, ITestOutputHelper? output = null) : base(output: output)
+        {
+            _logLevel = logLevel;
+        }
+
+        protected abstract void SendRawLogEventMessage(object message);
+
+        protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+        {
+            builder.ConfigureLoggers(logger =>
+            {
+                logger.LogLevel = _logLevel;
+                logger.ClearLoggers();
+                logger.AddLogger<ForwardAllEventsTestEventListener>();
+            });
+        }
+
+        protected override async Task BeforeTestStart()
+        {
+            await base.BeforeTestStart();
+            
+            //We send a ForwardAllEventsTo containing message to the TestEventListenerToForwarder logger (configured as a logger above).
+            //It should respond with an "OK" message when it has received the message.
+            var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
+            // ReSharper disable once DoNotCallOverridableMethodsInConstructor
+            SendRawLogEventMessage(initLoggerMessage);
+            try
+            {
+                await ExpectMsgAsync("OK", TimeSpan.FromSeconds(10));
+            }
+            catch (Exception e)
+            {
+                throw new Exception(
+                    "Failed to receive an OK signal from ForwardAllEventsTestEventListener logger during test start " +
+                    $"inside EventFilterTestBase. Running loggers: [{string.Join(", ", Sys.Settings.Loggers)}]", e);
+            }
+            //From now on we know that all messages will be forwarded to TestActor
+        }
+
+        protected override async Task AfterAllAsync()
+        {
+            //After every test we make sure no uncatched messages have been logged
+            if(TestSuccessful)
+            {
+                EnsureNoMoreLoggedMessages();
+            }
+            await base.AfterAllAsync();
+        }
+
+        private void EnsureNoMoreLoggedMessages()
+        {
+            //We log a Finished message. When it arrives to TestActor we know no other message has been logged.
+            //If we receive something else it means another message was logged, and ExpectMsg will fail
+            const string message = "<<Finished>>";
+            SendRawLogEventMessage(message);
+            ExpectMsg<LogEvent>(err => (string) err.Message == message,hint: "message to be \"" + message + "\"");
+        }
+
+    }
+}
+

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/ExceptionEventFilterTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/ExceptionEventFilterTests.cs
@@ -1,0 +1,174 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ExceptionEventFilterTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Event;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests;
+
+public class ExceptionEventFilterTests : EventFilterTestBase
+{
+    public ExceptionEventFilterTests()
+        : base(Event.LogLevel.ErrorLevel)
+    {
+    }
+    
+    public class SomeException : Exception { }
+
+    protected override void SendRawLogEventMessage(object message)
+    {
+        Sys.EventStream.Publish(new Error(null, nameof(ExceptionEventFilterTests), GetType(), message));
+    }
+
+    [Fact]
+    public void SingleExceptionIsIntercepted()
+    {
+        EventFilter.Exception<SomeException>()
+            .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+        ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void CanInterceptMessagesWhenStartIsSpecified()
+    {
+        EventFilter.Exception<SomeException>(start: "what")
+            .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+        ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void DoNotInterceptMessagesWhenStartDoesNotMatch()
+    {
+        EventFilter.Exception<SomeException>(start: "this is clearly not in message");
+        Log.Error(new SomeException(), "whatever");
+        ExpectMsg<Error>(err => (string)err.Message == "whatever");
+    }
+
+    [Fact]
+    public void CanInterceptMessagesWhenMessageIsSpecified()
+    {
+        EventFilter.Exception<SomeException>(message: "whatever")
+            .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+        ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void DoNotInterceptMessagesWhenMessageDoesNotMatch()
+    {
+        EventFilter.Exception<SomeException>(message: "this is clearly not the message");
+        Log.Error(new SomeException(), "whatever");
+        ExpectMsg<Error>(err => (string)err.Message == "whatever");
+    }
+
+    [Fact]
+    public void CanInterceptMessagesWhenContainsIsSpecified()
+    {
+        EventFilter.Exception<SomeException>(contains: "ate")
+            .ExpectOne(() => Log.Error(new SomeException(), "whatever"));
+        ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void DoNotInterceptMessagesWhenContainsDoesNotMatch()
+    {
+        EventFilter.Exception<SomeException>(contains: "this is clearly not in the message");
+        Log.Error(new SomeException(), "whatever");
+        ExpectMsg<Error>(err => (string)err.Message == "whatever");
+    }
+
+
+    [Fact]
+    public void CanInterceptMessagesWhenSourceIsSpecified()
+    {
+        EventFilter.Exception<SomeException>(source: LogSource.Create(this, Sys).Source)
+            .ExpectOne(() =>
+            {
+                Log.Error(new SomeException(), "whatever");
+            });
+        ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void DoNotInterceptMessagesWhenSourceDoesNotMatch()
+    {
+        EventFilter.Exception<SomeException>(source: "this is clearly not the source");
+        Log.Error(new SomeException(), "whatever");
+        ExpectMsg<Error>(err => (string)err.Message == "whatever");
+    }
+
+
+    [Fact]
+    public void SpecifiedNumbersOfExceptionsCanBeIntercepted()
+    {
+        EventFilter.Exception<SomeException>()
+            .Expect(2, () =>
+            {
+                Log.Error(new SomeException(), "whatever");
+                Log.Error(new SomeException(), "whatever");
+            });
+        ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void ShouldFailIfMoreExceptionsThenSpecifiedAreLogged()
+    {
+        Invoking(() =>
+            EventFilter.Exception<SomeException>().Expect(2, () =>
+            {
+                Log.Error(new SomeException(), "whatever");
+                Log.Error(new SomeException(), "whatever");
+                Log.Error(new SomeException(), "whatever");
+            }))
+            .Should().Throw<FailException>().WithMessage("*1 message too many*");
+    }
+
+    [Fact]
+    public void ShouldReportCorrectMessageCount()
+    {
+        var toSend = "Eric Cartman";
+        var actor = ActorOf( ExceptionTestActor.Props() );
+
+        EventFilter
+            .Exception<InvalidOperationException>(source: actor.Path.ToString())
+            // expecting 2 because the same exception is logged in PostRestart
+            .Expect(2, () => actor.Tell( toSend ));
+    }
+
+    internal sealed class ExceptionTestActor : UntypedActor
+    {
+        private ILoggingAdapter Log { get; } = Context.GetLogger();
+
+        protected override void PostRestart(Exception reason)
+        {
+            Log.Error(reason, "[PostRestart]");
+            base.PostRestart(reason);
+        }
+
+        protected override void OnReceive( object message )
+        {
+            switch (message)
+            {
+                case string msg:
+                    throw new InvalidOperationException( "I'm sailing away. Set an open course" );
+
+                default:
+                    Unhandled( message );
+                    break;
+            }
+        }
+
+        public static Props Props()
+        {
+            return Actor.Props.Create( () => new ExceptionTestActor() );
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/ForwardAllEventsTestEventListener.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestEventListenerTests/ForwardAllEventsTestEventListener.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ForwardAllEventsTestEventListener.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+
+namespace Akka.Hosting.TestKit.Tests.TestEventListenerTests;
+
+public class ForwardAllEventsTestEventListener : TestEventListener
+{
+    private IActorRef? _forwarder;
+
+    protected override void Print(LogEvent m)
+    {           
+        if(m.Message is ForwardAllEventsTo to)
+        {
+            _forwarder = to.Forwarder;
+            _forwarder.Tell("OK");
+        }
+        else if(_forwarder != null)
+        {
+            _forwarder.Forward(m);
+        }
+        else
+        {
+            base.Print(m);
+        }
+    }
+
+    public class ForwardAllEventsTo
+    {
+        public ForwardAllEventsTo(IActorRef forwarder)
+        {
+            Forwarder = forwarder;
+        }
+
+        public IActorRef Forwarder { get; }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestFSMRefTests/TestFSMRefSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestFSMRefTests/TestFSMRefSpec.cs
@@ -1,0 +1,91 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestFSMRefSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestFSMRefTests;
+
+public class TestFSMRefSpec : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        
+    }
+    
+    [Fact]
+    public void A_TestFSMRef_must_allow_access_to_internal_state()
+    {
+        var fsm = ActorOfAsTestFSMRef<StateTestFsm, int, string>("test-fsm-ref-1");
+
+        fsm.StateName.Should().Be(1);
+        fsm.StateData.Should().Be("");
+
+        fsm.Tell("go");
+        fsm.StateName.Should().Be(2);
+        fsm.StateData.Should().Be("go");
+
+        fsm.SetState(1);
+        fsm.StateName.Should().Be(1);
+        fsm.StateData.Should().Be("go");
+
+        fsm.SetStateData("buh");
+        fsm.StateName.Should().Be(1);
+        fsm.StateData.Should().Be("buh");
+
+        fsm.SetStateTimeout(TimeSpan.FromMilliseconds(100));
+        Within(TimeSpan.FromMilliseconds(80), TimeSpan.FromMilliseconds(500), () =>
+            AwaitCondition(() => fsm is { StateName: 2, StateData: "timeout" })
+        );
+    }
+
+    [Fact]
+    public void A_TestFSMRef_must_allow_access_to_timers()
+    {
+        var fsm = ActorOfAsTestFSMRef<TimerTestFsm, int, object>("test-fsm-ref-2");
+        fsm.IsTimerActive("test").Should().Be(false);
+        fsm.SetTimer("test", 12, TimeSpan.FromMilliseconds(10), true);
+        fsm.IsTimerActive("test").Should().Be(true);
+        fsm.CancelTimer("test");
+        fsm.IsTimerActive("test").Should().Be(false);
+    }
+
+    private class StateTestFsm : FSM<int, string>
+    {
+        public StateTestFsm()
+        {
+            StartWith(1, "");
+            When(1, e =>
+            {
+                var fsmEvent = e.FsmEvent;
+                if(Equals(fsmEvent, "go"))
+                    return GoTo(2).Using("go");
+                if(fsmEvent is StateTimeout)
+                    return GoTo(2).Using("timeout");
+                return null;
+            });
+            When(2, e =>
+            {
+                var fsmEvent = e.FsmEvent;
+                if(Equals(fsmEvent, "back"))
+                    return GoTo(1).Using("back");
+                return null;
+            });
+        }
+    }
+    private class TimerTestFsm : FSM<int, object>
+    {
+        public TimerTestFsm()
+        {
+            StartWith(1, "");
+            When(1, e => Stay());
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/AwaitAssertTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/AwaitAssertTests.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AwaitAssertTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class AwaitAssertTests : TestKit
+{
+    protected override Config Config { get; } = "akka.test.timefactor=2";
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void AwaitAssert_must_not_throw_any_exception_when_assertion_is_valid()
+    {
+        AwaitAssert(() => Assert.Equal("foo", "foo"));
+    }
+
+    [Fact]
+    public void AwaitAssert_must_throw_exception_when_assertion_is_invalid()
+    {
+        Within(TimeSpan.FromMilliseconds(300), TimeSpan.FromSeconds(1), () =>
+        {
+            Assert.Throws<EqualException>(() =>
+                AwaitAssert(() => Assert.Equal("foo", "bar"), TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(300)));
+        });
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/DilatedTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/DilatedTests.cs
@@ -1,0 +1,83 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DilatedTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using Akka.Configuration;
+using Xunit;
+using Xunit.Sdk;
+using FluentAssertions;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class DilatedTests : TestKit
+{
+    private const int TimeFactor = 4;
+    private const int Timeout = 1000;
+    private const int ExpectedTimeout = Timeout * TimeFactor;
+    private const int Margin = 1000; // margin for GC
+    private const int DiffDelta = 100; 
+
+    protected override Config Config { get; } = $"akka.test.timefactor={TimeFactor}";
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void Dilates_correctly_using_timeFactor()
+    {
+        Assert.Equal(Dilated(TimeSpan.FromMilliseconds(Timeout)), TimeSpan.FromMilliseconds(ExpectedTimeout));
+    }
+
+    [Fact]
+    public void AwaitCondition_should_dilate_timeout()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Invoking(() => AwaitCondition(() => false, TimeSpan.FromMilliseconds(Timeout)))
+            .Should().Throw<FailException>();
+        stopwatch.Stop();
+        AssertDilated(stopwatch.ElapsedMilliseconds, $"Expected the timeout to be {ExpectedTimeout} but in fact it was {stopwatch.ElapsedMilliseconds}.");
+    }
+
+    [Fact]
+    public void ReceiveN_should_dilate_timeout()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Invoking(() => ReceiveN(42, TimeSpan.FromMilliseconds(Timeout)))
+            .Should().Throw<TrueException>();
+        stopwatch.Stop();
+        AssertDilated(stopwatch.ElapsedMilliseconds, $"Expected the timeout to be {ExpectedTimeout} but in fact it was {stopwatch.ElapsedMilliseconds}.");
+    }
+
+    [Fact]
+    public void ExpectMsgAllOf_should_dilate_timeout()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Invoking(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(Timeout), new[]{"1", "2"} ))
+            .Should().Throw<TrueException>();
+        stopwatch.Stop();
+        AssertDilated(stopwatch.ElapsedMilliseconds, $"Expected the timeout to be {ExpectedTimeout} but in fact it was {stopwatch.ElapsedMilliseconds}.");
+    }
+
+    [Fact]
+    public void FishForMessage_should_dilate_timeout()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        Invoking(() => FishForMessage(_=>false, TimeSpan.FromMilliseconds(Timeout)))
+            .Should().Throw<TrueException>();
+        stopwatch.Stop();
+        AssertDilated(stopwatch.ElapsedMilliseconds, $"Expected the timeout to be {ExpectedTimeout} but in fact it was {stopwatch.ElapsedMilliseconds}.");
+    }
+
+    private static void AssertDilated(double diff, string? message = null)
+    {
+        Assert.True(diff >= ExpectedTimeout - DiffDelta, message);
+        Assert.True(diff < ExpectedTimeout + Margin, message); // margin for GC
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/ExpectTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/ExpectTests.cs
@@ -1,0 +1,61 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ExpectTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Xunit;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class ExpectTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void ExpectMsgAllOf_should_receive_correct_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell("3");
+        TestActor.Tell("4");
+        ExpectMsgAllOf(new []{"3", "1", "4", "2"}).Should()
+            .BeEquivalentTo(new[] { "1", "2", "3", "4" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void ExpectMsgAllOf_should_fail_when_receiving_unexpected()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell("Totally unexpected");
+        TestActor.Tell("3");
+        Invoking(() => ExpectMsgAllOf(new []{"3", "1", "2"} ))
+            .Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void ExpectMsgAllOf_should_timeout_when_not_receiving_any_messages()
+    {
+        Invoking(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(100), new []{"3", "1", "2"} ))
+            .Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void ExpectMsgAllOf_should_timeout_if_to_few_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        Invoking(() => ExpectMsgAllOf(TimeSpan.FromMilliseconds(100), new[]{"3", "1", "2"} ))
+            .Should().Throw<Exception>();
+    }
+
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/IgnoreMessagesTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/IgnoreMessagesTests.cs
@@ -1,0 +1,66 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IgnoreMessagesTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class IgnoreMessagesTests : TestKit
+{
+    public class IgnoredMessage
+    {
+        public IgnoredMessage(string? ignoreMe = null)
+        {
+            IgnoreMe = ignoreMe;
+        }
+
+        public string? IgnoreMe { get; }
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void IgnoreMessages_should_ignore_messages()
+    {
+        IgnoreMessages(o => o is 1);
+        TestActor.Tell(1);
+        TestActor.Tell("1");
+        string.Equals((string)ReceiveOne(), "1").Should().BeTrue();
+        HasMessages.Should().BeFalse();
+    }
+        
+    [Fact]
+    public void IgnoreMessages_should_ignore_messages_T()
+    {
+        IgnoreMessages<IgnoredMessage>();
+            
+        TestActor.Tell("1");
+        TestActor.Tell(new IgnoredMessage(), TestActor);
+        TestActor.Tell("2");
+        ReceiveN(2).Should().BeEquivalentTo(new[] { "1", "2" }, opt => opt.WithStrictOrdering());
+        HasMessages.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IgnoreMessages_should_ignore_messages_T_with_Func()
+    {
+        IgnoreMessages<IgnoredMessage>(m => String.IsNullOrWhiteSpace(m.IgnoreMe));
+
+        var msg = new IgnoredMessage("not ignored!");
+
+        TestActor.Tell("1");
+        TestActor.Tell(msg, TestActor);
+        TestActor.Tell("2");
+        ReceiveN(3).Should().BeEquivalentTo(new object[] { "1", msg, "2" }, opt => opt.WithStrictOrdering());
+        HasMessages.Should().BeFalse();
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/ReceiveTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/ReceiveTests.cs
@@ -1,0 +1,282 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ReceiveTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class ReceiveTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void ReceiveN_should_receive_correct_number_of_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell("3");
+        TestActor.Tell("4");
+        ReceiveN(3).Should().BeEquivalentTo(new[] { "1", "2", "3" }, opt => opt.WithStrictOrdering());
+        ReceiveN(1).Should().BeEquivalentTo(new[] { "4" });
+    }
+
+    [Fact]
+    public void ReceiveN_should_timeout_if_no_messages()
+    {
+        Invoking(() => ReceiveN(3, TimeSpan.FromMilliseconds(10)))
+            .Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void ReceiveN_should_timeout_if_to_few_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        Invoking(() => ReceiveN(3, TimeSpan.FromMilliseconds(100)))
+            .Should().Throw<Exception>();
+    }
+
+
+    [Fact]
+    public void FishForMessage_should_return_matched_message()
+    {
+        TestActor.Tell(1);
+        TestActor.Tell(2);
+        TestActor.Tell(10);
+        TestActor.Tell(20);
+        FishForMessage<int>(i => i >= 10).Should().Be(10);
+    }
+
+    [Fact]
+    public void FishForMessage_should_timeout_if_no_messages()
+    {
+        Invoking(() => FishForMessage(_ => false, TimeSpan.FromMilliseconds(10)))
+            .Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void FishForMessage_should_timeout_if_to_few_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        Invoking(() => FishForMessage(_ => false, TimeSpan.FromMilliseconds(100)))
+            .Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public async Task FishForMessage_should_fill_the_all_messages_param_if_not_null()
+    {
+        await Task.Run(delegate
+        {
+            var probe = base.CreateTestProbe("probe");
+            probe.Tell("1");
+            probe.Tell(2);
+            probe.Tell("3");
+            probe.Tell(4);
+            var allMessages = new ArrayList();
+            probe.FishForMessage<string>(isMessage: s => s == "3", allMessages: allMessages);
+            allMessages.Should().BeEquivalentTo(new ArrayList { "1", 2 });
+        });
+    }
+
+    [Fact]
+    public async Task FishForMessage_should_clear_the_all_messages_param_if_not_null_before_filling_it()
+    {
+        await Task.Run(delegate
+        {
+            var probe = base.CreateTestProbe("probe");
+            probe.Tell("1");
+            probe.Tell(2);
+            probe.Tell("3");
+            probe.Tell(4);
+            var allMessages = new ArrayList() { "pre filled data" };
+            probe.FishForMessage<string>(isMessage: x => x == "3", allMessages: allMessages);
+            allMessages.Should().BeEquivalentTo(new ArrayList { "1", 2 });
+        });
+    }
+
+    [Fact]
+    public async Task FishUntilMessageAsync_should_succeed_with_good_input()
+    {
+        var probe = CreateTestProbe("probe");
+        probe.Ref.Tell(1d, TestActor);
+        await probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10));
+    }
+
+
+    [Fact]
+    public async Task FishUntilMessageAsync_should_fail_with_bad_input()
+    {
+        var probe = CreateTestProbe("probe");
+        probe.Ref.Tell(3, TestActor);
+        Func<Task> func = () => probe.FishUntilMessageAsync<int>(max: TimeSpan.FromMilliseconds(10));
+        await func.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task WaitForRadioSilenceAsync_should_succeed_immediately_with_null_good_input()
+    {
+        var probe = CreateTestProbe("probe");
+        var messages = await probe.WaitForRadioSilenceAsync(max: TimeSpan.FromMilliseconds(0));
+        messages.Should().BeEquivalentTo(new ArrayList());
+    }
+
+    [Fact]
+    public async Task WaitForRadioSilenceAsync_should_succeed_immediately_with_good_pre_input()
+    {
+        var probe = CreateTestProbe("probe");
+        probe.Ref.Tell(1, TestActor);
+        var messages = await probe.WaitForRadioSilenceAsync(max: TimeSpan.FromMilliseconds(0));
+        messages.Should().BeEquivalentTo(new ArrayList { 1 });
+    }
+
+    [Fact]
+    public async Task WaitForRadioSilenceAsync_should_succeed_later_with_good_post_input()
+    {
+        var probe = CreateTestProbe("probe");
+        var task = probe.WaitForRadioSilenceAsync();
+        probe.Ref.Tell(1, TestActor);
+        var messages = await task;
+        messages.Should().BeEquivalentTo(new ArrayList { 1 });
+    }
+
+    [Fact]
+    public async Task WaitForRadioSilenceAsync_should_reset_timer_twice_only()
+    {
+        var probe = CreateTestProbe("probe");
+        var max = TimeSpan.FromMilliseconds(3000);
+        var halfMax = TimeSpan.FromMilliseconds(max.TotalMilliseconds / 2);
+        var doubleMax = TimeSpan.FromMilliseconds(max.TotalMilliseconds * 2);
+        var task = probe.WaitForRadioSilenceAsync(max: max, maxMessages: 2);
+        await Task.Delay(halfMax);
+        probe.Ref.Tell(1, TestActor);
+        await Task.Delay(halfMax);
+        probe.Ref.Tell(2, TestActor);
+        await Task.Delay(doubleMax);
+        probe.Ref.Tell(3, TestActor);
+        var messages = await task;
+        messages.Should().BeEquivalentTo(new ArrayList { 1, 2 });
+    }
+
+    [Fact]
+    public async Task WaitForRadioSilenceAsync_should_fail_immediately_with_bad_input()
+    {
+        var probe = CreateTestProbe("probe");
+        probe.Ref.Tell(3, TestActor);
+        try
+        {
+            await probe.WaitForRadioSilenceAsync(max: TimeSpan.FromMilliseconds(0), maxMessages: 0);
+            Assert.Fail("we should never get here");
+        }
+        catch (XunitException) { }
+    }
+
+    [Fact]
+    public void ReceiveWhile_Filter_should_on_a_timeout_return_no_messages()
+    {
+        ReceiveWhile<object>(_ => _, TimeSpan.FromMilliseconds(10)).Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void ReceiveWhile_Filter_should_break_on_function_returning_null_and_return_correct_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell(2);
+        TestActor.Tell("3");
+        TestActor.Tell(99999.0);
+        TestActor.Tell(4);
+        ReceiveWhile<string>(_ => (_ is double ? null : _.ToString())!)
+            .Should().BeEquivalentTo(new[] { "1", "2", "3" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void ReceiveWhile_Filter_should_not_consume_last_message_that_didnt_match()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell(4711);
+        ReceiveWhile<object>(_ => (_ is string ? _ : null)!);
+        ExpectMsg(4711);
+    }
+
+    [Fact]
+    public void ReceiveWhile_Predicate_should_on_a_timeout_return_no_messages()
+    {
+        ReceiveWhile<object>(_ => false, TimeSpan.FromMilliseconds(10)).Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void ReceiveWhile_Predicate_should_break_when_predicate_returns_false_and_return_correct_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell("3");
+        TestActor.Tell("-----------");
+        TestActor.Tell("4");
+        ReceiveWhile<string>(s => s.Length == 1)
+            .Should().BeEquivalentTo(new[] { "1", "2", "3" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void
+        ReceiveWhile_Predicate_should_break_when_type_is_wrong_and_we_dont_ignore_those_and_return_correct_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell("3");
+        TestActor.Tell(4);
+        TestActor.Tell("5");
+        ReceiveWhile<string>(s => s.Length == 1, shouldIgnoreOtherMessageTypes: false)
+            .Should().BeEquivalentTo(new[] { "1", "2", "3" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void
+        ReceiveWhile_Predicate_should_continue_when_type_is_other_but_we_ignore_other_types_and_return_correct_messages()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell("3");
+        TestActor.Tell(4);
+        TestActor.Tell("5");
+        ReceiveWhile<string>(s => s.Length == 1, shouldIgnoreOtherMessageTypes: true)
+            .Should().BeEquivalentTo(new[] { "1", "2", "3", "5" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void ReceiveWhile_Predicate_should_not_consume_last_message_that_didnt_match()
+    {
+        TestActor.Tell("1");
+        TestActor.Tell("2");
+        TestActor.Tell(4711);
+        TestActor.Tell("3");
+        TestActor.Tell("4");
+        TestActor.Tell("5");
+        TestActor.Tell(6);
+        TestActor.Tell("7");
+        TestActor.Tell("8");
+
+        var received = ReceiveWhile<object>(_ => _ is string);
+        received.Should().BeEquivalentTo(new[] { "1", "2" }, opt => opt.WithStrictOrdering());
+        
+        ExpectMsg(4711);
+
+        received = ReceiveWhile<object>(_ => _ is string);
+        received.Should().BeEquivalentTo(new[] { "3", "4", "5" }, opt => opt.WithStrictOrdering());
+
+        ExpectMsg(6);
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/RemainingTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/RemainingTests.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RemainingTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class RemainingTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        
+    }
+
+    [Fact]
+    public void Throw_if_remaining_is_called_outside_Within()
+    {
+        Assert.Throws<InvalidOperationException>(() => Remaining);
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/WithinTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKitBaseTests/WithinTests.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="WithinTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests.TestKitBaseTests;
+
+public class WithinTests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        
+    }
+
+    [Fact]
+    public void Within_should_increase_max_timeout_by_the_provided_epsilon_value()
+    {
+        Within(TimeSpan.FromSeconds(1), () => ExpectNoMsg(), TimeSpan.FromMilliseconds(50));
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKit_Config_Tests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestKit_Config_Tests.cs
@@ -1,0 +1,37 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestKit_Config_Tests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+// ReSharper disable once InconsistentNaming
+public class TestKit_Config_Tests : TestKit
+{
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+    }
+
+    [Fact]
+    public void DefaultValues_should_be_correct()
+    {
+        TestKitSettings.DefaultTimeout.Should().Be(TimeSpan.FromSeconds(5));
+        TestKitSettings.SingleExpectDefault.Should().Be(TimeSpan.FromSeconds(3));
+        TestKitSettings.TestEventFilterLeeway.Should().Be(TimeSpan.FromSeconds(3));
+        TestKitSettings.TestTimeFactor.Should().Be(1);
+        var callingThreadDispatcherTypeName = typeof(CallingThreadDispatcherConfigurator).FullName + ", " + typeof(CallingThreadDispatcher).GetTypeInfo().Assembly.GetName().Name;
+        Assert.False(Sys.Settings.Config.IsEmpty);
+        Sys.Settings.Config.GetString("akka.test.calling-thread-dispatcher.type", null).Should().Be(callingThreadDispatcherTypeName);
+        Sys.Settings.Config.GetString("akka.test.test-actor.dispatcher.type", null).Should().Be(callingThreadDispatcherTypeName);
+        CallingThreadDispatcher.Id.Should().Be("akka.test.calling-thread-dispatcher");
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestPersistenceTestKistTests/TestJournalSpec.cs
@@ -1,0 +1,156 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+using Akka.Hosting.TestKit.Tests.TestActorRefTests;
+using Akka.Persistence;
+using Akka.Persistence.TestKit;
+using Akka.TestKit;
+using FluentAssertions;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests;
+
+public class TestJournalSpec : PersistenceTestKit
+{
+    private TestProbe _probe = null!; 
+
+    public TestJournalSpec(ITestOutputHelper output) : base(nameof(TestJournalSpec), output)
+    {
+    }
+
+    // Expect should be passing by default, need to make them less sensitive to timing
+    protected override Config? Config => "akka.test.single-expect-default = 30s";
+
+    protected override Task BeforeTestStart()
+    {
+        _probe = CreateTestProbe();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public void must_have_journal_and_snapshot()
+    {
+        Journal.Should().NotBeNull();
+        JournalActorRef.Should().NotBeNull();
+        Snapshots.Should().NotBeNull();
+        SnapshotsActorRef.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task must_return_ack_after_new_write_interceptor_is_set()
+    {
+        JournalActorRef.Tell(new TestJournal.UseWriteInterceptor(null), TestActor);
+
+        await ExpectMsgAsync<TestJournal.Ack>(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task works_as_memory_journal_by_default()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnWrite.Pass();
+        actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+        await _probe.ExpectMsgAsync("ack");
+    }
+
+    [Fact]
+    public async Task must_recover_restarted_actor()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnRecovery.Pass();
+        actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+        actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+
+        await actor.GracefulStop(TimeSpan.FromSeconds(1));
+        await ExpectTerminatedAsync(actor);
+
+        ActorOf(() => new PersistActor(_probe));
+        await _probe.ExpectMsgAsync("1");
+        await _probe.ExpectMsgAsync("2");
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+    }
+
+    [Fact]
+    public async Task when_fail_on_write_is_set_all_writes_to_journal_will_fail()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnWrite.Fail();
+        actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+        await _probe.ExpectMsgAsync("failure");
+        await ExpectTerminatedAsync(actor);
+    }
+
+    [Fact]
+    public async Task must_recover_failed_actor()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnRecovery.Pass();
+        actor.Tell(new PersistActor.WriteMessage("1"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+        actor.Tell(new PersistActor.WriteMessage("2"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+
+        await Journal.OnWrite.Fail();
+        actor.Tell(new PersistActor.WriteMessage("3"), TestActor);
+
+        await _probe.ExpectMsgAsync("failure");
+        await ExpectTerminatedAsync(actor);
+
+        ActorOf(() => new PersistActor(_probe));
+        await _probe.ExpectMsgAsync("1");
+        await _probe.ExpectMsgAsync("2");
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+    }
+
+    [Fact]
+    public async Task when_reject_on_write_is_set_all_writes_to_journal_will_be_rejected()
+    {
+        var actor = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor);
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+        await Journal.OnWrite.Reject();
+        actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+        await _probe.ExpectMsgAsync("rejected");
+    }
+
+    [Fact]
+    public async Task journal_must_reset_state_to_pass()
+    {
+        await WithJournalWrite(write => write.Fail(), async () =>
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            await WatchAsync(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+            await _probe.ExpectMsgAsync("failure");
+            await ExpectTerminatedAsync(actor);
+        });
+
+        var actor2 = ActorOf(() => new PersistActor(_probe));
+        await WatchAsync(actor2);
+
+        await _probe.ExpectMsgAsync<RecoveryCompleted>();
+        actor2.Tell(new PersistActor.WriteMessage("write"), TestActor);
+        await _probe.ExpectMsgAsync("ack");
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestPersistenceTestKistTests/TestSnapshotStoreSpec.cs
@@ -1,0 +1,110 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestSnapshotStoreSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Tests.TestPersistenceTestKistTests;
+
+using Actor;
+using Akka.Persistence;
+using Akka.Persistence.TestKit;
+using Akka.Persistence.TestKit.Tests;
+using Akka.TestKit;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+public sealed class TestSnapshotStoreSpec : PersistenceTestKit
+{
+    public TestSnapshotStoreSpec(ITestOutputHelper output) : base(nameof(TestSnapshotStoreSpec), output: output)
+    {
+    }
+
+    protected override Task BeforeTestStart()
+    {
+        _probe = CreateTestProbe();
+        return Task.CompletedTask;
+    }
+
+    private TestProbe _probe = null!;
+
+    [Fact]
+    public async Task send_ack_after_load_interceptor_is_set()
+    {
+        SnapshotsActorRef.Tell(new TestSnapshotStore.UseLoadInterceptor(null), TestActor);
+        await ExpectMsgAsync<TestSnapshotStore.Ack>();
+    }
+
+    [Fact]
+    public async Task send_ack_after_save_interceptor_is_set()
+    {
+        SnapshotsActorRef.Tell(new TestSnapshotStore.UseSaveInterceptor(null), TestActor);
+        await ExpectMsgAsync<TestSnapshotStore.Ack>();
+    }
+
+    [Fact]
+    public async Task send_ack_after_delete_interceptor_is_set()
+    {
+        SnapshotsActorRef.Tell(new TestSnapshotStore.UseDeleteInterceptor(null), TestActor);
+        await ExpectMsgAsync<TestSnapshotStore.Ack>();
+    }
+
+    [Fact]
+    public async Task after_load_behavior_was_executed_store_is_back_to_pass_mode()
+    {
+        // create snapshot
+        var actor = ActorOf(() => new SnapshotActor(_probe));
+        actor.Tell("save");
+        await _probe.ExpectMsgAsync<SaveSnapshotSuccess>();
+        await actor.GracefulStop(TimeSpan.FromSeconds(3));
+
+        await WithSnapshotLoad(load => load.Fail(), async () =>
+        {
+            ActorOf(() => new SnapshotActor(_probe));
+            await _probe.ExpectMsgAsync<SnapshotActor.RecoveryFailure>();
+        });
+
+        ActorOf(() => new SnapshotActor(_probe));
+        await _probe.ExpectMsgAsync<SnapshotOffer>();
+    }
+
+    [Fact]
+    public async Task after_save_behavior_was_executed_store_is_back_to_pass_mode()
+    {
+        // create snapshot
+        var actor = ActorOf(() => new SnapshotActor(_probe));
+
+        await WithSnapshotSave(save => save.Fail(), async () =>
+        {
+            actor.Tell("save");
+            await _probe.ExpectMsgAsync<SaveSnapshotFailure>();
+        });
+
+        actor.Tell("save");
+        await _probe.ExpectMsgAsync<SaveSnapshotSuccess>();
+    }
+
+    [Fact]
+    public async Task after_delete_behavior_was_executed_store_is_back_to_pass_mode()
+    {
+        // create snapshot
+        var actor = ActorOf(() => new SnapshotActor(_probe));
+        actor.Tell("save");
+
+        var success = await _probe.ExpectMsgAsync<SaveSnapshotSuccess>();
+        var nr = success.Metadata.SequenceNr;
+
+        await WithSnapshotDelete(del => del.Fail(), async () =>
+        {
+            actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
+            await _probe.ExpectMsgAsync<DeleteSnapshotFailure>();
+        });
+
+        actor.Tell(new SnapshotActor.DeleteOne(nr), TestActor);
+        await _probe.ExpectMsgAsync<DeleteSnapshotSuccess>();
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/TestSchedulerTests.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/TestSchedulerTests.cs
@@ -1,0 +1,207 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestSchedulerTests.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.TestKit.Configs;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Hosting.TestKit.Tests;
+
+public class TestSchedulerTests : TestKit
+{
+    private IActorRef? _testReceiveActor;
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+       
+    }
+
+    protected override async Task BeforeTestStart()
+    {
+        await base.BeforeTestStart();
+        _testReceiveActor = Sys.ActorOf(Props.Create(() => new TestReceiveActor())
+            .WithDispatcher(CallingThreadDispatcher.Id));
+    }
+
+    protected override Config Config { get; } = TestConfigs.TestSchedulerConfig; 
+
+    [Fact]
+    public async Task Delivers_message_when_scheduled_time_reached()
+    {
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(1)));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        Scheduler.Advance(TimeSpan.FromSeconds(1));
+        await ExpectMsgAsync<ScheduleOnceMessage>();
+    }
+
+    [Fact]
+    public async Task Does_not_deliver_message_prematurely()
+    {
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(1)));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        Scheduler.Advance(TimeSpan.FromMilliseconds(999));
+        await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(20));
+    }
+
+    [Fact]
+    public async Task Delivers_messages_scheduled_for_same_time_in_order_they_were_added()
+    {
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(1), 1));
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(1), 2));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        Scheduler.Advance(TimeSpan.FromSeconds(1));
+        var firstId = (await ExpectMsgAsync<ScheduleOnceMessage>()).Id;
+        var secondId = (await ExpectMsgAsync<ScheduleOnceMessage>()).Id;
+        Assert.Equal(1, firstId);
+        Assert.Equal(2, secondId);
+    }
+
+    [Fact]
+    public async Task Keeps_delivering_rescheduled_message()
+    {
+        _testReceiveActor.Tell(new RescheduleMessage(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        for (int i = 0; i < 500; i ++)
+        {
+            Scheduler.Advance(TimeSpan.FromSeconds(5));
+            await ExpectMsgAsync<RescheduleMessage>();
+        }
+    }
+
+    [Fact]
+    public async Task Uses_initial_delay_to_schedule_first_rescheduled_message()
+    {
+        _testReceiveActor.Tell(new RescheduleMessage(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5)));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        Scheduler.Advance(TimeSpan.FromSeconds(1));
+        await ExpectMsgAsync<RescheduleMessage>();
+    }
+
+    [Fact]
+    public async Task Doesnt_reschedule_cancelled()
+    {
+        _testReceiveActor.Tell(new CancelableMessage(TimeSpan.FromSeconds(1)));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        Scheduler.Advance(TimeSpan.FromSeconds(1));
+        await ExpectMsgAsync<CancelableMessage>();
+        _testReceiveActor.Tell(new CancelMessage());
+        Scheduler.Advance(TimeSpan.FromSeconds(1));
+        await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(20));
+    }
+
+
+    [Fact]
+    public async Task Advance_to_takes_us_to_correct_time()
+    {
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(1), 1));
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(2), 2));
+        _testReceiveActor.Tell(new ScheduleOnceMessage(TimeSpan.FromSeconds(3), 3));
+        (await _testReceiveActor.Ask<ActorIdentity>(new Identify(null), RemainingOrDefault).WaitAsync(RemainingOrDefault))
+            .Should().BeOfType<ActorIdentity>(); // verify that the ActorCell has started
+
+        Scheduler.AdvanceTo(Scheduler.Now.AddSeconds(2));
+        var firstId = (await ExpectMsgAsync<ScheduleOnceMessage>()).Id;
+        var secondId = (await ExpectMsgAsync<ScheduleOnceMessage>()).Id;
+        await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(20));
+        Assert.Equal(1, firstId);
+        Assert.Equal(2, secondId);
+    }
+
+    private class TestReceiveActor : ReceiveActor
+    {
+        private Cancelable? _cancelable;
+
+        public TestReceiveActor()
+        {
+            Receive<ScheduleOnceMessage>(x =>
+            {
+                Context.System.Scheduler.ScheduleTellOnce(x.ScheduleOffset, Sender, x, Self);
+            });
+
+            Receive<RescheduleMessage>(x =>
+            {
+                Context.System.Scheduler.ScheduleTellRepeatedly(x.InitialOffset, x.ScheduleOffset, Sender, x, Self);
+            });
+
+            Receive<CancelableMessage>(x =>
+            {
+                _cancelable = new Cancelable(Context.System.Scheduler);
+                Context.System.Scheduler.ScheduleTellRepeatedly(x.ScheduleOffset, x.ScheduleOffset, Sender, x, Self, _cancelable);
+            });
+
+            Receive<CancelMessage>(_ =>
+            {
+                if (_cancelable is null)
+                    throw new NullReferenceException("_cancelable is null, actor has not received any CancelableMessage message");
+                
+                _cancelable.Cancel();
+            });
+
+        }
+    }
+
+    private class CancelableMessage
+    {
+        public TimeSpan ScheduleOffset { get; }
+        public int Id { get; }
+
+        public CancelableMessage(TimeSpan scheduleOffset, int id = 1)
+        {
+            ScheduleOffset = scheduleOffset;
+            Id = id;
+        }
+    }
+
+    private class CancelMessage { }
+
+    private class ScheduleOnceMessage
+    {
+        public TimeSpan ScheduleOffset { get; }
+        public int Id { get; }
+
+        public ScheduleOnceMessage(TimeSpan scheduleOffset, int id = 1)
+        {
+            ScheduleOffset = scheduleOffset;
+            Id = id;
+        }
+    }
+
+    private class RescheduleMessage
+    {
+        public TimeSpan InitialOffset { get; }
+        public TimeSpan ScheduleOffset { get; }
+        public int Id { get; }
+
+        public RescheduleMessage(TimeSpan initialOffset, TimeSpan scheduleOffset, int id = 1)
+        {
+            InitialOffset = initialOffset;
+            ScheduleOffset = scheduleOffset;
+            Id = id;
+        }
+    }
+
+
+    private TestScheduler Scheduler => (TestScheduler)Sys.Scheduler;
+}

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/xunit.runner.json
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
+  "longRunningTestSeconds": 60,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}

--- a/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.Xunit2.csproj
+++ b/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.Xunit2.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>TestKit for writing tests for Akka.NET using Akka.Hosting and xUnit.</Description>
+        <TargetFrameworks>$(LibraryFramework);$(NetLibraryFramework)</TargetFrameworks>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>true</IsPackable>
+        <IsTestProject>false</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="xunit" Version="$(XunitVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+        <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Akka.Hosting\Akka.Hosting.csproj" />
+      <ProjectReference Include="..\Akka.Persistence.Hosting\Akka.Persistence.Hosting.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.csproj.DotSettings
+++ b/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=wrapper/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Akka.Hosting.TestKit.Xunit2/Internals/TestKitLoggerFactoryLogger.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2/Internals/TestKitLoggerFactoryLogger.cs
@@ -1,0 +1,32 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="LoggerFactoryLogger.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using Akka.Hosting.Logging;
+
+namespace Akka.Hosting.TestKit.Internals
+{
+    public class TestKitLoggerFactoryLogger: LoggerFactoryLogger
+    {
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            { 
+                case InitializeLogger init:
+                    InternalLogger.Info($"{nameof(TestKitLoggerFactoryLogger)} started");
+                    ((EventStream)init.LoggingBus).Subscribe<LogEvent>(Self);
+                    // Only reply if there's an actual sender waiting (not NoSender)
+                    if (!Sender.Equals(ActorRefs.NoSender))
+                        Sender.Tell(new LoggerInitialized());
+                    return true;
+                
+                default:
+                    return base.Receive(message);
+            }
+        }
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2/Internals/XUnitLogger.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2/Internals/XUnitLogger.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Internals
+{
+    public class XUnitLogger: ILogger
+    {
+        private const string NullFormatted = "[null]";
+
+        private readonly string _category;
+        private readonly ITestOutputHelper _helper;
+        private readonly LogLevel _logLevel;
+
+        public XUnitLogger(string category, ITestOutputHelper helper, LogLevel logLevel)
+        {
+            _category = category;
+            _helper = helper;
+            _logLevel = logLevel;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            if (!TryFormatMessage(state, exception, formatter, out var formattedMessage))
+                return;
+            
+            WriteLogEntry(logLevel, eventId, formattedMessage, exception);
+        }
+
+        private void WriteLogEntry(LogLevel logLevel, EventId eventId, string? message, Exception? exception)
+        {
+            var level = logLevel switch
+            {
+                LogLevel.Critical => "CRT",
+                LogLevel.Debug => "DBG",
+                LogLevel.Error => "ERR",
+                LogLevel.Information => "INF",
+                LogLevel.Warning => "WRN",
+                LogLevel.Trace => "DBG",
+                _ => "???"
+            };
+            
+            var msg = $"{DateTime.Now}:{level}:{_category}:{eventId} {message}";
+            if (exception != null)
+                msg += $"\n{exception.GetType()} {exception.Message}\n{exception.StackTrace}";
+
+            try
+            {
+                
+                _helper.WriteLine(msg);
+            }
+            catch
+            {
+                // no active xUnit test available
+                Console.WriteLine("No active xUnit test available, but logging was attempted. Message: " + msg);
+            }
+        }
+        
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel switch
+            {
+                LogLevel.None => false,
+                _ => logLevel >= _logLevel
+            };
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+        
+        private static bool TryFormatMessage<TState>(
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter,
+            out string? result)
+        {
+            formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
+            
+            var formattedMessage = formatter(state, exception);
+            if (formattedMessage == NullFormatted)
+            {
+                result = null;
+                return false;
+            }
+            
+            result = formattedMessage;
+            return true;
+        }
+
+        private class NullScope : IDisposable
+        {
+            private NullScope() { }
+            public static NullScope Instance { get; } = new NullScope();
+            public void Dispose() { }
+        }
+    }    
+}
+

--- a/src/Akka.Hosting.TestKit.Xunit2/Internals/XUnitLoggerProvider.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2/Internals/XUnitLoggerProvider.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit.Internals
+{
+    public class XUnitLoggerProvider : ILoggerProvider
+    {
+        private readonly ITestOutputHelper _helper;
+        private readonly LogLevel _logLevel;
+
+        public XUnitLoggerProvider(ITestOutputHelper helper, LogLevel logLevel)
+        {
+            _helper = helper;
+            _logLevel = logLevel;
+        }
+
+        public void Dispose()
+        {
+            // no-op
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new XUnitLogger(categoryName, _helper, _logLevel);
+        }
+    }    
+}
+

--- a/src/Akka.Hosting.TestKit.Xunit2/PersistenceTestKit.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2/PersistenceTestKit.cs
@@ -1,0 +1,279 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HostingSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.TestKit;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Akka.Hosting.TestKit;
+
+public abstract class PersistenceTestKit : TestKit
+{
+    public static readonly Config DefaultConfiguration = ConfigurationFactory.FromResource<TestJournal>("Akka.Persistence.TestKit.config.conf");
+        
+    /// <summary>
+    /// Create a new instance of the <see cref="PersistenceTestKit"/> class.
+    /// A new system with the specified configuration will be created.
+    /// </summary>
+    public PersistenceTestKit(string? actorSystemName = null, ITestOutputHelper? output = null, TimeSpan? startupTimeout = null, LogLevel logLevel = LogLevel.Information)
+        : base(actorSystemName, output, startupTimeout, logLevel)
+    {
+    }
+
+    /// <summary>
+    /// Actor reference to persistence Journal used by current actor system.
+    /// </summary>
+    public IActorRef JournalActorRef { get; private set; } = null!;
+
+    /// <summary>
+    /// Actor reference to persistence Snapshot Store used by current actor system.
+    /// </summary>
+    public IActorRef SnapshotsActorRef { get; private set; } = null!;
+
+    /// <summary>
+    /// Current journal IActorRef wrapped inside a TestJournal
+    /// </summary>
+    public ITestJournal Journal { get; private set; } = null!;
+
+    /// <summary>
+    /// Current snapshot store IActorRef wrapped inside a TestSnapshotStore
+    /// </summary>
+    public ITestSnapshotStore Snapshots { get; private set; } = null!;
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Journal.OnRecovery);
+            await execution();
+        }
+        finally
+        {
+            await Journal.OnRecovery.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Journal.OnWrite);
+            await execution();
+        }
+        finally
+        {
+            await Journal.OnWrite.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Recovery operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Recovery behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithJournalRecovery(Func<JournalRecoveryBehavior, Task> behaviorSelector, Action execution)
+        => WithJournalRecovery(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(new object());
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Journal Behavior applied to Write operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Write behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Journal behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithJournalWrite(Func<JournalWriteBehavior, Task> behaviorSelector, Action execution)
+        => WithJournalWrite(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(new object());
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnSave);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnSave.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnLoad);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnLoad.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public async Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Func<Task> execution)
+    {
+        if (behaviorSelector == null) throw new ArgumentNullException(nameof(behaviorSelector));
+        if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+        try
+        {
+            await behaviorSelector(Snapshots.OnDelete);
+            await execution();
+        }
+        finally
+        {
+            await Snapshots.OnDelete.Pass();
+        }
+    }
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Save operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Save behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotSave(Func<SnapshotStoreSaveBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotSave(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Load operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Load behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotLoad(Func<SnapshotStoreLoadBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotLoad(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    /// <summary>
+    ///     Execute <paramref name="execution"/> delegate with Snapshot Store Behavior applied to Delete operation.
+    /// </summary>
+    /// <remarks>
+    ///     After <paramref name="execution"/> will be executed, Delete behavior will be reverted back to normal.
+    /// </remarks>
+    /// <param name="behaviorSelector">Delegate which will select Snapshot Store behavior.</param>
+    /// <param name="execution">Async delegate which will be executed with applied Journal behavior.</param>
+    /// <returns><see cref="Task"/> which must be awaited.</returns>
+    public Task WithSnapshotDelete(Func<SnapshotStoreDeleteBehavior, Task> behaviorSelector, Action execution)
+        => WithSnapshotDelete(behaviorSelector, () =>
+        {
+            if (execution == null) throw new ArgumentNullException(nameof(execution));
+
+            execution();
+            return Task.FromResult(true);
+        });
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.AddHocon(DefaultConfiguration, HoconAddMode.Append);
+
+        builder.AddStartup((system, registry) =>
+        {
+            var persistenceExtension = Persistence.Persistence.Instance.Apply(system);
+            
+            JournalActorRef = persistenceExtension.JournalFor(null);
+            Journal = TestJournal.FromRef(JournalActorRef);
+            SnapshotsActorRef = persistenceExtension.SnapshotStoreFor(null);
+            Snapshots = TestSnapshotStore.FromRef(SnapshotsActorRef);
+        });
+    }
+}

--- a/src/Akka.Hosting.TestKit.Xunit2/Properties/FriendsOf.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2/Properties/FriendsOf.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Akka.Hosting.TestKit.Xunit2.Tests")]

--- a/src/Akka.Hosting.TestKit.Xunit2/TestKit.cs
+++ b/src/Akka.Hosting.TestKit.Xunit2/TestKit.cs
@@ -1,0 +1,311 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="HostingSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Actor.Setup;
+using Akka.Annotations;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Hosting.Logging;
+using Akka.Hosting.TestKit.Internals;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Akka.TestKit.Xunit2.Internals;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Akka.Hosting.TestKit
+{
+    public abstract class TestKit: TestKitBase, IAsyncLifetime
+    {
+        /// <summary>
+        /// Commonly used assertions used throughout the testkit.
+        /// </summary>
+        protected static XunitAssertions Assertions { get; } = new XunitAssertions();
+
+        private IHost? _host;
+        public IHost Host
+        {
+            get
+            {
+                if(_host is null)
+                    throw new XunitException("Test has not been initialized yet");
+                    
+                // Ensure implicit sender is set on current thread when accessing Host
+                EnsureImplicitSender();
+                return _host;
+            }
+        }
+
+        public ActorRegistry ActorRegistry => Host.Services.GetRequiredService<ActorRegistry>();
+        
+        /// <summary>
+        /// Ensures the implicit sender is set on the current thread.
+        /// Called automatically when accessing Host or Sys.
+        /// </summary>
+        private void EnsureImplicitSender()
+        {
+            if (this is not INoImplicitSender && TestActor != null)
+            {
+                InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+            }
+        }
+        
+        public TimeSpan StartupTimeout { get; }
+        public string ActorSystemName { get; }
+        public ITestOutputHelper? Output { get; }
+        public LogLevel LogLevel { get; }
+
+        private readonly TaskCompletionSource<Done> _initialized = new TaskCompletionSource<Done>();
+
+        protected TestKit(string? actorSystemName = null, ITestOutputHelper? output = null, TimeSpan? startupTimeout = null, LogLevel logLevel = LogLevel.Information)
+        : base(Assertions)
+        {
+            ActorSystemName = actorSystemName ?? "test";
+            Output = output;
+            LogLevel = logLevel;
+            StartupTimeout = startupTimeout ?? TimeSpan.FromSeconds(30);
+        }
+        
+        protected virtual void ConfigureHostConfiguration(IConfigurationBuilder builder)
+        { }
+        
+        protected virtual void ConfigureAppConfiguration(HostBuilderContext context, IConfigurationBuilder builder)
+        { }
+
+        protected virtual void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        { }
+        
+        protected virtual void ConfigureHostBuilder(IHostBuilder builder)
+        { }
+        
+        private void InternalConfigureServices(HostBuilderContext context, IServiceCollection services)
+        {
+            ConfigureServices(context, services);
+            
+            services.AddAkka(ActorSystemName, (builder, provider) =>
+            {
+                builder.AddHocon(DefaultConfig, HoconAddMode.Prepend);
+                if (Config is { })
+                    builder.AddHocon(Config, HoconAddMode.Prepend);
+
+                builder.ConfigureLoggers(logger =>
+                {
+                    logger.LogLevel = ToAkkaLogLevel(LogLevel);
+                    logger.ClearLoggers();
+                    logger.AddLogger<TestEventListener>();
+                });
+
+                if (Output is { })
+                {
+                    builder.StartActors(async (system, registry) =>
+                    {
+                        await LoggerHook(system, registry);
+                    });
+                }
+                
+                // Register TestProbe using StartActors (not AddStartup) so it runs BEFORE user's WithActors
+                // This ensures TestProbe is available for any actors that depend on IRequiredActor<TestProbe>
+                builder.StartActors((actorSystem, actorRegistry) =>
+                {
+                    // Initialize TestActor here to ensure it's available before user actors start
+                    base.InitializeTest(actorSystem, (ActorSystemSetup)null!, null, null);
+                    actorRegistry.Register<TestProbe>(TestActor);
+                    
+                    // Set implicit sender on initialization thread
+                    if (this is not INoImplicitSender)
+                    {
+                        InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+                    }
+                });
+
+                // User configuration comes AFTER TestProbe registration
+                // Their WithActors/StartActors will be added after ours
+                ConfigureAkka(builder, provider);
+
+                builder.AddStartup((_, _) =>
+                {
+                    _initialized.TrySetResult(Done.Instance);
+                });
+            });
+        }
+
+        internal virtual Task LoggerHook(ActorSystem system, IActorRegistry registry)
+        {
+            var extSystem = (ExtendedActorSystem)system;
+            var loggerName = $"log-test-{Guid.NewGuid():N}";
+            var logger = extSystem.SystemActorOf(Props.Create(() => new TestKitLoggerFactoryLogger()), loggerName);
+            // Fire and forget the logger initialization to avoid blocking
+            // The logger will eventually initialize itself
+            logger.Tell(new InitializeLogger(system.EventStream), ActorRefs.NoSender);
+            return Task.CompletedTask;
+        }
+
+        protected virtual Config? Config { get; } = null;
+        
+        protected virtual void ConfigureLogging(ILoggingBuilder builder)
+        { }
+
+        protected abstract void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider);
+        
+        [InternalApi]
+        public async Task InitializeAsync()
+        {
+            var hostBuilder = new HostBuilder();
+            if (Output != null)
+                hostBuilder.ConfigureLogging(logger =>
+                {
+                    logger.ClearProviders();
+                    logger.AddProvider(new XUnitLoggerProvider(Output, LogLevel));
+                    logger.AddFilter("Akka.*", LogLevel);
+                    ConfigureLogging(logger);
+                });
+            hostBuilder
+                .ConfigureHostConfiguration(ConfigureHostConfiguration)
+                .ConfigureAppConfiguration(ConfigureAppConfiguration);
+            ConfigureHostBuilder(hostBuilder);
+            hostBuilder.ConfigureServices(InternalConfigureServices);
+
+            _host = hostBuilder.Build();
+
+            using var cts = new CancellationTokenSource(StartupTimeout);
+            try
+            {
+                await _host.StartAsync(cts.Token);
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Host failed to start within {StartupTimeout.TotalSeconds} seconds");
+            }
+
+            // Wait for Akka initialization with timeout
+            var initializedTask = _initialized.Task;
+            var timeoutTask = Task.Delay(StartupTimeout, CancellationToken.None);
+            if (await Task.WhenAny(initializedTask, timeoutTask) == timeoutTask)
+            {
+                throw new TimeoutException($"Akka.NET failed to initialize within {StartupTimeout.TotalSeconds} seconds");
+            }
+            
+            // TestActor initialization and registration now happens in AddStartup
+            // before user actors are created, preventing race conditions
+            
+            // ALWAYS set the implicit sender context on the current thread after initialization
+            // This ensures it's available on the thread where tests will run
+            // This is critical for tests using DI-created actors
+            if (this is not INoImplicitSender && TestActor != null)
+            {
+                InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+            }
+            
+            await BeforeTestStart();
+        }
+
+        protected sealed override void InitializeTest(ActorSystem system, ActorSystemSetup config, string actorSystemName, string testActorName)
+        {
+            // no-op, deferring InitializeTest after Host have ran
+        }
+        
+        /// <summary>
+        /// Override Sys property to ensure implicit sender is set when accessing the actor system
+        /// </summary>
+        public new ActorSystem Sys 
+        { 
+            get 
+            {
+                EnsureImplicitSender();
+                return base.Sys;
+            }
+        }
+
+        protected virtual Task BeforeTestStart()
+        {
+            // Ensure the implicit sender is set on the current thread before each test
+            // This is critical because tests may run on different threads than initialization
+            if (this is not INoImplicitSender)
+            {
+                InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)TestActor).Underlying;
+            }
+            
+            return Task.CompletedTask;
+        }
+        
+        /// <summary>
+        /// This method is called when a test ends.
+        ///
+        /// <remarks>
+        /// If you override this, then make sure you either call base.AfterAllAsync()
+        /// to shut down the system. Otherwise a memory leak will occur.
+        /// </remarks>
+        /// </summary>
+        protected virtual Task AfterAllAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
+        {
+            Exception? exception = null;
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                await Task.WhenAny(Task.Delay(Timeout.Infinite, cts.Token), AfterAllAsync());
+                if (cts.IsCancellationRequested)
+                    throw new TimeoutException($"{nameof(AfterAllAsync)} took more than 5 seconds to execute, aborting.");
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+            finally
+            {
+                try
+                {
+                    Shutdown();
+                    if (_host != null)
+                    {
+                        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                        await _host.StopAsync(cts.Token);
+                    }
+                }
+                catch
+                {
+                    // no-op
+                }
+                finally
+                {
+                    _host?.Dispose();
+                }
+                
+                if (exception is { })
+                    throw exception;
+            }
+        }
+
+        private static Event.LogLevel ToAkkaLogLevel(LogLevel logLevel)
+            => logLevel switch
+            {
+                LogLevel.Trace => Event.LogLevel.DebugLevel,
+                LogLevel.Debug => Event.LogLevel.DebugLevel,
+                LogLevel.Information => Event.LogLevel.InfoLevel,
+                LogLevel.Warning => Event.LogLevel.WarningLevel,
+                LogLevel.Error => Event.LogLevel.ErrorLevel,
+                LogLevel.Critical => Event.LogLevel.ErrorLevel,
+                _ => Event.LogLevel.ErrorLevel
+            };
+        
+    }    
+}
+

--- a/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
+++ b/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
+        <PackageReference Include="xunit.v3.extensibility.core" Version="$(Xunit3Version)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     </ItemGroup>

--- a/src/Akka.Hosting.TestKit/Internals/XUnitLogger.cs
+++ b/src/Akka.Hosting.TestKit/Internals/XUnitLogger.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.TestKit.Internals
 {

--- a/src/Akka.Hosting.TestKit/Internals/XUnitLoggerProvider.cs
+++ b/src/Akka.Hosting.TestKit/Internals/XUnitLoggerProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.TestKit.Internals
 {

--- a/src/Akka.Hosting.TestKit/PersistenceTestKit.cs
+++ b/src/Akka.Hosting.TestKit/PersistenceTestKit.cs
@@ -10,7 +10,7 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.TestKit;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.TestKit;
 

--- a/src/Akka.Hosting.TestKit/TestKit.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.cs
@@ -16,14 +16,12 @@ using Akka.Event;
 using Akka.Hosting.Logging;
 using Akka.Hosting.TestKit.Internals;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2;
-using Akka.TestKit.Xunit2.Internals;
+using Akka.TestKit.Xunit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -162,7 +160,7 @@ namespace Akka.Hosting.TestKit
         protected abstract void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider);
         
         [InternalApi]
-        public async Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             var hostBuilder = new HostBuilder();
             if (Output != null)
@@ -255,7 +253,7 @@ namespace Akka.Hosting.TestKit
             return Task.CompletedTask;
         }
 
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             Exception? exception = null;
             try

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,13 +11,13 @@
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+    <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="22.11.1" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
+    <PackageReference Include="Verify.XunitV3" Version="31.14.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Akka.Hosting.Tests/Configuration/ConfigurationHoconAdapterTest.cs
+++ b/src/Akka.Hosting.Tests/Configuration/ConfigurationHoconAdapterTest.cs
@@ -81,12 +81,12 @@ public class ConfigurationHoconAdapterTest: IAsyncLifetime
             .Build();
     }
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         Environment.SetEnvironmentVariable("akka__TEST_VALUE_1__A", null);
         Environment.SetEnvironmentVariable("akka__TEST_VALUE_1__B", null);
@@ -107,7 +107,7 @@ public class ConfigurationHoconAdapterTest: IAsyncLifetime
         Environment.SetEnvironmentVariable("MISE____SESSION", null);
         Environment.SetEnvironmentVariable("____MISE_SESSION", null);
         
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
     
     #region Adapter unit tests

--- a/src/Akka.Hosting.Tests/ExtensionsSpecs.cs
+++ b/src/Akka.Hosting.Tests/ExtensionsSpecs.cs
@@ -9,13 +9,11 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
-using Akka.TestKit.Xunit2.Internals;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using static FluentAssertions.FluentActions;
 

--- a/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
+++ b/src/Akka.Hosting.Tests/HealthChecks/HealthChecksSpec.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Hosting.Tests.HealthChecks;
 

--- a/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/Issue701SemanticLoggingRegressionSpecs.cs
@@ -13,7 +13,6 @@ using Akka.Event;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.Tests.Logging;

--- a/src/Akka.Hosting.Tests/Logging/LogMessageFormatterSpec.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogMessageFormatterSpec.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using static FluentAssertions.FluentActions;
 
@@ -40,7 +39,7 @@ public class LogMessageFormatterSpec
         try
         {
             var sys = host.Services.GetRequiredService<ActorSystem>();
-            var testKit = new Akka.TestKit.Xunit2.TestKit(sys);
+            var testKit = new Akka.TestKit.Xunit.TestKit(sys);
 
             var probe = testKit.CreateTestProbe();
             sys.EventStream.Subscribe(probe, typeof(Error));

--- a/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LogStateSnapshotSpecs.cs
@@ -16,7 +16,6 @@ using Akka.Hosting;
 using Microsoft.Extensions.Logging;
 using VerifyXunit;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.Tests.Logging;
@@ -25,7 +24,6 @@ namespace Akka.Hosting.Tests.Logging;
 /// Verify snapshot tests for LoggerFactoryLogger structured state output.
 /// Follows the same sanitization pattern as DefaultLogFormatSpec in Akka.NET.
 /// </summary>
-[UsesVerify]
 public class LogStateSnapshotSpecs : TestKit.TestKit
 {
     private readonly SnapshotTestSink _sink;

--- a/src/Akka.Hosting.Tests/Logging/LoggerConfigEnd2EndSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerConfigEnd2EndSpecs.cs
@@ -8,12 +8,11 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Hosting.Tests.TestHelpers;
 
 namespace Akka.Hosting.Tests.Logging;
 
-public class LoggerConfigEnd2EndSpecs : Akka.TestKit.Xunit2.TestKit
+public class LoggerConfigEnd2EndSpecs : Akka.TestKit.Xunit.TestKit
 {
     private class CustomLoggingProvider : ILoggerProvider
     {

--- a/src/Akka.Hosting.Tests/Logging/LoggerFactoryLoggerSpec.cs
+++ b/src/Akka.Hosting.Tests/Logging/LoggerFactoryLoggerSpec.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.Tests.Logging;
@@ -34,17 +33,17 @@ public class LoggerFactoryLoggerSpec: IAsyncLifetime
         _logger = new TestLogger(helper);
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await SetupHost(_logger);
         var registry = _host.Services.GetRequiredService<ActorRegistry>();
         _echo = registry.Get<EchoActor>();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _host?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Fact(DisplayName = "LoggerFactoryLogger should log events")]

--- a/src/Akka.Hosting.Tests/Logging/SemanticLoggingSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/SemanticLoggingSpecs.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.Tests.Logging;
@@ -38,17 +37,17 @@ public class SemanticLoggingSpecs : IAsyncLifetime
         _logger = new SemanticTestLogger(helper);
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await SetupHost(_logger);
         var registry = _host.Services.GetRequiredService<ActorRegistry>();
         _testActor = registry.Get<TestActor>();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _host?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Fact(DisplayName = "Should extract named template properties and add to MEL state dictionary")]

--- a/src/Akka.Hosting.Tests/Logging/SerilogLoggerEnd2EndSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/SerilogLoggerEnd2EndSpecs.cs
@@ -12,7 +12,6 @@ using FluentAssertions;
 using Serilog;
 using Serilog.Core;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Hosting.Tests.Logging;
 

--- a/src/Akka.Hosting.Tests/Logging/TestLogger.cs
+++ b/src/Akka.Hosting.Tests/Logging/TestLogger.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.Tests.Logging;
 

--- a/src/Akka.Hosting.Tests/Logging/WithContextSpecs.cs
+++ b/src/Akka.Hosting.Tests/Logging/WithContextSpecs.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Akka.Hosting.Tests.Logging;
@@ -37,17 +36,17 @@ public class WithContextSpecs : IAsyncLifetime
         _logger = new SemanticTestLogger(helper);
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _host = await SetupHost(_logger);
         var registry = _host.Services.GetRequiredService<ActorRegistry>();
         _testActor = registry.Get<WithContextTestActor>();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _host?.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Fact(DisplayName = "WithContext single property should appear in MEL state dictionary")]

--- a/src/Akka.Hosting.Tests/StartFailureSpec.cs
+++ b/src/Akka.Hosting.Tests/StartFailureSpec.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
 
 namespace Akka.Hosting.Tests;

--- a/src/Akka.Hosting.Tests/TestHelpers.cs
+++ b/src/Akka.Hosting.Tests/TestHelpers.cs
@@ -2,10 +2,10 @@
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
-using Akka.TestKit.Xunit2.Internals;
+using Akka.TestKit.Xunit.Internals;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.Tests;
 

--- a/src/Akka.Hosting.Tests/XUnitLogger.cs
+++ b/src/Akka.Hosting.Tests/XUnitLogger.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.Tests;
 

--- a/src/Akka.Hosting.Tests/XUnitLoggerProvider.cs
+++ b/src/Akka.Hosting.Tests/XUnitLoggerProvider.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Hosting.Tests;
 

--- a/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
+++ b/src/Akka.Persistence.Hosting.Tests/Akka.Persistence.Hosting.Tests.csproj
@@ -2,15 +2,17 @@
 
     <PropertyGroup>
         <TargetFramework>$(TestsNetCoreFramework)</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Akka.Persistence.Query.InMemory" Version="$(AkkaVersion)" />
-        <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunneVisualstudio)">
+        <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Akka.Persistence.Hosting.Tests/BuilderOptionsAccessSpec.cs
+++ b/src/Akka.Persistence.Hosting.Tests/BuilderOptionsAccessSpec.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Persistence.Hosting.Tests.UnifiedApiTestResources;
 
 namespace Akka.Persistence.Hosting.Tests;

--- a/src/Akka.Persistence.Hosting.Tests/EventAdapterRuntimeInvocationSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/EventAdapterRuntimeInvocationSpecs.cs
@@ -12,7 +12,6 @@ using Akka.Streams;
 using Akka.Streams.Dsl;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Hosting.Tests;
 

--- a/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/InMemoryPersistenceSpecs.cs
@@ -4,12 +4,10 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.Hosting;
-using Akka.TestKit.Xunit2.Internals;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Hosting.Tests
 {

--- a/src/Akka.Persistence.Hosting.Tests/UnifiedApiSpecs.cs
+++ b/src/Akka.Persistence.Hosting.Tests/UnifiedApiSpecs.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Hosting.Tests;
 


### PR DESCRIPTION
## Changes

* Convert Akka.Hosting.TestKit to use the new xUnit 3 Akka.TestKit.Xunit
* **Add Akka.Hosting.TestKit.Xunit2 that still supports the old xUnit 2**
* Convert all tests (including API approval) to use xUnit 3