### PR TITLE
fix: prevent flaky TestKit serialization rebuild race

### DIFF
--- a/src/Akka.Hosting.TestKit/TestKit.Shared.cs
+++ b/src/Akka.Hosting.TestKit/TestKit.Shared.cs
@@ -97,11 +97,13 @@ namespace Akka.Hosting.TestKit
                 if (Config is { })
                     builder.AddHocon(Config, HoconAddMode.Prepend);
 
+                // Don't re-register TestEventListener here — DefaultConfig (prepended above) already
+                // configures it with a short type name. AddLogger<T> produces a fully-qualified name,
+                // which makes InjectTopLevelFallback think the config changed and triggers a full
+                // serialization rebuild. Under CI load that rebuild can race with scheduler disposal.
                 builder.ConfigureLoggers(logger =>
                 {
                     logger.LogLevel = ToAkkaLogLevel(LogLevel);
-                    logger.ClearLoggers();
-                    logger.AddLogger<TestEventListener>();
                 });
 
                 if (Output is { })


### PR DESCRIPTION
## Summary
- Removes `ClearLoggers()`/`AddLogger<TestEventListener>()` from `TestKit.Shared.cs` `InternalConfigureServices` to prevent an unnecessary full serialization rebuild that races with scheduler disposal under CI load
- `DefaultConfig` (already prepended) configures `TestEventListener` with a short type name, but `AddLogger<T>` re-registers it with a fully-qualified assembly name — this mismatch makes `InjectTopLevelFallback` think the config changed, triggering `RebuildConfig` → `ReloadSerialization` → re-instantiation of all serializers including `ReplicatorMessageSerializer`, whose constructor calls `ScheduleRepeatedly` on a potentially-disposed scheduler

Fixes the flaky `ShardedDaemonProcessSpecs.ShardedDaemonProcess_must_start_N_actors_with_unique_ids` failure seen in CI:
```
Akka.Actor.SchedulerException : cannot enqueue after timer shutdown
  at Akka.Actor.HashedWheelTimerScheduler.Start()
  at Akka.DistributedData.Serialization.ReplicatorMessageSerializer..ctor(ExtendedActorSystem system)
  at Akka.Serialization.Serialization..ctor(ExtendedActorSystem system)
  at Akka.Actor.Settings.RebuildConfig()
```

## Test plan
- [ ] Existing TestKit-based tests pass (no behavioral change — `TestEventListener` is still active via `DefaultConfig`)
- [ ] `ShardedDaemonProcessSpecs` no longer flakes in CI