### PR TITLE
Bump AkkaVersion to 1.5.66

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
     <Xunit3RunneVisualstudio>3.1.5</Xunit3RunneVisualstudio>
-    <AkkaVersion>1.5.65</AkkaVersion>
+    <AkkaVersion>1.5.66</AkkaVersion>
     <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
     <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Bumps Akka.NET dependency from 1.5.65 to 1.5.66.

This pulls in the latest Akka.NET release including the new `akka.actor.serialization-settings.allow-unregistered-types` setting.