### PR TITLE
fix: use TestProbe instead of TestActor in ClusterShardingDistributedDataSpecs to eliminate Windows flakiness

### DIFF
--- a/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
+++ b/src/Akka.Cluster.Hosting.Tests/ClusterShardingDistributedDataSpecs.cs
@@ -48,11 +48,14 @@ public class ClusterShardingDistributedDataSpecs: Akka.Hosting.TestKit.TestKit
         var coordinatorName = settings.RestartReplicatorOnFailure ? $"{ReplicatorName}Supervisor" : ReplicatorName;
         
         var actorSelection = Sys.ActorSelection(new RootActorPath(cluster.SelfAddress) / "user" / coordinatorName);
-        
+
+        // Use a fresh TestProbe rather than TestActor: on Windows, TestActor can be a stale dead
+        // reference due to the startup race window between EnsureTestActorAliveAsync and the test body.
+        var probe = CreateTestProbe();
         await AwaitAssertAsync(async () =>
         {
-            actorSelection.Tell(new Identify("coordinator"), TestActor);
-            var identity = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(1));
+            actorSelection.Tell(new Identify("coordinator"), probe.Ref);
+            var identity = await probe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(1));
             Assert.NotNull(identity.Subject);
         }, duration: TimeSpan.FromSeconds(10));
     }


### PR DESCRIPTION
## Root Cause

`ClusterShardingDistributedDataSpecs.WithDistributedDataStartsAutomaticallyTest` was failing on Windows CI because it used `TestActor` as the explicit sender for `Identify` messages. On Windows, the Akka.Hosting TestKit's startup race means `TestActor` can survive `EnsureTestActorAliveAsync`'s liveness check, then die in the narrow window before the test body runs — leaving `TestActor` as a stale dead `ActorRef` for the duration of the test.

The replicator was alive and responding correctly on every retry. All 10 `ActorIdentity` responses went to dead letters because they were addressed to the dead `testActor3` ref.

## Fix

Create a `TestProbe` in the test body (post-startup, unaffected by the startup race) and use `probe.Ref` as the sender instead of `TestActor`. The probe is alive for the duration of the test.

## Test plan
- [ ] Windows CI passes `WithDistributedData should start DistributedData extension automatically`
- [ ] Linux CI continues to pass