### PR TITLE
Bump AkkaVersion to 1.5.67

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <CoverletVersion>6.0.3</CoverletVersion>
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
     <Xunit3RunneVisualstudio>3.1.5</Xunit3RunneVisualstudio>
-    <AkkaVersion>1.5.66</AkkaVersion>
+    <AkkaVersion>1.5.67</AkkaVersion>
     <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
     <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
   </PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.67 April 26th 2026 ####
+
+**Updates**
+* [Bump Akka version from 1.5.66 to 1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67) - Hotfix release reverting the Task.Yield() optimization in AsyncWriteJournal/SnapshotStore that broke the persistence plugin threading contract.
+
 #### 1.5.65 April 10th 2026 ####
 
 **Updates**


### PR DESCRIPTION
## What's Changed

Bump `AkkaVersion` from 1.5.66 to 1.5.67.

Akka.NET 1.5.67 is a hotfix release that reverts the `Task.Yield()` optimization in `AsyncWriteJournal`/`SnapshotStore` introduced in 1.5.66, which broke the persistence plugin threading contract for plugins that:
- Access `Self` inside `WriteMessagesAsync`
- Use non-thread-safe collections for write tracking
- Send messages to subscribers after writes complete

See: https://github.com/akkadotnet/akka.net/releases/tag/1.5.67