### PR TITLE
fix: pin upload-release-assets to specific git SHA

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -56,7 +56,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Upload Release Asset
-      uses: AButler/upload-release-assets@v4.0
+      uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962
       with:
           repo-token: ${{ github.token }}
           release-tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Pins `AButler/upload-release-assets@v4.0` to its exact git commit SHA to prevent tag drift and unexpected pipeline breaks.

### Changes
- `publish_nuget.yml`: `AButler/upload-release-assets@v4.0` → `AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962`

### Rationale
As per Dependabot/SOP guidelines, GitHub Actions should be pinned to exact Git SHAs instead of tags to prevent:
- Tag deletion/recreation causing unexpected version changes
- Supply chain attacks via tag rewriting
- Unpredictable pipeline breaks from upstream tag drift

v4.0.0 commit SHA: `34491005a5d7ec239a784e460807ce844fde7962`