### PR TITLE
fix: flaky DData spec timeout in CI

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -46,13 +46,8 @@ public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
         await AwaitAssertAsync(async () =>
         {
             actorSelection.Tell(new Identify("coordinator"), TestActor);
-            var identity = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(3));
-            
-            // The DData replicator should be running
-            // * This actor is created inside DistributedData extension .ctor
-            // * Marks that the extension is running
-            // * We can't use DistributedData.Get() because that defeats the purpose.
+            var identity = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(1));
             Assert.NotNull(identity.Subject);
-        });
+        }, duration: TimeSpan.FromSeconds(10));
     }
 }


### PR DESCRIPTION
## Summary
- Fixes flaky `ClusterShardingDistributedDataSpecs.WithDistributedDataStartsAutomaticallyTest` on Windows CI
- The outer `AwaitAssertAsync` had no explicit `duration` (defaulting to ~3s) while the inner `ExpectMsgAsync` also waited 3s — only one attempt was possible before timeout
- On slow CI runners the DData replicator isn't ready in time; the `ActorIdentity` response arrives at a stale `TestActor` incarnation and goes to dead letters
- Fix: shorten inner expect to 1s, give outer loop 10s so multiple retries can succeed

## Test plan
- [ ] `WithDistributedDataStartsAutomaticallyTest` passes reliably on both ubuntu and windows CI