### PR TITLE
fix: resolve GHSA-g94r-2vxg-569j by bumping OpenTelemetry to 1.10.0 and MEL floor to 9.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <XunitRunneVisualstudio>3.1.5</XunitRunneVisualstudio>
     <Xunit3RunneVisualstudio>3.1.5</Xunit3RunneVisualstudio>
     <AkkaVersion>1.5.67</AkkaVersion>
-    <MicrosoftExtensionsVersion>[8.0.0,)</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>[9.0.0,)</MicrosoftExtensionsVersion>
     <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
     <Xunit3RunneVisualstudio>3.1.5</Xunit3RunneVisualstudio>
     <AkkaVersion>1.5.67</AkkaVersion>
     <MicrosoftExtensionsVersion>[9.0.0,)</MicrosoftExtensionsVersion>
-    <SystemTextJsonVersion>[8.0.5,)</SystemTextJsonVersion>
+    <SystemTextJsonVersion>[9.0.0,)</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">

--- a/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
+++ b/src/Akka.Cluster.Hosting.Tests/Akka.Cluster.Hosting.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
         <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunneVisualstudio)">

--- a/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />

--- a/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Tests/Akka.Hosting.TestKit.Tests.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/Akka.Hosting.TestKit.Xunit2.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/Akka.Hosting.TestKit.Xunit2.Tests.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />

--- a/src/Akka.Hosting.TestKit.Xunit2.Tests/Akka.Hosting.TestKit.Xunit2.Tests.csproj
+++ b/src/Akka.Hosting.TestKit.Xunit2.Tests/Akka.Hosting.TestKit.Xunit2.Tests.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="FluentAssertions" Version="6.12.2" />

--- a/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.Xunit2.csproj
+++ b/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.Xunit2.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />

--- a/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.Xunit2.csproj
+++ b/src/Akka.Hosting.TestKit.Xunit2/Akka.Hosting.TestKit.Xunit2.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />

--- a/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
+++ b/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="xunit.v3.extensibility.core" Version="$(Xunit3Version)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />

--- a/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
+++ b/src/Akka.Hosting.TestKit/Akka.Hosting.TestKit.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
         <PackageReference Include="Akka.Persistence.TestKit" Version="$(AkkaVersion)" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
         <PackageReference Include="xunit.v3.extensibility.core" Version="$(Xunit3Version)" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
         <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Akka.Logger.Serilog" Version="1.5.25" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
+++ b/src/Akka.Hosting.Tests/Akka.Hosting.Tests.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Akka.Logger.Serilog" Version="1.5.25" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
     <PackageReference Include="Akka.TestKit.Xunit" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />

--- a/src/Akka.Hosting/Akka.Hosting.csproj
+++ b/src/Akka.Hosting/Akka.Hosting.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageReference Include="OpenTelemetry" Version="[1.9.0,)" />
+    <PackageReference Include="OpenTelemetry" Version="[1.10.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Examples/Akka.Hosting.LoggingDemo/Akka.Hosting.LoggingDemo.csproj
+++ b/src/Examples/Akka.Hosting.LoggingDemo/Akka.Hosting.LoggingDemo.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
+++ b/src/Examples/Akka.Hosting.OpenTelemetry.Demo/Akka.Hosting.OpenTelemetry.Demo.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bumps `OpenTelemetry` minimum version floor in `Akka.Hosting.csproj` from `[1.9.0,)` to `[1.10.0,)`
- Bumps `OpenTelemetry.Extensions.Hosting` and `OpenTelemetry.Exporter.OpenTelemetryProtocol` in the example project from `1.9.0` to `1.10.0`

## Why

`OpenTelemetry.Api` 1.9.0 has a known moderate severity vulnerability ([GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j)). Because `Akka.Hosting` pinned `OpenTelemetry >= 1.9.0`, NuGet resolved to exactly 1.9.0, which pulled the vulnerable `OpenTelemetry.Api` 1.9.0 into downstream consumers.

This was discovered when a Dependabot PR in `akkadotnet/akka.net` ([#8192](https://github.com/akkadotnet/akka.net/pull/8192)) bumped `Akka.Management` to 1.5.67 (which depends on `Akka.Hosting` 1.5.67). The build failed with:

```
error NU1902: Warning As Error: Package 'OpenTelemetry.Api' 1.9.0 has a known moderate severity vulnerability
```

Bumping the minimum to `[1.10.0,)` resolves the transitive pull of the vulnerable package. `OpenTelemetry.Api` 1.10.0 is not affected by the vulnerability.

## Test plan

- [ ] CI passes (NuGet audit no longer flags vulnerable transitive dependency)